### PR TITLE
Refactor RequestItems and ElementViewModel structures

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,6 +1,10 @@
 name: Swift Build
-
-on: [push]
+on:
+  pull_request:
+    types: [opened, reopened]
+  push:
+    branches: ['main']
+    tags: [ v* ]
 jobs:
   build:
     runs-on: macos-latest

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ebf47c2682782005cbaf1f28ff387c17a3cad1d91fcba1d59b4cd31b98367167",
+  "originHash" : "751cb5694cd2e9d547658bb43e87ff87c1bec7fe7c5e3372d7734d8835c52c02",
   "pins" : [
     {
       "identity" : "blueecc",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git",
       "state" : {
-        "revision" : "2f00a68370572f914997706a29d15d6fc0b89ceb",
-        "version" : "0.3.3"
+        "revision" : "900416bcab3e95a17dea2fbf224210521c5b68d6",
+        "version" : "0.3.7"
       }
     },
     {
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/KittyMac/Sextant.git",
       "state" : {
-        "revision" : "52a77d0bce0210cf9557faef7fd0adb9a6da02fb",
-        "version" : "0.4.31"
+        "revision" : "b2141d4a693e2a768720534009cb621252be39a0",
+        "version" : "0.4.33"
       }
     },
     {
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "df5d2fcd22e3f480e3ef85bf23e277a4a0ef524d",
-        "version" : "1.2.0"
+        "revision" : "7faebca1ea4f9aaf0cda1cef7c43aecd2311ddf6",
+        "version" : "1.3.0"
       }
     },
     {
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-certificates.git",
       "state" : {
-        "revision" : "2f797305c1b5b982acaa6005d8a9f970cc4e97ff",
-        "version" : "1.5.0"
+        "revision" : "1fbb6ef21f1525ed5faf4c95207b9c11bea27e94",
+        "version" : "1.6.1"
       }
     },
     {
@@ -177,8 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "ffca28be3c9c6a86a579949d23f68818a4b9b5d8",
-        "version" : "3.8.0"
+        "revision" : "06dc63c6d8da54ee11ceb268cde1fa68161afc96",
+        "version" : "3.9.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
     .package(url: "https://github.com/apple/swift-log.git", from: "1.5.3"),
 		.package(url: "https://github.com/crspybits/swift-log-file", from: "0.1.0"),
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git",  exact: "0.3.3"),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git",  exact: "0.3.7"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git", exact: "0.3.0"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-siop-openid4vp-swift.git", exact: "0.6.0"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git", exact: "0.7.0"),

--- a/Sources/EudiWalletKit/Services/PresentationService.swift
+++ b/Sources/EudiWalletKit/Services/PresentationService.swift
@@ -18,7 +18,7 @@ import Foundation
 import MdocDataTransfer18013
 
 /// [Doc Types to [Namespace to Items]] dictionary
-public typealias RequestItems = [String: [String: [String]]]
+public typealias RequestItems = MdocDataTransfer18013.RequestItems
 
 /// Presentation service abstract protocol
 

--- a/Sources/EudiWalletKit/ViewModels/DocElementsViewModel.swift
+++ b/Sources/EudiWalletKit/ViewModels/DocElementsViewModel.swift
@@ -16,6 +16,7 @@ limitations under the License.
 
 import Foundation
 import MdocDataModel18013
+import MdocDataTransfer18013
 
 /// View model used in SwiftUI for presentation request elements
 public struct DocElementsViewModel: Identifiable, Sendable {
@@ -27,12 +28,13 @@ public struct DocElementsViewModel: Identifiable, Sendable {
 	public var elements: [ElementViewModel]
 }
 extension DocElementsViewModel {
-	static func fluttenItemViewModels(_ nsItems: [String:[String]], valid isEnabled: Bool, mandatoryElementKeys: [String]) -> [ElementViewModel] {
+	static func fluttenItemViewModels(_ nsItems: [String:[RequestItem]], valid isEnabled: Bool, mandatoryElementKeys: [String]) -> [ElementViewModel] {
 		nsItems.map { k,v in nsItemsToViewModels(k,v, isEnabled, mandatoryElementKeys) }.flatMap {$0}
 	}
 	
-	static func nsItemsToViewModels(_ ns: String, _ items: [String], _ isEnabled: Bool, _ mandatoryElementKeys: [String]) -> [ElementViewModel] {
-		items.map { ElementViewModel(nameSpace: ns, elementIdentifier:$0, isMandatory: mandatoryElementKeys.contains($0), isEnabled: isEnabled) }
+	static func nsItemsToViewModels(_ ns: String, _ items: [RequestItem], _ isEnabled: Bool, _ mandatoryElementKeys: [String]) -> [ElementViewModel] {
+		// default for intent-to-retain is false, default for isOptional is true
+		items.map { ElementViewModel(nameSpace: ns, elementIdentifier: $0.elementIdentifier, isOptional: $0.isOptional ?? !mandatoryElementKeys.contains($0.elementIdentifier), intentToRetain: $0.intentToRetain ?? false, isEnabled: isEnabled) }
 	}
 	
 	static func getMandatoryElementKeys(docType: String) -> [String] {
@@ -76,12 +78,18 @@ public struct ElementViewModel: Identifiable, Sendable {
 	public var id: String { "\(nameSpace)_\(elementIdentifier)" }
 	public let nameSpace: String
 	public let elementIdentifier: String
-	public let isMandatory: Bool
+	public let isOptional: Bool
+	public let intentToRetain: Bool
 	public var isEnabled: Bool
 	public var isDisabled: Bool { !isEnabled }
 	public var isSelected = true
 }
 
 extension Array where Element == ElementViewModel {
-	var nsDictionary: [String: [String]] { Dictionary(grouping: self, by: \.nameSpace).mapValues { $0.map(\.elementIdentifier)} }
+	var nsDictionary: [String: [RequestItem]] {
+		Dictionary(grouping: self, by: \.nameSpace)
+			.mapValues {
+				evm in evm.map { RequestItem(elementIdentifier: $0.elementIdentifier, intentToRetain: $0.intentToRetain, isOptional: $0.isOptional) }
+			}
+	}
 }

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,14 @@
+## v0.7.7
+ - Fix issue [#118](https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-kit/issues/118)
+ ### Breaking changes
+- `RequestItems` is now a dictionary with a key of type `String` (doc-type) and a value of type `[String: [RequestItem]]` (namespace to request items)
+- `RequestItem` is a struct with the following properties: `elementIdentifier`, `intentToRetain` and `isOptional`
+ ```swift
+ public typealias RequestItems = [String: [String: [RequestItem]]]
+```
+- ElementViewModel: `public var isMandatory: Bool` is removed
+- ElementViewModel: `public var isOptional: Bool` is added (opposite of `isMandatory`)
+
 ## v0.7.4
 - Update Package.resolved and Package.swift with new versions for openid4vci, openid4vp
 


### PR DESCRIPTION
Refactor the structures to improve functionality. Update the `RequestItems` type to include `RequestItem` properties, and modify `ElementViewModel` to replace `isMandatory` with `isOptional`. Adjust dependencies and versioning accordingly.