### PR TITLE
Update eudi-lib-ios-siop-openid4vp-swift to version 0.0.72

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-siop-openid4vp-swift.git",
       "state" : {
-        "revision" : "e94e0c7e8fd4d766d13b305d6d580c3138d042de",
-        "version" : "0.0.70"
+        "revision" : "152880755e25cf025f5921b09c030b746dc883cc",
+        "version" : "0.0.72"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,9 +15,9 @@ let package = Package(
     dependencies: [
 		.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.3"),
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git", .upToNextMajor(from: "0.1.8")),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git", .upToNextMajor(from: "0.2.2")),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git", .upToNextMajor(from: "0.1.7")),
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-siop-openid4vp-swift.git", .upToNextMajor(from: "0.0.66")),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-siop-openid4vp-swift.git", .upToNextMajor(from: "0.0.72")),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git", .upToNextMajor(from: "0.0.4")),
 	],
     targets: [

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+## v.0.2.9
+- Fixed MAC validation error for mDL document type
+
 ## v0.1.7
 - Added delete documents func
 - Storage manager functions are now `async throws`


### PR DESCRIPTION
This pull request updates the eudi-lib-ios-siop-openid4vp-swift dependency to version 0.0.72. Additionally, it includes a fix for a MAC validation error for the mDL document type.