### PR TITLE
Send VPtoken instead of CBOR device response for DCQL queries

### DIFF
--- a/Sources/EudiWalletKit/Services/OpenId4VpService.swift
+++ b/Sources/EudiWalletKit/Services/OpenId4VpService.swift
@@ -202,7 +202,7 @@ public final class OpenId4VpService: @unchecked Sendable, PresentationService {
 		logger.info("Openid4vp request items: \(itemsToSend.mapValues { $0.mapValues { ar in ar.map(\.elementIdentifier) } })")
 		if unlockData == nil { _ = try await startQrEngagement(secureAreaName: nil, crv: .P256) }
 		if formatsRequested.first(where: { (_, value: DocDataFormat) in value == .cbor }) != nil { makeCborDocs() }
-		if formatsRequested.allSatisfy({ (_, value: DocDataFormat) in value == .cbor }) {
+		if dcql == nil, formatsRequested.allSatisfy({ (_, value: DocDataFormat) in value == .cbor }) {
 			let vpToken = try await generateCborVpToken(itemsToSend: itemsToSend)
 			let inputId = presentationDefinition?.inputDescriptors.first!.id ?? dcql?.credentials.first?.id.value ?? ""
 			try await SendVpTokens([(inputId, nil, vpToken.0)], presentationDefinition, dcql, resolved, onSuccess)


### PR DESCRIPTION
Modify the logic to send a VPtoken when processing DCQL queries instead of returning a CBOR device response. This change enhances the handling of requests based on the presence of DCQL.