### PR TITLE
Remove metadata cache entry for offerUri after issuing document

### DIFF
--- a/Sources/EudiWalletKit/EudiWallet.swift
+++ b/Sources/EudiWalletKit/EudiWallet.swift
@@ -295,6 +295,7 @@ public final class EudiWallet: ObservableObject, @unchecked Sendable {
 			guard let docData = try await openId4VCIService.issueDocumentByOfferUrl(offerUri: offerUri, docTypeModel: docTypeModel, txCodeValue: txCodeValue, format: format, promptMessage: promptMessage, claimSet: claimSet) else { continue }
 			documents.append(try await finalizeIssuing(data: docData, docType: docData.isDeferred ? docTypes[i].docType : nil, format: format, issueReq: openId4VCIService.issueReq, openId4VCIService: openId4VCIService))
 		}
+		OpenId4VCIService.metadataCache.removeValue(forKey: offerUri)
 		return documents
 	}
 	

--- a/Sources/EudiWalletKit/Services/OpenId4VciService.swift
+++ b/Sources/EudiWalletKit/Services/OpenId4VciService.swift
@@ -99,7 +99,6 @@ public class OpenId4VCIService: NSObject, @unchecked Sendable, ASWebAuthenticati
 	
 	func issueDocumentByOfferUrl(offerUri: String, docTypeModel: OfferedDocModel, txCodeValue: String?, format: DataFormat, promptMessage: String? = nil, claimSet: ClaimSet? = nil) async throws -> IssuanceOutcome? {
 		guard format == .cbor else { fatalError("jwt format not implemented") }
-		defer { Self.metadataCache.removeValue(forKey: offerUri) }
 		guard let offer = Self.metadataCache[offerUri] else { throw WalletError(description: "offerUri not resolved. resolveOfferDocTypes must be called first")}
 		guard let credentialInfo = try? getCredentialIdentifier(credentialsSupported: offer.credentialIssuerMetadata.credentialsSupported, docType: docTypeModel.docType, format: format) else { return nil }
 		try await initSecurityKeys(algSupported: credentialInfo.algValuesSupported)


### PR DESCRIPTION
- Fixes [bug with cancel](https://github.com/eu-digital-identity-wallet/eudi-doc-testing-application-internal/issues/39)
- Fixes [bug with credential offer with multiple documents to be issued](https://github.com/eu-digital-identity-wallet/eudi-doc-testing-application-internal/issues/40)