### PR TITLE
Refresh access token handling and update dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5718e6ca2fa8af8c06b670655addcf2b2509a90dbce31b187f438ba026da5367",
+  "originHash" : "8aed2678bafc8bf26e7e2d36def953005d4dbf5a38d5fe56a3d6aa88705d5b19",
   "pins" : [
     {
       "identity" : "cryptoswift",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git",
       "state" : {
-        "revision" : "be60de2e1587ec5691d9fdc69b9cad749db71860",
-        "version" : "0.33.0"
+        "revision" : "0a706012f7c42bcbe7548d3298efd8e9773b70e0",
+        "version" : "0.33.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git", exact: "0.11.1"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift.git", exact: "0.14.1"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-siop-openid4vp-swift.git", exact: "0.31.0"),
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git", exact: "0.33.0"),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git", exact: "0.33.1"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-statium-swift.git", exact: "0.4.0"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/SwiftCopyableMacro.git", from: "0.0.3")
 	],

--- a/Sources/EudiWalletKit/Services/OpenId4VciService.swift
+++ b/Sources/EudiWalletKit/Services/OpenId4VciService.swift
@@ -221,9 +221,11 @@ public actor OpenId4VCIService {
 		let authorizedOutcome: AuthorizeRequestOutcome
 		if var authorized {
 			do {
-				authorized = try await issuer.refresh(client: vciConfig.client, authorizedRequest: authorized, dPopNonce: nil)
+				if authorized.isAccessTokenExpired() {
+					authorized = try await issuer.refresh(client: vciConfig.client, authorizedRequest: authorized, dPopNonce: nil)
+					logger.info("Refreshed authorized request for offer \(offerUri)")
+				}
 				authorizedOutcome = .authorized(authorized)
-				logger.info("Refreshed authorized request for offer \(offerUri)")
 				return (authorizedOutcome, issuer, credentialInfos)
 			}
 			catch {
@@ -861,7 +863,7 @@ extension WalletError {
 			else { return WalletError(description: wae.localizedDescription) }
 		}
 		return WalletError(description:"Authorization request failed: \(error.localizedDescription)")
-		
+
 	}
 }
 


### PR DESCRIPTION
Refresh authorized requests only when the access token is expired and log the action. Update the package dependency for `eudi-lib-ios-openid4vci-swift` to version 0.33.1.