### PR TITLE
Update eudi-lib-ios-openid4vci-swift dependency to version 0.1.5

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git",
       "state" : {
-        "revision" : "92513586f525c1fe78401d76036b540eac792cba",
-        "version" : "0.1.2"
+        "revision" : "caf034c60163f0e2b6a046b780f9b19ce0761b32",
+        "version" : "0.1.5"
       }
     },
     {
@@ -158,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-certificates.git",
       "state" : {
-        "revision" : "83640c8097acaec17c9835a083e89678cb0f2b66",
-        "version" : "1.3.0"
+        "revision" : "4688f242811d21a9c7a8ad669b3bc5b336759929",
+        "version" : "1.4.0"
       }
     },
     {
@@ -167,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "94cf62b3ba8d4bed62680a282d4c25f9c63c2efb",
-        "version" : "1.1.0"
+        "revision" : "ee97538f5b81ae89698fd95938896dec5217b148",
+        "version" : "1.1.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git", exact: "0.2.9"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git", .upToNextMajor(from: "0.2.0")),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-siop-openid4vp-swift.git", exact: "0.1.1"),
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git", exact: "0.1.2"),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git", exact: "0.1.5"),
 	],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/Sources/EudiWalletKit/Services/OpenId4VciService.swift
+++ b/Sources/EudiWalletKit/Services/OpenId4VciService.swift
@@ -76,9 +76,7 @@ public class OpenId4VCIService: NSObject, ASWebAuthenticationPresentationContext
 	///   - format: format of the exchanged data
 	/// - Returns: The data of the document
 	public func resolveOfferDocTypes(uriOffer: String, format: DataFormat = .cbor) async throws -> [OfferedDocModel] {
-		guard let uriOfferNormalized = uriOffer.removingPercentEncoding else { throw WalletError(description: "Invalid uri offer \(uriOffer)")}
-		guard let offerUrlNormalied = URL(string: uriOfferNormalized) else { throw WalletError(description: "Invalid URL string \(uriOffer)")}
-		let result = await CredentialOfferRequestResolver().resolve(source: try .init(urlString: offerUrlNormalied.absoluteString))
+		let result = await CredentialOfferRequestResolver().resolve(source: try .init(urlString: uriOffer))
 		switch result {
 		case .success(let offer):
 			Self.metadataCache[uriOffer] = offer


### PR DESCRIPTION
This pull request updates the `eudi-lib-ios-openid4vci-swift` dependency to version 0.1.5. The previous version was 0.1.2. This update includes changes to the `Package.swift` file and the `OpenId4VCIService` class.

Closes #69