### PR TITLE
Throw error for unsupported document types with nil credentialSets

### DIFF
--- a/Sources/EudiWalletKit/Services/Openid4VpUtils.swift
+++ b/Sources/EudiWalletKit/Services/Openid4VpUtils.swift
@@ -60,6 +60,7 @@ class Openid4VpUtils {
 		return Data(bytes).base64URLEncodedString()
 	}
 
+	/// Parse DCQL into request items (docType -> namespaced items), formats requested (docType -> dataFormat) and input descriptor map (docType -> credentialQueryId)
 	static func parseDcql(_ dcql: DCQL, idsToDocTypes: [String: String], dataFormats: [String: DocDataFormat], docDisplayNames: [String: [String: [String: String]]?], logger: Logger? = nil) throws -> (RequestItems?, [String: DocDataFormat], [String: String]) {
 		var inputDescriptorMap = [String: String]()
 		var requestItems = RequestItems()
@@ -67,6 +68,11 @@ class Openid4VpUtils {
 		for credQuery in dcql.credentials {
 			let formatRequested: DocDataFormat = credQuery.dataFormat
 			guard let docType = credQuery.docType else { continue }
+			if !idsToDocTypes.values.contains(docType) {
+				logger?.warning("Document type \(docType) not in supported document types \(idsToDocTypes.values)")
+				// todo: implement full support for credentialSets
+				if dcql.credentialSets == nil { throw WalletError(description: "Document type \(docType) not in supported document types \(idsToDocTypes.values)") }
+			}
 			var nsItems: [String: [RequestItem]] = [:]
 			for claim in credQuery.claims ?? [] {
 				guard let pair =  Self.parseClaim(claim, formatRequested) else { continue }

--- a/Tests/EudiWalletKitTests/EudiWalletKitTests.swift
+++ b/Tests/EudiWalletKitTests/EudiWalletKitTests.swift
@@ -35,7 +35,7 @@ struct EudiWalletKitTests {
 		let wrapper = try JSONDecoder().decode(Wrapper.self, from: testDcqlData)
 		let testDcql = wrapper.dcql_query
 		do {
-			let (items, fmtsRequested, _) = try Openid4VpUtils.parseDcql(testDcql,  idsToDocTypes: [:], dataFormats: [:], docDisplayNames: [:])
+			let (items, fmtsRequested, _) = try Openid4VpUtils.parseDcql(testDcql,  idsToDocTypes: ["1": "urn:eu.europa.ec.eudi:pid:1"], dataFormats: [:], docDisplayNames: [:])
 			if let items, let docType = items.first?.key, let nsItems = items.first?.value.first {
 				print("DocType: ", docType, "ns:", nsItems.key, "Items: ", nsItems.value.map { $0.elementIdentifier })
 				#expect(fmtsRequested.allSatisfy({ (k,v) in v == format }))


### PR DESCRIPTION
Implement error handling when a requested document type is not present and credentialSets is nil, improving robustness in parsing DCQL.