### PR TITLE
Update the eudi-lib-sdjwt-swift dependency to version 0.7.2 and enhance DPoP support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8ef2d15d58a2bfbd7bccaadeea06ce531aad85ad86f8118ac779d4564f2dda17",
+  "originHash" : "0fe4c61a2fc50ecefd629116721d822517058486c925b2fde33abf7bf1ca3b0c",
   "pins" : [
     {
       "identity" : "blueecc",
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift.git",
       "state" : {
-        "revision" : "b0768e77a2216e3a6c4b1ac15ba7232722db0969",
-        "version" : "0.7.1"
+        "revision" : "5d33ca40db259729d9473dd7c71f1bb214ec1755",
+        "version" : "0.7.2"
       }
     },
     {
@@ -231,8 +231,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/niscy-eudiw/swift-json-schema",
       "state" : {
-        "revision" : "871937a16f0c75da739bda9a57693cd50185e379",
-        "version" : "0.0.3"
+        "revision" : "105cfcd41cf83f264f23ed36dc11191dea45b65f",
+        "version" : "0.0.4"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "603e99f0e0bcbbaaa1e1d586587e7ce00329d3b6824e959469bbc8b11fa42722",
+  "originHash" : "8ef2d15d58a2bfbd7bccaadeea06ce531aad85ad86f8118ac779d4564f2dda17",
   "pins" : [
     {
       "identity" : "blueecc",
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift.git",
       "state" : {
-        "revision" : "5d318469727bc845f4b001490974b80392d2acb8",
-        "version" : "0.6.3"
+        "revision" : "b0768e77a2216e3a6c4b1ac15ba7232722db0969",
+        "version" : "0.7.1"
       }
     },
     {
@@ -224,6 +224,15 @@
       "state" : {
         "revision" : "e8d6eba1fef23ae5b359c46b03f7d94be2f41fed",
         "version" : "3.12.3"
+      }
+    },
+    {
+      "identity" : "swift-json-schema",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/niscy-eudiw/swift-json-schema",
+      "state" : {
+        "revision" : "871937a16f0c75da739bda9a57693cd50185e379",
+        "version" : "0.0.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
 	name: "EudiWalletKit",
-	platforms: [.macOS(.v13), .iOS(.v16), .watchOS(.v10)],
+	platforms: [.macOS(.v14), .iOS(.v16), .watchOS(.v10)],
 	products: [
 		// Products define the executables and libraries a package produces, making them visible to other packages.
 		.library(
@@ -17,7 +17,7 @@ let package = Package(
 		.package(url: "https://github.com/crspybits/swift-log-file", from: "0.1.0"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git", exact: "0.7.3"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git", exact: "0.6.1"),
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift.git", exact: "0.7.1"),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift.git", exact: "0.7.2"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-siop-openid4vp-swift.git", exact: "0.13.1"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git",exact: "0.15.1"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-statium-swift.git", exact: "0.2.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
 		.package(url: "https://github.com/crspybits/swift-log-file", from: "0.1.0"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git", exact: "0.7.3"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git", exact: "0.6.1"),
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift.git", exact: "0.6.3"),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift.git", exact: "0.7.1"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-siop-openid4vp-swift.git", exact: "0.13.1"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git",exact: "0.15.1"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-statium-swift.git", exact: "0.2.0"),

--- a/Sources/EudiWalletKit/Models/OpenId4VCIConfiguration.swift
+++ b/Sources/EudiWalletKit/Models/OpenId4VCIConfiguration.swift
@@ -40,7 +40,7 @@ public struct OpenId4VCIConfiguration {
 extension OpenId4VCIConfiguration {
 
 	static var supportedDPoPAlgorithms: Set<JWSAlgorithm> {
-		[JWSAlgorithm(.ES256), JWSAlgorithm(.ES384), JWSAlgorithm(.ES512)]
+		[JWSAlgorithm(.ES256), JWSAlgorithm(.ES384), JWSAlgorithm(.ES512), JWSAlgorithm(.RS256)]
 	}
 
 	static func makeDPoPConstructor(algorithms: [JWSAlgorithm]?) throws -> DPoPConstructorType? {
@@ -52,9 +52,10 @@ extension OpenId4VCIConfiguration {
 		}
 		let alg = JWSAlgorithm(name: algName)
 		logger.info("Signing algorithm for DPoP constructor to be used is: \(alg.name)")
-		// supported bit sizes are 256, 384, or 521.
-		let bits: Int = switch alg.name { case JWSAlgorithm(.ES256).name: 256; case JWSAlgorithm(.ES384).name: 384; case JWSAlgorithm(.ES512).name: 521; default: throw WalletError(description: "Unsupported DPoP algorithm: \(alg.name)") }
-		let privateKey = try SecKey.createRandomKey(type: SecKey.KeyType.ellipticCurve, bits: bits)
+		// EC supported bit sizes are 256, 384, or 521. RS256 is 2048 bits.
+		let bits: Int = switch alg.name { case JWSAlgorithm(.ES256).name: 256; case JWSAlgorithm(.ES384).name: 384; case JWSAlgorithm(.ES512).name: 521; case JWSAlgorithm(.RS256).name: 2048; default: throw WalletError(description: "Unsupported DPoP algorithm: \(alg.name)") }
+		let type: SecKey.KeyType = switch alg.name { case JWSAlgorithm(.RS256).name: .rsa; default: .ellipticCurve }
+		let privateKey = try SecKey.createRandomKey(type: type, bits: bits)
 		let publicKey = try KeyController.generateECDHPublicKey(from: privateKey)
 		let publicKeyJWK = try ECPublicKey(publicKey: publicKey, additionalParameters: ["alg": alg.name, "use": "sig", "kid": UUID().uuidString])
 		let privateKeyProxy: SigningKeyProxy = .secKey(privateKey)

--- a/Sources/EudiWalletKit/Models/OpenId4VCIConfiguration.swift
+++ b/Sources/EudiWalletKit/Models/OpenId4VCIConfiguration.swift
@@ -45,11 +45,13 @@ extension OpenId4VCIConfiguration {
 
 	static func makeDPoPConstructor(algorithms: [JWSAlgorithm]?) throws -> DPoPConstructorType? {
 		guard let algorithms = algorithms, !algorithms.isEmpty else { return nil }
-		let setCommonJwsAlgorithmNames = Set(algorithms.map(\.name)).intersection(Self.supportedDPoPAlgorithms.map(\.name))
+		logger.info("Creating DPoP constructor for algorithms \(algorithms.map(\.name))")
+		let setCommonJwsAlgorithmNames = Array(Set(algorithms.map(\.name)).intersection(Self.supportedDPoPAlgorithms.map(\.name))).sorted()
 		guard let algName = setCommonJwsAlgorithmNames.first else {
 			throw WalletError(description: "No supported DPoP algorithm found in the provided algorithms. Supported algorithms are: \(Self.supportedDPoPAlgorithms.map(\.name))")
 		}
 		let alg = JWSAlgorithm(name: algName)
+		logger.info("Signing algorithm for DPoP constructor to be used is: \(alg.name)")
 		// supported bit sizes are 256, 384, or 521.
 		let bits: Int = switch alg.name { case JWSAlgorithm(.ES256).name: 256; case JWSAlgorithm(.ES384).name: 384; case JWSAlgorithm(.ES512).name: 521; default: throw WalletError(description: "Unsupported DPoP algorithm: \(alg.name)") }
 		let privateKey = try SecKey.createRandomKey(type: SecKey.KeyType.ellipticCurve, bits: bits)


### PR DESCRIPTION
Update the eudi-lib-sdjwt-swift dependency to version 0.7.2 and adjust the platform version to macOS 14. Enhance DPoP constructor logging and add support for the RS256 algorithm in key generation.