### PR TITLE
Make storage manager methods async throws

### DIFF
--- a/Sources/eudi-lib-ios-wallet-kit/ViewModels/WalletError.swift
+++ b/Sources/eudi-lib-ios-wallet-kit/ViewModels/WalletError.swift
@@ -14,6 +14,7 @@
  limitations under the License.
  */
 import Foundation
+/// Wallet error
 public struct WalletError: LocalizedError {
 	
 	var description: String


### PR DESCRIPTION
This pull request updates the storage manager methods in the EudiWallet class to be asynchronous and throw errors when necessary. This allows for better error handling and improves the overall performance of the application.