### PR TITLE
Fix for openid4vp for sd-jwt: Refactor path filtering logic in SdJwtElement extraction methods

### DIFF
--- a/Sources/EudiWalletKit/Models/DocElements.swift
+++ b/Sources/EudiWalletKit/Models/DocElements.swift
@@ -169,7 +169,7 @@ extension RequestItem {
 
 	public func extractSdJwtElement(allPaths: [JSONPointer], docClaims: [DocClaim], isMandatory: Bool, bRootOnly: Bool) -> SdJwtElement {
 		// find path that the request item contains it
-		let query = allPaths.first { path in elementPath.contains(path.tokenArray) }
+		let query = allPaths.first { path in elementPath.elementsEqual(path.tokenArray) } ?? allPaths.first { path in elementPath.contains(path.tokenArray) }
 		let isValid = query != nil
 		let requestPath = bRootOnly ? [rootIdentifier] : elementPath
 		let docClaim: DocClaim? = findDocClaimByPath(docClaims: docClaims, requestPath: requestPath)

--- a/Sources/EudiWalletKit/Models/DocElements.swift
+++ b/Sources/EudiWalletKit/Models/DocElements.swift
@@ -168,7 +168,8 @@ extension RequestItem {
 	}
 
 	public func extractSdJwtElement(allPaths: [JSONPointer], docClaims: [DocClaim], isMandatory: Bool, bRootOnly: Bool) -> SdJwtElement {
-		let query = allPaths.first { elementPath == $0.tokenArray }
+		// find path that the request item contains it
+		let query = allPaths.first { path in elementPath.contains(path.tokenArray) }
 		let isValid = query != nil
 		let requestPath = bRootOnly ? [rootIdentifier] : elementPath
 		let docClaim: DocClaim? = findDocClaimByPath(docClaims: docClaims, requestPath: requestPath)

--- a/Sources/EudiWalletKit/Services/Openid4VpUtils.swift
+++ b/Sources/EudiWalletKit/Services/Openid4VpUtils.swift
@@ -156,7 +156,7 @@ class Openid4VpUtils {
 	static func getSdJwtPresentation(_ sdJwt: SignedSDJWT, hashingAlg: HashingAlgorithm, signer: SecureAreaSigner, signAlg: JSONWebAlgorithms.SigningAlgorithm, requestItems: [RequestItem], nonce: String, aud: String, transactionData: [TransactionData]?) async throws -> SignedSDJWT? {
 		let allPaths = try sdJwt.disclosedPaths()
 		let requestPaths = requestItems.map(\.elementPath)
-		let query = Set(allPaths.filter { requestPaths.contains($0.tokenArray) })
+		let query = Set(allPaths.filter { path in requestPaths.contains(where: { r in r.contains(path.tokenArray) }) })
 		if query.isEmpty { throw WalletError(description: "No items to present found") }
 		let presentedSdJwt = try await sdJwt.present(query: query)
 		guard let presentedSdJwt else { return nil }


### PR DESCRIPTION
Improved the path filtering logic to allow extraction of any path contained within the request item.