### PR TITLE
Update OpenId4Vp dependency and enhance error logging

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "67d2db4b0462867ec80e4776652249fbc601bb4841bd903e04945f52f3277787",
+  "originHash" : "2bba76a0e94d4feb529fdf774356736328d34073f3278bfb5bb2f0f7245a3e3c",
   "pins" : [
     {
       "identity" : "blueecc",
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git",
       "state" : {
-        "revision" : "8242b43aa470a4a203cd163f5491b2f888819cf9",
-        "version" : "0.12.2"
+        "revision" : "751f66133efceb0662a3d6acfdd644d2627aa655",
+        "version" : "0.12.3"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7a61e1eb3ca6c1113649219183c822f22ae9a1a78f2a8aebea8305d33f8a6688",
+  "originHash" : "67d2db4b0462867ec80e4776652249fbc601bb4841bd903e04945f52f3277787",
   "pins" : [
     {
       "identity" : "blueecc",
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-siop-openid4vp-swift.git",
       "state" : {
-        "revision" : "b240cae2f084ceabfdad88fe56404f255060e2b9",
-        "version" : "0.8.3"
+        "revision" : "679a14c70ffd8ee37a81412ce388298e726747a7",
+        "version" : "0.9.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
 		// .package(path: "../eudi-lib-ios-wallet-storage"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift.git", exact: "0.6.0"),
 		.package(url:"https://github.com/eu-digital-identity-wallet/eudi-lib-ios-siop-openid4vp-swift.git", exact: "0.9.0"),
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git",exact: "0.12.2"),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git",exact: "0.12.3"),
 	],
 	targets: [
 		// Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git", exact: "0.4.8"),
 		// .package(path: "../eudi-lib-ios-wallet-storage"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift.git", exact: "0.6.0"),
-		.package(url:"https://github.com/eu-digital-identity-wallet/eudi-lib-ios-siop-openid4vp-swift.git", exact: "0.8.3"),
+		.package(url:"https://github.com/eu-digital-identity-wallet/eudi-lib-ios-siop-openid4vp-swift.git", exact: "0.9.0"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git",exact: "0.12.2"),
 	],
 	targets: [

--- a/Sources/EudiWalletKit/Services/OpenId4VpService.swift
+++ b/Sources/EudiWalletKit/Services/OpenId4VpService.swift
@@ -110,6 +110,10 @@ public final class OpenId4VpService: @unchecked Sendable, PresentationService {
 			switch try await siopOpenId4Vp.authorize(url: openid4VPURI)  {
 			case .notSecured(data: _):
 				throw PresentationSession.makeError(str: "Not secure request received.")
+			case .invalidResolution(error: let error, dispatchDetails: let details):
+				logger.error("Invalid resolution: \(error.localizedDescription)")
+				if let details { logger.error("Details: \(details)") }
+				throw PresentationSession.makeError(str: "Invalid resolution: \(error.localizedDescription)")
 			case let .jwt(request: resolvedRequestData):
 				self.resolvedRequestData = resolvedRequestData
 				switch resolvedRequestData {

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+## v0.10.5
+- Updated OpenID4VP library to version [v0.9.0](https://github.com/eu-digital-identity-wallet/eudi-lib-ios-siop-openid4vp-swift/releases/tag/v0.9.0)
+
+## v0.10.4
+- Support transaction data for OpenID4VP
+- Fix issue #162 
+- Fix issue #163
+
 ## v0.10.3
 - Removed `vct` from `docClaims` collection. 
 


### PR DESCRIPTION
Upgrade the OpenID4VP library to version 0.9.0 and improve error logging in the OpenId4VpService.
Update the OpenID4VCI library to version 0.12.3
Update the changelog for versions 0.10.4 and 0.10.5 to reflect these changes.