### PR TITLE
Reorder DocClaims by issuer Metadata in toClaimsModel function

### DIFF
--- a/Sources/EudiWalletKit/Extensions.swift
+++ b/Sources/EudiWalletKit/Extensions.swift
@@ -374,3 +374,37 @@ extension DocClaim {
 		if let children { children.map(\.claimPath) } else { [claimPath] }
 	}
 }
+
+extension DocClaimsModelConfiguration {
+	init(from model: DocClaimsModel) {
+		self.init(
+			id: model.id, createdAt: model.createdAt, docType: model.docType,
+			displayName: model.displayName, display: model.display, issuerDisplay: model.issuerDisplay,
+			credentialIssuerIdentifier: model.credentialIssuerIdentifier,
+			configurationIdentifier: model.configurationIdentifier,
+			validFrom: model.validFrom, validUntil: model.validUntil,
+			statusIdentifier: model.statusIdentifier,
+			credentialsUsageCounts: model.credentialsUsageCounts,
+			credentialPolicy: model.credentialPolicy, secureAreaName: model.secureAreaName,
+			modifiedAt: model.modifiedAt, ageOverXX: model.ageOverXX,
+			docClaims: model.docClaims, docDataFormat: model.docDataFormat,
+			hashingAlg: model.hashingAlg, nameSpaces: model.nameSpaces
+		)
+	}
+
+	func withDocClaims(_ docClaims: [DocClaim]) -> DocClaimsModelConfiguration {
+		DocClaimsModelConfiguration(
+			id: id, createdAt: createdAt, docType: docType,
+			displayName: displayName, display: display, issuerDisplay: issuerDisplay,
+			credentialIssuerIdentifier: credentialIssuerIdentifier,
+			configurationIdentifier: configurationIdentifier,
+			validFrom: validFrom, validUntil: validUntil,
+			statusIdentifier: statusIdentifier,
+			credentialsUsageCounts: credentialsUsageCounts,
+			credentialPolicy: credentialPolicy, secureAreaName: secureAreaName,
+			modifiedAt: modifiedAt, ageOverXX: ageOverXX,
+			docClaims: docClaims, docDataFormat: docDataFormat,
+			hashingAlg: hashingAlg, nameSpaces: nameSpaces
+		)
+	}
+}

--- a/Sources/EudiWalletKit/Services/StorageManager.swift
+++ b/Sources/EudiWalletKit/Services/StorageManager.swift
@@ -132,10 +132,12 @@ public final class StorageManager: ObservableObject, @unchecked Sendable {
 	///
 	/// - Returns: An optional `DocClaimsModel` model created from the given document.
 	public static func toClaimsModel(doc: WalletStorage.Document, uiCulture: String?, modelFactory: (any DocClaimsDecodableFactory)? = nil) -> DocClaimsModel? {
-		switch doc.docDataFormat {
-		case .cbor:	toCborMdocModel(doc: doc, uiCulture: uiCulture, modelFactory: modelFactory)
+		let model: DocClaimsModel? = switch doc.docDataFormat {
+		case .cbor: toCborMdocModel(doc: doc, uiCulture: uiCulture, modelFactory: modelFactory)
 		case .sdjwt: toSdJwtDocModel(doc: doc, uiCulture: uiCulture, modelFactory: modelFactory)
 		}
+		guard let model else { return nil }
+		return reorderDocClaimsByMetadata(model, doc: doc, uiCulture: uiCulture)
 	}
 
 	public static func toCborMdocModel(doc: WalletStorage.Document, uiCulture: String?, modelFactory: (any DocClaimsDecodableFactory)? = nil) -> DocClaimsModel? {
@@ -156,6 +158,35 @@ public final class StorageManager: ObservableObject, @unchecked Sendable {
 			retModel = defModel ?? DocClaimsModel(configuration: configuration, issuerSigned: iss, displayNames: cmd?.displayNames, mandatory: cmd?.mandatory)
 		}
 		return retModel
+	}
+
+	static func reorderDocClaimsByMetadata(_ model: DocClaimsModel, doc: WalletStorage.Document, uiCulture: String?) -> DocClaimsModel {
+		let docMetadata = DocMetadata(from: doc.metadata)
+		guard let claimMetadata = docMetadata?.getMetadata(uiCulture: uiCulture).claimMetadata, !claimMetadata.isEmpty else { return model }
+
+		// Build order map: claim path string -> position in metadata
+		var claimOrderMap = [String: Int]()
+		for (index, meta) in claimMetadata.enumerated() {
+			let pathKey = meta.claimPath.joined(separator: "/").replacingOccurrences(of: "//", with: "/")
+			if claimOrderMap[pathKey] == nil {
+				claimOrderMap[pathKey] = index
+			}
+		}
+		// Sort docClaims by metadata order, preserving original position for unmatched claims
+		let reorderedClaims = model.docClaims.enumerated().sorted { lhs, rhs in
+			let lhsPath = lhs.element.path.joined(separator: "/").replacingOccurrences(of: "//", with: "/")
+			let rhsPath = rhs.element.path.joined(separator: "/").replacingOccurrences(of: "//", with: "/")
+			let lhsOrder = claimOrderMap[lhsPath] ?? Int.max
+			let rhsOrder = claimOrderMap[rhsPath] ?? Int.max
+			if lhsOrder != rhsOrder { return lhsOrder < rhsOrder }
+			return lhs.offset < rhs.offset
+		}.enumerated().map { newOrder, pair in
+			var claim = pair.element
+			claim.order = newOrder
+			return claim
+		}.sorted(using: KeyPathComparator(\.order))
+		let configuration = DocClaimsModelConfiguration(from: model).withDocClaims(reorderedClaims)
+		return DocClaimsModel(configuration: configuration)
 	}
 
 	public static func toSdJwtDocModel(doc: WalletStorage.Document, uiCulture: String?, modelFactory: (any DocClaimsDecodableFactory)? = nil) -> DocClaimsModel? {

--- a/Tests/EudiWalletKitTests/EudiWalletKitTests.swift
+++ b/Tests/EudiWalletKitTests/EudiWalletKitTests.swift
@@ -72,6 +72,87 @@ struct EudiWalletKitTests {
 		#expect("org.iso.18013.5.1.mDL" == iss.issuerAuth.mso.docType)
 	}
 
+	@Test("CBOR docClaims order follows metadata claim order")
+	func testCborDocClaimsRespectMetadataOrder() throws {
+		// 1. Load issuer metadata and extract claim paths for pid-mso-mdoc
+		let issuerData = try #require(Data(name: "pid-demo-openid-credential-issuer", ext: "json", from: Bundle.module))
+		let issuerJson = try JSON(data: issuerData)
+		let claimsJson = try #require(issuerJson["credential_configurations_supported"]["pid-mso-mdoc"]["credential_metadata"]["claims"].array)
+
+		let claimMetadata = claimsJson.compactMap { claimJson -> DocClaimMetadata? in
+			guard let path = claimJson["path"].array?.map(\.stringValue) else { return nil }
+			let displayArr = claimJson["display"].array?.compactMap { d -> DisplayMetadata? in
+				guard let name = d["name"].string else { return nil }
+				return DisplayMetadata(name: name, localeIdentifier: d["locale"].string, logo: nil, description: nil, backgroundColor: nil, textColor: nil)
+			}
+			return DocClaimMetadata(display: displayArr, isMandatory: claimJson["mandatory"].bool, claimPath: path)
+		}
+		#expect(!claimMetadata.isEmpty)
+
+		// 2. Load the current (pre-reorder) doc claims
+		let claimsData = try #require(Data(name: "pid_demo_current_doc_claims_order", ext: "json", from: Bundle.module))
+		let currentClaimsJson = try #require(try JSON(data: claimsData).array)
+
+		let docClaims = currentClaimsJson.enumerated().map { index, claim in
+			DocClaim(
+				name: claim["name"].stringValue,
+				path: claim["path"].arrayValue.map(\.stringValue),
+				displayName: claim["displayName"].string,
+				dataValue: .string(claim["stringValue"].stringValue),
+				stringValue: claim["stringValue"].stringValue,
+				isOptional: claim["isOptional"].boolValue,
+				order: index,
+				namespace: claim["namespace"].string
+			)
+		}
+		#expect(docClaims.count == currentClaimsJson.count)
+
+		// 3. Build model and document with metadata
+		let docType = "eu.europa.ec.eudi.pid.1"
+		let metadata = DocMetadata(
+			credentialIssuerIdentifier: issuerJson["credential_issuer"].stringValue,
+			configurationIdentifier: "pid-mso-mdoc",
+			docType: docType,
+			display: nil,
+			issuerDisplay: nil,
+			claims: claimMetadata,
+			authorizedRequestData: nil,
+			keyOptions: nil,
+			credentialOptions: nil
+		)
+
+		let model = DocClaimsModel(configuration: DocClaimsModelConfiguration(
+			id: UUID().uuidString, docType: docType, displayName: nil, display: nil,
+			credentialIssuerIdentifier: nil, configurationIdentifier: nil,
+			validFrom: nil, validUntil: nil, statusIdentifier: nil,
+			credentialsUsageCounts: nil, credentialPolicy: .rotateUse,
+			secureAreaName: nil, modifiedAt: nil,
+			docClaims: docClaims, docDataFormat: .cbor, hashingAlg: nil
+		))
+
+		let document = WalletStorage.Document(
+			id: model.id, docType: docType, docDataFormat: .cbor,
+			data: Data(), docKeyInfo: nil, createdAt: .now, modifiedAt: .now,
+			metadata: metadata.toData(), displayName: nil, status: .issued
+		)
+
+		// 4. Apply reordering
+		let reordered = StorageManager.reorderDocClaimsByMetadata(model, doc: document, uiCulture: nil)
+
+		// 5. Verify claims are now in metadata order
+		let expectedOrder = claimMetadata
+			.filter { meta in docClaims.contains { $0.path == meta.claimPath } }
+			.map { $0.claimPath.last! }
+
+		let actualOrder = reordered.docClaims.map(\.name)
+		#expect(actualOrder == expectedOrder)
+
+		// Verify order values are sequential
+		for (i, claim) in reordered.docClaims.enumerated() {
+			#expect(claim.order == i)
+		}
+	}
+
 	@Test("Generate OpenId4Vp Session Transcript with JwkThumbprint") func testGenerateOpenId4VpSessionTranscriptWithJwkThumbprint() {
 		let OPENID4VP_1_0_SESSION_TRANSCRIPT = "83f6f682714f70656e494434565048616e646f7665725820048bc053c00442af9b8eed494cefdd9d95240d254b046b11b68013722aad38ac"
 		let clientId = "x509_san_dns:example.com"

--- a/Tests/EudiWalletKitTests/Resources/pid-demo-openid-credential-issuer.json
+++ b/Tests/EudiWalletKitTests/Resources/pid-demo-openid-credential-issuer.json
@@ -1,0 +1,1755 @@
+{
+  "credential_issuer": "https://demo.pid-provider.bundesdruckerei.de",
+  "credential_endpoint": "https://demo.pid-provider.bundesdruckerei.de/credential",
+  "nonce_endpoint": "https://demo.pid-provider.bundesdruckerei.de/nonce",
+  "batch_credential_issuance": {
+    "batch_size": 42
+  },
+  "display": [
+    {
+      "name": "Bundesdruckerei GmbH",
+      "locale": "de"
+    },
+    {
+      "name": "Bundesdruckerei GmbH",
+      "locale": "en"
+    }
+  ],
+  "credential_configurations_supported": {
+    "pid-sd-jwt": {
+      "format": "dc+sd-jwt",
+      "vct": "urn:eudi:pid:de:1",
+      "scope": "pid",
+      "credential_signing_alg_values_supported": [
+        "ES256"
+      ],
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "proof_types_supported": {
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
+        },
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ]
+        }
+      },
+      "credential_metadata": {
+        "display": [
+          {
+            "name": "German PID",
+            "locale": "en"
+          },
+          {
+            "name": "Deutsche PID",
+            "locale": "de"
+          }
+        ],
+        "claims": [
+          {
+            "path": [
+              "issuing_country"
+            ],
+            "display": [
+              {
+                "name": "Issuing country",
+                "locale": "en"
+              },
+              {
+                "name": "Ausstellendes Land",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "issuing_authority"
+            ],
+            "display": [
+              {
+                "name": "Issuing authority",
+                "locale": "en"
+              },
+              {
+                "name": "Ausstellender Staat",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "family_name"
+            ],
+            "display": [
+              {
+                "name": "Family name",
+                "locale": "en"
+              },
+              {
+                "name": "Familienname",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "given_name"
+            ],
+            "display": [
+              {
+                "name": "Given name(s)",
+                "locale": "en"
+              },
+              {
+                "name": "Vorname(n)",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "birth_family_name"
+            ],
+            "display": [
+              {
+                "name": "Birth name",
+                "locale": "en"
+              },
+              {
+                "name": "Geburtsname",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "birthdate"
+            ],
+            "display": [
+              {
+                "name": "Date of birth",
+                "locale": "en"
+              },
+              {
+                "name": "Geburtsdatum",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "source_document_type"
+            ],
+            "display": [
+              {
+                "name": "Document type",
+                "locale": "en"
+              },
+              {
+                "name": "Dokumentenart",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "nationalities"
+            ],
+            "display": [
+              {
+                "name": "Nationality",
+                "locale": "en"
+              },
+              {
+                "name": "Staatsangehörigkeit",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "age_equal_or_over",
+              "12"
+            ],
+            "display": [
+              {
+                "name": "Age over 12",
+                "locale": "en"
+              },
+              {
+                "name": "Älter als 12",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "age_equal_or_over",
+              "14"
+            ],
+            "display": [
+              {
+                "name": "Age over 14",
+                "locale": "en"
+              },
+              {
+                "name": "Älter als 14",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "age_equal_or_over",
+              "16"
+            ],
+            "display": [
+              {
+                "name": "Age over 16",
+                "locale": "en"
+              },
+              {
+                "name": "Älter als 16",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "age_equal_or_over",
+              "18"
+            ],
+            "display": [
+              {
+                "name": "Age over 18",
+                "locale": "en"
+              },
+              {
+                "name": "Älter als 18",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "age_equal_or_over",
+              "21"
+            ],
+            "display": [
+              {
+                "name": "Age over 21",
+                "locale": "en"
+              },
+              {
+                "name": "Älter als 21",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "age_equal_or_over",
+              "65"
+            ],
+            "display": [
+              {
+                "name": "Age over 65",
+                "locale": "en"
+              },
+              {
+                "name": "Älter als 65",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "place_of_birth",
+              "locality"
+            ],
+            "display": [
+              {
+                "name": "Place of birth",
+                "locale": "en"
+              },
+              {
+                "name": "Geburtsort",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "place_of_birth",
+              "country"
+            ],
+            "display": [
+              {
+                "name": "Country of birth",
+                "locale": "en"
+              },
+              {
+                "name": "Geburtsland",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "place_of_birth",
+              "region"
+            ],
+            "display": [
+              {
+                "name": "Region of birth",
+                "locale": "en"
+              },
+              {
+                "name": "Geburtsregion",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "address",
+              "locality"
+            ],
+            "display": [
+              {
+                "name": "Resident city",
+                "locale": "en"
+              },
+              {
+                "name": "Stadt des Wohnsitzes",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "address",
+              "country"
+            ],
+            "display": [
+              {
+                "name": "Resident country",
+                "locale": "en"
+              },
+              {
+                "name": "Wohnsitzland",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "address",
+              "region"
+            ],
+            "display": [
+              {
+                "name": "Resident state",
+                "locale": "en"
+              },
+              {
+                "name": "Staat/Provinz/Distrikt des Wohnsitzes",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "address",
+              "formatted"
+            ],
+            "display": [
+              {
+                "name": "Place of residence",
+                "locale": "en"
+              },
+              {
+                "name": "Wohnsitz",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "address",
+              "postal_code"
+            ],
+            "display": [
+              {
+                "name": "Resident Postal Code",
+                "locale": "en"
+              },
+              {
+                "name": "Postleitzahl des Wohnsitzes",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "address",
+              "street_address"
+            ],
+            "display": [
+              {
+                "name": "Resident Street",
+                "locale": "en"
+              },
+              {
+                "name": "Straße des Wohnsitzes",
+                "locale": "de"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "pid-sd-jwt_2-beta": {
+      "format": "dc+sd-jwt",
+      "vct": "urn:eudi:pid:de:1",
+      "scope": "pid",
+      "credential_signing_alg_values_supported": [
+        "ES256"
+      ],
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "proof_types_supported": {
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
+        },
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ]
+        }
+      },
+      "credential_metadata": {
+        "display": [
+          {
+            "name": "German PID",
+            "locale": "en"
+          },
+          {
+            "name": "Deutsche PID",
+            "locale": "de"
+          }
+        ],
+        "claims": [
+          {
+            "path": [
+              "issuing_country"
+            ],
+            "display": [
+              {
+                "name": "Issuing country",
+                "locale": "en"
+              },
+              {
+                "name": "Ausstellendes Land",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "issuing_authority"
+            ],
+            "display": [
+              {
+                "name": "Issuing authority",
+                "locale": "en"
+              },
+              {
+                "name": "Ausstellender Staat",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "family_name"
+            ],
+            "display": [
+              {
+                "name": "Family name",
+                "locale": "en"
+              },
+              {
+                "name": "Familienname",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "given_name"
+            ],
+            "display": [
+              {
+                "name": "Given name(s)",
+                "locale": "en"
+              },
+              {
+                "name": "Vorname(n)",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "birth_name"
+            ],
+            "display": [
+              {
+                "name": "Birth name",
+                "locale": "en"
+              },
+              {
+                "name": "Geburtsname",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "birthdate"
+            ],
+            "display": [
+              {
+                "name": "Date of birth",
+                "locale": "en"
+              },
+              {
+                "name": "Geburtsdatum",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "source_document_type"
+            ],
+            "display": [
+              {
+                "name": "Document type",
+                "locale": "en"
+              },
+              {
+                "name": "Dokumentenart",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "nationalities"
+            ],
+            "display": [
+              {
+                "name": "Nationality",
+                "locale": "en"
+              },
+              {
+                "name": "Staatsangehörigkeit",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "age_equal_or_over",
+              "12"
+            ],
+            "display": [
+              {
+                "name": "Age over 12",
+                "locale": "en"
+              },
+              {
+                "name": "Älter als 12",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "age_equal_or_over",
+              "14"
+            ],
+            "display": [
+              {
+                "name": "Age over 14",
+                "locale": "en"
+              },
+              {
+                "name": "Älter als 14",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "age_equal_or_over",
+              "16"
+            ],
+            "display": [
+              {
+                "name": "Age over 16",
+                "locale": "en"
+              },
+              {
+                "name": "Älter als 16",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "age_equal_or_over",
+              "18"
+            ],
+            "display": [
+              {
+                "name": "Age over 18",
+                "locale": "en"
+              },
+              {
+                "name": "Älter als 18",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "age_equal_or_over",
+              "21"
+            ],
+            "display": [
+              {
+                "name": "Age over 21",
+                "locale": "en"
+              },
+              {
+                "name": "Älter als 21",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "age_equal_or_over",
+              "65"
+            ],
+            "display": [
+              {
+                "name": "Age over 65",
+                "locale": "en"
+              },
+              {
+                "name": "Älter als 65",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "place_of_birth",
+              "locality"
+            ],
+            "display": [
+              {
+                "name": "Place of birth",
+                "locale": "en"
+              },
+              {
+                "name": "Geburtsort",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "place_of_birth",
+              "no_place_info"
+            ],
+            "display": [
+              {
+                "name": "Place of birth known",
+                "locale": "en"
+              },
+              {
+                "name": "Geburtsort bekannt",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "address",
+              "locality"
+            ],
+            "display": [
+              {
+                "name": "Resident city",
+                "locale": "en"
+              },
+              {
+                "name": "Stadt des Wohnsitzes",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "address",
+              "country"
+            ],
+            "display": [
+              {
+                "name": "Resident country",
+                "locale": "en"
+              },
+              {
+                "name": "Wohnsitzland",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "address",
+              "region"
+            ],
+            "display": [
+              {
+                "name": "Resident state",
+                "locale": "en"
+              },
+              {
+                "name": "Staat/Provinz/Distrikt des Wohnsitzes",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "address",
+              "formatted"
+            ],
+            "display": [
+              {
+                "name": "Place of residence",
+                "locale": "en"
+              },
+              {
+                "name": "Wohnsitz",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "address",
+              "postal_code"
+            ],
+            "display": [
+              {
+                "name": "Resident Postal Code",
+                "locale": "en"
+              },
+              {
+                "name": "Postleitzahl des Wohnsitzes",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "address",
+              "street_address"
+            ],
+            "display": [
+              {
+                "name": "Resident Street",
+                "locale": "en"
+              },
+              {
+                "name": "Straße des Wohnsitzes",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "also_known_as"
+            ],
+            "display": [
+              {
+                "name": "Religious/artistic name",
+                "locale": "en"
+              },
+              {
+                "name": "Ordens-/Künstlername",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "title"
+            ],
+            "display": [
+              {
+                "name": "Doctoral degree",
+                "locale": "en"
+              },
+              {
+                "name": "Doktorgrad",
+                "locale": "de"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "pid-mso-mdoc": {
+      "format": "mso_mdoc",
+      "doctype": "eu.europa.ec.eudi.pid.1",
+      "scope": "pid",
+      "credential_signing_alg_values_supported": [
+        "ES256"
+      ],
+      "cryptographic_binding_methods_supported": [
+        "cose_key"
+      ],
+      "proof_types_supported": {
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
+        },
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ]
+        }
+      },
+      "credential_metadata": {
+        "display": [
+          {
+            "name": "German PID",
+            "locale": "en"
+          },
+          {
+            "name": "Deutsche PID",
+            "locale": "de"
+          }
+        ],
+        "claims": [
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "issuing_country"
+            ],
+            "display": [
+              {
+                "name": "Issuing country",
+                "locale": "en"
+              },
+              {
+                "name": "Ausstellendes Land",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "issuing_authority"
+            ],
+            "display": [
+              {
+                "name": "Issuing authority",
+                "locale": "en"
+              },
+              {
+                "name": "Ausstellender Staat",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "issuance_date"
+            ],
+            "display": [
+              {
+                "name": "Issuing date",
+                "locale": "en"
+              },
+              {
+                "name": "Ausstellungsdatum",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "expiry_date"
+            ],
+            "display": [
+              {
+                "name": "Valid until",
+                "locale": "en"
+              },
+              {
+                "name": "Gültig bis",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "family_name"
+            ],
+            "display": [
+              {
+                "name": "Family name",
+                "locale": "en"
+              },
+              {
+                "name": "Familienname",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "given_name"
+            ],
+            "display": [
+              {
+                "name": "Given name(s)",
+                "locale": "en"
+              },
+              {
+                "name": "Vorname(n)",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "family_name_birth"
+            ],
+            "display": [
+              {
+                "name": "Birth name",
+                "locale": "en"
+              },
+              {
+                "name": "Geburtsname",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "birth_date"
+            ],
+            "display": [
+              {
+                "name": "Date of birth",
+                "locale": "en"
+              },
+              {
+                "name": "Geburtsdatum",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "source_document_type"
+            ],
+            "display": [
+              {
+                "name": "Document type",
+                "locale": "en"
+              },
+              {
+                "name": "Dokumentenart",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "nationality"
+            ],
+            "display": [
+              {
+                "name": "Nationality",
+                "locale": "en"
+              },
+              {
+                "name": "Staatsangehörigkeit",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "age_over_12"
+            ],
+            "display": [
+              {
+                "name": "Age over 12",
+                "locale": "en"
+              },
+              {
+                "name": "Älter als 12",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "age_over_14"
+            ],
+            "display": [
+              {
+                "name": "Age over 14",
+                "locale": "en"
+              },
+              {
+                "name": "Älter als 14",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "age_over_16"
+            ],
+            "display": [
+              {
+                "name": "Age over 16",
+                "locale": "en"
+              },
+              {
+                "name": "Älter als 16",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "age_over_18"
+            ],
+            "display": [
+              {
+                "name": "Age over 18",
+                "locale": "en"
+              },
+              {
+                "name": "Älter als 18",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "age_over_21"
+            ],
+            "display": [
+              {
+                "name": "Age over 21",
+                "locale": "en"
+              },
+              {
+                "name": "Älter als 21",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "age_over_65"
+            ],
+            "display": [
+              {
+                "name": "Age over 65",
+                "locale": "en"
+              },
+              {
+                "name": "Älter als 65",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "birth_place",
+              "locality"
+            ],
+            "display": [
+              {
+                "name": "Place of birth",
+                "locale": "en"
+              },
+              {
+                "name": "Geburtsort",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "birth_place",
+              "country"
+            ],
+            "display": [
+              {
+                "name": "Country of birth",
+                "locale": "en"
+              },
+              {
+                "name": "Geburtsland",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "birth_place",
+              "region"
+            ],
+            "display": [
+              {
+                "name": "Region of birth",
+                "locale": "en"
+              },
+              {
+                "name": "Geburtsregion",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "resident_city"
+            ],
+            "display": [
+              {
+                "name": "Resident city",
+                "locale": "en"
+              },
+              {
+                "name": "Stadt des Wohnsitzes",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "resident_country"
+            ],
+            "display": [
+              {
+                "name": "Resident country",
+                "locale": "en"
+              },
+              {
+                "name": "Wohnsitzland",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "resident_state"
+            ],
+            "display": [
+              {
+                "name": "Resident state",
+                "locale": "en"
+              },
+              {
+                "name": "Staat/Provinz/Distrikt des Wohnsitzes",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "resident_address"
+            ],
+            "display": [
+              {
+                "name": "Place of residence",
+                "locale": "en"
+              },
+              {
+                "name": "Wohnsitz",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "resident_postal_code"
+            ],
+            "display": [
+              {
+                "name": "Resident Postal Code",
+                "locale": "en"
+              },
+              {
+                "name": "Postleitzahl des Wohnsitzes",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "resident_street"
+            ],
+            "display": [
+              {
+                "name": "Resident Street",
+                "locale": "en"
+              },
+              {
+                "name": "Straße des Wohnsitzes",
+                "locale": "de"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "pid-mso-mdoc_2-beta": {
+      "format": "mso_mdoc",
+      "doctype": "eu.europa.ec.eudi.pid.1",
+      "scope": "pid",
+      "credential_signing_alg_values_supported": [
+        "ES256"
+      ],
+      "cryptographic_binding_methods_supported": [
+        "cose_key"
+      ],
+      "proof_types_supported": {
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+            "key_storage": [
+              "iso_18045_high"
+            ],
+            "user_authentication": [
+              "iso_18045_high"
+            ]
+          }
+        },
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ]
+        }
+      },
+      "credential_metadata": {
+        "display": [
+          {
+            "name": "German PID",
+            "locale": "en"
+          },
+          {
+            "name": "Deutsche PID",
+            "locale": "de"
+          }
+        ],
+        "claims": [
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "issuing_country"
+            ],
+            "display": [
+              {
+                "name": "Issuing country",
+                "locale": "en"
+              },
+              {
+                "name": "Ausstellendes Land",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "issuing_authority"
+            ],
+            "display": [
+              {
+                "name": "Issuing authority",
+                "locale": "en"
+              },
+              {
+                "name": "Ausstellender Staat",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "issuance_date"
+            ],
+            "display": [
+              {
+                "name": "Issuing date",
+                "locale": "en"
+              },
+              {
+                "name": "Ausstellungsdatum",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "expiry_date"
+            ],
+            "display": [
+              {
+                "name": "Valid until",
+                "locale": "en"
+              },
+              {
+                "name": "Gültig bis",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "family_name"
+            ],
+            "display": [
+              {
+                "name": "Family name",
+                "locale": "en"
+              },
+              {
+                "name": "Familienname",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "given_name"
+            ],
+            "display": [
+              {
+                "name": "Given name(s)",
+                "locale": "en"
+              },
+              {
+                "name": "Vorname(n)",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.de.1",
+              "birth_name"
+            ],
+            "display": [
+              {
+                "name": "Birth name",
+                "locale": "en"
+              },
+              {
+                "name": "Geburtsname",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "birth_date"
+            ],
+            "display": [
+              {
+                "name": "Date of birth",
+                "locale": "en"
+              },
+              {
+                "name": "Geburtsdatum",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.de.1",
+              "source_document_type"
+            ],
+            "display": [
+              {
+                "name": "Document type",
+                "locale": "en"
+              },
+              {
+                "name": "Dokumentenart",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "nationality"
+            ],
+            "display": [
+              {
+                "name": "Nationality",
+                "locale": "en"
+              },
+              {
+                "name": "Staatsangehörigkeit",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.de.1",
+              "age_over_12"
+            ],
+            "display": [
+              {
+                "name": "Age over 12",
+                "locale": "en"
+              },
+              {
+                "name": "Älter als 12",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.de.1",
+              "age_over_14"
+            ],
+            "display": [
+              {
+                "name": "Age over 14",
+                "locale": "en"
+              },
+              {
+                "name": "Älter als 14",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.de.1",
+              "age_over_16"
+            ],
+            "display": [
+              {
+                "name": "Age over 16",
+                "locale": "en"
+              },
+              {
+                "name": "Älter als 16",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.de.1",
+              "age_over_18"
+            ],
+            "display": [
+              {
+                "name": "Age over 18",
+                "locale": "en"
+              },
+              {
+                "name": "Älter als 18",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.de.1",
+              "age_over_21"
+            ],
+            "display": [
+              {
+                "name": "Age over 21",
+                "locale": "en"
+              },
+              {
+                "name": "Älter als 21",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.de.1",
+              "age_over_65"
+            ],
+            "display": [
+              {
+                "name": "Age over 65",
+                "locale": "en"
+              },
+              {
+                "name": "Älter als 65",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "place_of_birth",
+              "locality"
+            ],
+            "display": [
+              {
+                "name": "Place of birth",
+                "locale": "en"
+              },
+              {
+                "name": "Geburtsort",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.de.1",
+              "place_of_birth",
+              "no_place_info"
+            ],
+            "display": [
+              {
+                "name": "Place of birth known",
+                "locale": "en"
+              },
+              {
+                "name": "Geburtsort bekannt",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "resident_city"
+            ],
+            "display": [
+              {
+                "name": "Resident city",
+                "locale": "en"
+              },
+              {
+                "name": "Stadt des Wohnsitzes",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "resident_country"
+            ],
+            "display": [
+              {
+                "name": "Resident country",
+                "locale": "en"
+              },
+              {
+                "name": "Wohnsitzland",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "resident_state"
+            ],
+            "display": [
+              {
+                "name": "Resident state",
+                "locale": "en"
+              },
+              {
+                "name": "Staat/Provinz/Distrikt des Wohnsitzes",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "resident_address"
+            ],
+            "display": [
+              {
+                "name": "Place of residence",
+                "locale": "en"
+              },
+              {
+                "name": "Wohnsitz",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "resident_postal_code"
+            ],
+            "display": [
+              {
+                "name": "Resident Postal Code",
+                "locale": "en"
+              },
+              {
+                "name": "Postleitzahl des Wohnsitzes",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.1",
+              "resident_street"
+            ],
+            "display": [
+              {
+                "name": "Resident Street",
+                "locale": "en"
+              },
+              {
+                "name": "Straße des Wohnsitzes",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.de.1",
+              "also_known_as"
+            ],
+            "display": [
+              {
+                "name": "Religious/artistic name",
+                "locale": "en"
+              },
+              {
+                "name": "Ordens-/Künstlername",
+                "locale": "de"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eu.europa.ec.eudi.pid.de.1",
+              "academic_title"
+            ],
+            "display": [
+              {
+                "name": "Doctoral degree",
+                "locale": "en"
+              },
+              {
+                "name": "Doktorgrad",
+                "locale": "de"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/Tests/EudiWalletKitTests/Resources/pid_demo_current_doc_claims_order.json
+++ b/Tests/EudiWalletKitTests/Resources/pid_demo_current_doc_claims_order.json
@@ -1,0 +1,56 @@
+[
+  {
+    "order": 0,
+    "name": "birth_date",
+    "displayName": "Date of birth",
+    "namespace": "eu.europa.ec.eudi.pid.1",
+    "path": ["eu.europa.ec.eudi.pid.1", "birth_date"],
+    "stringValue": "1964-08-12",
+    "isOptional": false
+  },
+  {
+    "order": 1,
+    "name": "issuing_authority",
+    "displayName": "Issuing authority",
+    "namespace": "eu.europa.ec.eudi.pid.1",
+    "path": ["eu.europa.ec.eudi.pid.1", "issuing_authority"],
+    "stringValue": "DE",
+    "isOptional": false
+  },
+  {
+    "order": 2,
+    "name": "resident_postal_code",
+    "displayName": "Resident Postal Code",
+    "namespace": "eu.europa.ec.eudi.pid.1",
+    "path": ["eu.europa.ec.eudi.pid.1", "resident_postal_code"],
+    "stringValue": "51147",
+    "isOptional": false
+  },
+  {
+    "order": 3,
+    "name": "source_document_type",
+    "displayName": "Document type",
+    "namespace": "eu.europa.ec.eudi.pid.1",
+    "path": ["eu.europa.ec.eudi.pid.1", "source_document_type"],
+    "stringValue": "ID",
+    "isOptional": false
+  },
+  {
+    "order": 4,
+    "name": "given_name",
+    "displayName": "Given name(s)",
+    "namespace": "eu.europa.ec.eudi.pid.1",
+    "path": ["eu.europa.ec.eudi.pid.1", "given_name"],
+    "stringValue": "ERIKA",
+    "isOptional": false
+  },
+  {
+    "order": 5,
+    "name": "age_over_12",
+    "displayName": "Age over 12",
+    "namespace": "eu.europa.ec.eudi.pid.1",
+    "path": ["eu.europa.ec.eudi.pid.1", "age_over_12"],
+    "stringValue": "true",
+    "isOptional": false
+  }
+]


### PR DESCRIPTION
Add tests for CBOR docClaims order and include necessary resources
- Implemented a new test `testCborDocClaimsRespectMetadataOrder` to verify that the order of document claims follows the metadata claim order.
- Added `pid-demo-openid-credential-issuer.json` to provide issuer metadata for testing.
- Created `pid_demo_current_doc_claims_order.json` to represent the current order of document claims for comparison in tests.