### PR TITLE
Update eudi-lib-ios-iso18013-data-model and eudi-lib-ios-iso18013-data-transfer dependencies

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git",
       "state" : {
-        "revision" : "bf62cc73ae2cea61e98020d2d037c153500207e7",
-        "version" : "0.2.5"
+        "revision" : "12314daf45d637a1afeda321d605f328d422fe8d",
+        "version" : "0.2.6"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git",
       "state" : {
-        "revision" : "4e18b4b5de1ab2e9c5b9495574667b1a27508a9e",
-        "version" : "0.2.8"
+        "revision" : "ceeddd2a37f579212752bfb38e54efa87ec567e3",
+        "version" : "0.2.9"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
 		.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.3"),
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git", .upToNextMajor(from: "0.2.8")),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git", exact: "0.2.9"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git", .upToNextMajor(from: "0.2.0")),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-siop-openid4vp-swift.git", exact: "0.1.1"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git", exact: "0.1.2"),


### PR DESCRIPTION
This pull request updates the dependencies `eudi-lib-ios-iso18013-data-model` and `eudi-lib-ios-iso18013-data-transfer` to their latest versions. The `eudi-lib-ios-iso18013-data-model` dependency is updated to version 0.2.6, and the `eudi-lib-ios-iso18013-data-transfer` dependency is updated to version 0.2.9. This ensures that we are using the most up-to-date versions of these dependencies in our project.