### PR TITLE
Refactor JSON extension to exclude vct claim from display

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "51219fb8a370931044c84ba9973b1778542183e52da9414455335c602ba6312f",
+  "originHash" : "838741d271af3973a1f7c6fb2ea5efac692044f9bb56724aaab4acc4c1cb2e51",
   "pins" : [
     {
       "identity" : "blueecc",
@@ -79,7 +79,7 @@
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-siop-openid4vp-swift.git",
       "state" : {
         "revision" : "1a5418f8bb11f31ef5acd0a795944e340ad29b9d",
-        "version" : "0.8.1"
+        "version" : "0.8.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git", exact: "0.4.8"),
 		// .package(path: "../eudi-lib-ios-wallet-storage"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift.git",exact: "0.6.0"),
-		.package(url:"https://github.com/eu-digital-identity-wallet/eudi-lib-ios-siop-openid4vp-swift.git",exact: "0.8.1"),
+		.package(url:"https://github.com/eu-digital-identity-wallet/eudi-lib-ios-siop-openid4vp-swift.git",exact: "0.8.2"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git",exact: "0.12.1"),
 	],
 	targets: [

--- a/Sources/EudiWalletKit/Extensions.swift
+++ b/Sources/EudiWalletKit/Extensions.swift
@@ -223,10 +223,10 @@ extension JSON {
 	}
 
 	func toDocClaim(_ key: String, order n: Int, pathPrefix: [String], _ claimDisplayNames: [String: String]?, _ mandatoryClaims: [String: Bool]?, _ claimValueTypes: [String: String]?, namespace: String? = nil) -> DocClaim? {
-		let bDebug = false // UserDefaults.standard.bool(forKey: "DebugDisplay")
-		if key == "cnf", type == .dictionary, !bDebug { return nil } // members used to identify the proof-of-possession key.
-		if key == "status", type == .dictionary, self["status_list"].type == .dictionary, !bDebug { return nil } // status list.
-		if key == "assurance_level" || key == JWTClaimNames.issuer, type == .string { if !bDebug { return nil } }
+		if key == "cnf", type == .dictionary { return nil } // members used to identify the proof-of-possession key.
+		if key == "status", type == .dictionary, self["status_list"].type == .dictionary { return nil } // status list.
+		if key == "assurance_level" || key == JWTClaimNames.issuer || key == JWTClaimNames.audience, type == .string {  return nil }
+		if key == "vct", type == .string  { return nil }
 		guard let pair = getDataValue(name: key, valueType: claimValueTypes?[key]) else { return nil}
 		let ch = toClaimsArray(pathPrefix: pathPrefix + [key], claimDisplayNames, mandatoryClaims, claimValueTypes, namespace)
 		let isMandatory = mandatoryClaims?[key] ?? true

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,13 @@
+## v0.10.3
+- Removed `vct` from `docClaims` collection. 
+
+## v0.10.2
+- Simplified OpenID4VCI configuration
+```swift
+wallet = try! EudiWallet(serviceName: Self.serviceName, trustedReaderCertificates: certs, 
+  openID4VciConfig: OpenId4VCIConfiguration(useDPoP: true), logFileName: "temp.txt", secureAreas: [mySecureArea])
+```
+
 ## v0.10.1
 - OpenID4VP Draft 23 support
 


### PR DESCRIPTION
Remove the vct claim from the displayed claims in the JSON extension to streamline the output.