### PR TITLE
Refactor DocPresentInfo properties to public

### DIFF
--- a/Sources/EudiWalletKit/ViewModels/DocElements.swift
+++ b/Sources/EudiWalletKit/ViewModels/DocElements.swift
@@ -127,13 +127,13 @@ public final class SdJwtElements: Identifiable, @unchecked Sendable {
 }
 
 extension IssuerSigned {
-	func extractMsoMdocElements(docId: String, docType: String, displayName: String?, docClaims: [DocClaim], itemsRequested: [NameSpace: [RequestItem]]) -> MsoMdocElements {
+	public func extractMsoMdocElements(docId: String, docType: String, displayName: String?, docClaims: [DocClaim], itemsRequested: [NameSpace: [RequestItem]]) -> MsoMdocElements {
 		MsoMdocElements(docId: docId, docType: docType, displayName: displayName, nameSpacedElements: itemsRequested.compactMap { ns, requestItems in
 			extractNameSpacedElements(docType: docType, ns: ns, docClaims: docClaims, requestItems: requestItems)
 		})
 	}
 
-	func extractNameSpacedElements(docType: String, ns: String, docClaims: [DocClaim], requestItems: [RequestItem]) -> NameSpacedElements? {
+	public func extractNameSpacedElements(docType: String, ns: String, docClaims: [DocClaim], requestItems: [RequestItem]) -> NameSpacedElements? {
 		guard let issuedItems = issuerNameSpaces?[ns] else { return nil }
 		let mandatoryElementKeys = MsoMdocElements.getMandatoryElementKeys(docType: docType, ns: ns)
 		let isMandatory: (RequestItem) -> Bool = { if let o = $0.isOptional { !o } else { mandatoryElementKeys.contains($0.rootIdentifier) } }
@@ -142,7 +142,7 @@ extension IssuerSigned {
 }
 
 extension SignedSDJWT {
-	func extractSdJwtElements(docId: String, vct: String, displayName: String?, docClaims: [DocClaim], itemsRequested: [NameSpace: [RequestItem]]) -> SdJwtElements? {
+	public func extractSdJwtElements(docId: String, vct: String, displayName: String?, docClaims: [DocClaim], itemsRequested: [NameSpace: [RequestItem]]) -> SdJwtElements? {
 		guard let allPaths = try? disclosedPaths() else { return nil }
 		let isMandatory: (RequestItem) -> Bool = { if let o = $0.isOptional { !o } else { false } }
 		guard let itemsReq = itemsRequested[""] else { return nil }
@@ -160,14 +160,14 @@ extension SignedSDJWT {
 }
 
 extension RequestItem {
-	func extractMsoMdocElement(ns: String, nsItems: [IssuerSignedItem], docClaims: [DocClaim], isMandatory: Bool) -> MsoMdocElement {
+	public func extractMsoMdocElement(ns: String, nsItems: [IssuerSignedItem], docClaims: [DocClaim], isMandatory: Bool) -> MsoMdocElement {
 		let issuedElement = nsItems.first { $0.elementIdentifier == rootIdentifier }
 		let stringValue = issuedElement?.description
 		let docClaim = docClaims.first { $0.namespace == ns && $0.name == rootIdentifier }
 		return MsoMdocElement(elementIdentifier: elementIdentifier, displayName: rootDisplayName ?? docClaim?.displayName ?? rootIdentifier, isOptional: !isMandatory, intentToRetain: intentToRetain ?? false, stringValue: stringValue, docClaim: docClaim, isValid: issuedElement != nil)
 	}
 
-	func extractSdJwtElement(allPaths: [JSONPointer], docClaims: [DocClaim], isMandatory: Bool, bRootOnly: Bool) -> SdJwtElement {
+	public func extractSdJwtElement(allPaths: [JSONPointer], docClaims: [DocClaim], isMandatory: Bool, bRootOnly: Bool) -> SdJwtElement {
 		let query = allPaths.first { elementPath == $0.tokenArray }
 		let isValid = query != nil
 		let requestPath = bRootOnly ? [rootIdentifier] : elementPath
@@ -176,7 +176,7 @@ extension RequestItem {
 		return SdJwtElement(elementPath: requestPath, displayNames: displayNames, isOptional: !isMandatory, intentToRetain: intentToRetain ?? false, stringValue: stringValue, docClaim: docClaim, isValid: isValid, nestedElements: nil)
 	}
 
-	func findDocClaimByPath(docClaims: [DocClaim], requestPath: [String]) -> DocClaim? {
+	public func findDocClaimByPath(docClaims: [DocClaim], requestPath: [String]) -> DocClaim? {
 		var res: DocClaim? = nil
 		var docClaimsArray: [DocClaim]? = docClaims
 		for i in requestPath.indices {

--- a/Sources/EudiWalletKit/ViewModels/DocElements.swift
+++ b/Sources/EudiWalletKit/ViewModels/DocElements.swift
@@ -20,11 +20,11 @@ import MdocDataTransfer18013
 import eudi_lib_sdjwt_swift
 
 public struct DocPresentInfo: Sendable {
-	let docType: String
-	let docDataFormat: DocDataFormat
-	let displayName: String?
-	let docClaims: [DocClaim]
-	let typedData: DocTypedData
+	public let docType: String
+	public let docDataFormat: DocDataFormat
+	public let displayName: String?
+	public let docClaims: [DocClaim]
+	public let typedData: DocTypedData
 }
 
 public enum DocElements: Identifiable, Sendable {
@@ -171,7 +171,7 @@ extension RequestItem {
 		let query = allPaths.first { elementPath == $0.tokenArray }
 		let isValid = query != nil
 		let requestPath = bRootOnly ? [rootIdentifier] : elementPath
-		let docClaim: DocClaim? = if elementPath.count == 1 || !bRootOnly { findDocClaimByPath(docClaims: docClaims, requestPath: requestPath) } else { nil } 
+		let docClaim: DocClaim? = if elementPath.count == 1 || !bRootOnly { findDocClaimByPath(docClaims: docClaims, requestPath: requestPath) } else { nil }
 		let stringValue: String? = if elementPath.count == 1 || !bRootOnly { docClaim?.stringValue } else { nil }
 		return SdJwtElement(elementPath: requestPath, displayNames: displayNames, isOptional: !isMandatory, intentToRetain: intentToRetain ?? false, stringValue: stringValue, docClaim: docClaim, isValid: isValid, nestedElements: nil)
 	}


### PR DESCRIPTION
Change the properties of the `DocPresentInfo` struct to public access level for improved accessibility.