### PR TITLE
Fix transaction logs decoding error

### DIFF
--- a/Sources/EudiWalletKit/Extensions.swift
+++ b/Sources/EudiWalletKit/Extensions.swift
@@ -194,6 +194,10 @@ extension DocMetadata {
 	}
 }
 
+extension DocKeyInfo {
+	static var `default`: Self { DocKeyInfo(secureAreaName: SoftwareSecureArea.name, batchSize: 1, credentialPolicy: .rotateUse) }
+}
+
 extension URL {
 	func getBaseUrl() -> String {
 		var urlString = scheme! + "://" + host!

--- a/Sources/EudiWalletKit/Services/StorageManager.swift
+++ b/Sources/EudiWalletKit/Services/StorageManager.swift
@@ -142,7 +142,7 @@ public final class StorageManager: ObservableObject, @unchecked Sendable {
 		// guard let str = D dd = Data(base64Encoded: d.1.bytes)  else { return nil }
 		guard let iss = IssuerSigned(data: d.1.bytes) else { logger.error("Could not decode IssuerSigned"); return nil }
 		let docMetadata = DocMetadata(from: doc.metadata)
-		guard let docKeyInfo = DocKeyInfo(from: doc.docKeyInfo) else { logger.error("Could not decode DocKeyInfo"); return nil }
+		let docKeyInfo = DocKeyInfo(from: doc.docKeyInfo) ?? .default
 		let md = docMetadata?.getMetadata(uiCulture: uiCulture)
 		let cmd = md?.claimMetadata?.convertToCborClaimMetadata(uiCulture)
 		var retModel: (any DocClaimsDecodable)? = modelFactory?.makeClaimsDecodableFromCbor(id: d.0, createdAt: doc.createdAt, issuerSigned: iss, displayName: md?.displayName, display: md?.display, issuerDisplay: md?.issuerDisplay, credentialIssuerIdentifier: md?.credentialIssuerIdentifier, configurationIdentifier: md?.configurationIdentifier, validFrom: iss.validFrom, validUntil: iss.validUntil, statusIdentifier: iss.issuerAuth.statusIdentifier, credentialPolicy: docKeyInfo.credentialPolicy, secureAreaName: docKeyInfo.secureAreaName, displayNames: cmd?.displayNames, mandatory: cmd?.mandatory)
@@ -160,7 +160,7 @@ public final class StorageManager: ObservableObject, @unchecked Sendable {
 	public static func toSdJwtDocModel(doc: WalletStorage.Document, uiCulture: String?, modelFactory: (any DocClaimsDecodableFactory)? = nil) -> (any DocClaimsDecodable)? {
 		var docClaims = [DocClaim]()
 		let docMetadata: DocMetadata? = DocMetadata(from: doc.metadata)
-		guard let docKeyInfo = DocKeyInfo(from: doc.docKeyInfo) else { logger.error("Could not decode DocKeyInfo"); return nil }
+		let docKeyInfo = DocKeyInfo(from: doc.docKeyInfo) ?? .default
 		let md = docMetadata?.getMetadata(uiCulture: uiCulture)
 		guard let recreatedClaims = recreateSdJwtClaims(docData: doc.data) else { return nil }
 		if let cs = recreatedClaims.json.toClaimsArray(pathPrefix: [], md?.claimMetadata, uiCulture)?.0 { docClaims.append(contentsOf: cs) }

--- a/Sources/EudiWalletKit/Services/TransactionLogUtils.swift
+++ b/Sources/EudiWalletKit/Services/TransactionLogUtils.swift
@@ -77,13 +77,13 @@ class TransactionLogUtils {
 	}
 
 	static func parseCBORDocClaimsDecodable(id: String, docType: String, issuerSigned: IssuerSigned, metadata: Data?, uiCulture: String?) -> (any DocClaimsDecodable)? {
-		let document = WalletStorage.Document(id: id, docType: docType, docDataFormat: .cbor, data: Data(issuerSigned.encode(options: CBOROptions())), docKeyInfo: nil, createdAt: .now, modifiedAt: .now, metadata: metadata, displayName: docType, status: .issued)
+		let document = WalletStorage.Document(id: id, docType: docType, docDataFormat: .cbor, data: Data(issuerSigned.encode(options: CBOROptions())), docKeyInfo: DocKeyInfo.default.toData(), createdAt: .now, modifiedAt: .now, metadata: metadata, displayName: docType, status: .issued)
 		return StorageManager.toClaimsModel(doc: document, uiCulture: uiCulture, modelFactory: nil)
 	}
 
 	static func parseSdJwtDocClaimsDecodable(id: String, docType: String, sdJwtSerialized: String, metadata: Data?, uiCulture: String?) -> (any DocClaimsDecodable)? {
 		guard let sdJwtData = sdJwtSerialized.data(using: .utf8) else { return nil }
-		let document = WalletStorage.Document(id: id, docType: docType, docDataFormat: .sdjwt, data: sdJwtData, docKeyInfo: nil, createdAt: .now, modifiedAt: .now, metadata: metadata, displayName: docType, status: .issued)
+		let document = WalletStorage.Document(id: id, docType: docType, docDataFormat: .sdjwt, data: sdJwtData, docKeyInfo: DocKeyInfo.default.toData(), createdAt: .now, modifiedAt: .now, metadata: metadata, displayName: docType, status: .issued)
 		return StorageManager.toClaimsModel(doc: document, uiCulture: uiCulture, modelFactory: nil)
 	}
 


### PR DESCRIPTION
Improve handling of `DocKeyInfo` by providing a default value when decoding fails, ensuring smoother transaction log processing.