### PR TITLE
Update eudi-lib-ios-iso18013-data-transfer to version 0.8.3

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ba7342b28596545c9bdb52fbebd046ef46e365682a103da820e392b8a01850f3",
+  "originHash" : "be3620e7d43cc8df0ae201999867cc68845c145a3d903323cc7516873a9e37a7",
   "pins" : [
     {
       "identity" : "blueecc",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git",
       "state" : {
-        "revision" : "6c5be04ea3d759aab100ad7ab4cbab221c1cd236",
-        "version" : "0.8.2"
+        "revision" : "7b27c74921ab2d569174c71e97cc775a27441163",
+        "version" : "0.8.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
 	dependencies: [
 		.package(url: "https://github.com/apple/swift-log.git", from: "1.6.3"),
 		.package(url: "https://github.com/crspybits/swift-log-file", from: "0.1.0"),
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git", exact: "0.8.2"),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git", exact: "0.8.3"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git", exact: "0.8.0"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift.git", exact: "0.9.1"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-siop-openid4vp-swift.git", exact: "0.17.6"),


### PR DESCRIPTION
Upgrade the eudi-lib-ios-iso18013-data-transfer dependency to version 0.8.3 to incorporate the latest changes and improvements.