### PR TITLE
Update eudi-lib-ios-iso18013-data-transfer to version 0.3.8

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "751cb5694cd2e9d547658bb43e87ff87c1bec7fe7c5e3372d7734d8835c52c02",
+  "originHash" : "d38f85b065a32877c668f73f6814a437fd82f13d6bf2d947c60a917106f9ce7b",
   "pins" : [
     {
       "identity" : "blueecc",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git",
       "state" : {
-        "revision" : "900416bcab3e95a17dea2fbf224210521c5b68d6",
-        "version" : "0.3.7"
+        "revision" : "25a71bea1d4bddd7faf8490f39dbf52ef902b671",
+        "version" : "0.3.8"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
     .package(url: "https://github.com/apple/swift-log.git", from: "1.5.3"),
 		.package(url: "https://github.com/crspybits/swift-log-file", from: "0.1.0"),
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git",  exact: "0.3.7"),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git",  exact: "0.3.8"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git", exact: "0.3.0"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-siop-openid4vp-swift.git", exact: "0.6.0"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git", exact: "0.7.0"),

--- a/Tests/EudiWalletKitTests/EudiWalletKitTests.swift
+++ b/Tests/EudiWalletKitTests/EudiWalletKitTests.swift
@@ -35,7 +35,6 @@ final class EudiWalletKitTests: XCTestCase {
 		let testPD = try JSONDecoder().decode(PresentationDefinition.self, from: Data(name: "TestPresentationDefinition", ext: "json", from: Bundle.module)! )
 		let items = try XCTUnwrap(Openid4VpUtils.parsePresentationDefinition(testPD))
 		XCTAssert(!items.keys.isEmpty)
-		print(items)
 	}
 	
 	let ANNEX_B_OPENID4VP_HANDOVER = "835820DA25C527E5FB75BC2DD31267C02237C4462BA0C1BF37071F692E7DD93B10AD0B5820F6ED8E3220D3C59A5F17EB45F48AB70AEECF9EE21744B1014982350BD96AC0C572616263646566676831323334353637383930"


### PR DESCRIPTION
Upgrade the eudi-lib-ios-iso18013-data-transfer dependency to the latest version for improved functionality and performance.