### PR TITLE
Add partial claims presentation support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ff6e6e34e9493407bf1043b6219be25394d7fb1594bdfd87ecd0972b13c99271",
+  "originHash" : "6a1872b6caeeb1fd8402a33d2eb5bc9eb7ff38bf31609b163ac8652ad5d6ff49",
   "pins" : [
     {
       "identity" : "cryptoswift",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git",
       "state" : {
-        "revision" : "315883536773e85f3bfda886eb807c7271fb3a93",
-        "version" : "0.34.0"
+        "revision" : "69df986e52c420f2d2b567dcd9901c8555e661c8",
+        "version" : "0.34.1"
       }
     },
     {

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The library provides the following functionality:
       document transfer
         - [x] ClienID scheme: preregistered, x509_san_uri, x509_san_dns, redirect_uri
         - [x] DCQL
+        - [x] Optional partial claim presentation for DCQL requests
 
 The library is written in Swift and is compatible with iOS 16 or higher. It requires Swift 6.2 or later. It is distributed as a Swift package and can be included in any iOS project.
 
@@ -124,13 +125,16 @@ let config = EudiWalletConfiguration(
     logFileName: "wallet.log"
 )
 let openId4VpConfig = OpenId4VpConfiguration(
-    clientIdSchemes: [.x509SanDns, .x509Hash, .redirectUri]
+    clientIdSchemes: [.x509SanDns, .x509Hash, .redirectUri],
+    allowPresentingPartialClaims: true
 )
 let wallet = try! EudiWallet(
     eudiWalletConfig: config,
     openID4VpConfig: openId4VpConfig
 )
 ```
+
+Set `allowPresentingPartialClaims` to `true` when you want OpenID4VP DCQL resolution to skip claims that are missing from an otherwise matching credential. The default value is `false`, which keeps all requested claims mandatory.
 
 ### OpenID4VCI Configuration
 

--- a/Sources/EudiWalletKit/EudiWalletKit.docc/PresentationService.md
+++ b/Sources/EudiWalletKit/EudiWalletKit.docc/PresentationService.md
@@ -10,6 +10,19 @@ let session = eudiWallet.beginPresentation(flow: flow)
 ShareView(presentationSession: session)
 ```
 
+For OpenID4VP flows, partial DCQL claim presentation can be enabled through ``OpenId4VpConfiguration``. When ``OpenId4VpConfiguration/allowPresentingPartialClaims`` is `true`, claims that are not present in an otherwise matching credential are omitted instead of causing the presentation request to fail.
+
+```swift
+let openId4VpConfig = OpenId4VpConfiguration(
+    clientIdSchemes: [.x509SanDns, .x509Hash, .redirectUri],
+    allowPresentingPartialClaims: true
+)
+let wallet = try! EudiWallet(
+    eudiWalletConfig: config,
+    openID4VpConfig: openId4VpConfig
+)
+```
+
 On view appearance the attestations are presented with the ``PresentationService/receiveRequest()`` method. For the BLE (proximity) case, the ``PresentationSession/deviceEngagement`` property is populated with the QR code to be displayed on the holder device.
 
 ```swift
@@ -19,7 +32,7 @@ On view appearance the attestations are presented with the ``PresentationService
 }
 ```
 
-After the request is received the ``PresentationSession/disclosedDocuments`` contains the requested attested items. The selected state of the items can be modified via UI binding. Finally, the response is sent with the following code: 
+After the request is received the ``PresentationSession/disclosedDocuments`` contains the requested attested items that can be satisfied by the selected credential. When partial-claim presentation is enabled, this includes only the claims that are both requested and available. The selected state of the items can be modified via UI binding. Finally, the response is sent with the following code: 
 
 ```swift
 // Send the disclosed document items after biometric authentication (FaceID or TouchID)
@@ -31,4 +44,3 @@ await presentationSession.sendResponse(userAccepted: true,
     }
   })
 ```
-

--- a/Sources/EudiWalletKit/Models/OpenId4VpConfiguration.swift
+++ b/Sources/EudiWalletKit/Models/OpenId4VpConfiguration.swift
@@ -76,15 +76,22 @@ public struct OpenId4VpConfiguration: Sendable {
 	/// When provided, the wallet will encrypt the presentation response using the specified
 	/// encryption parameters before sending it to the verifier.
 	public let responseEncryptionConfiguration: ResponseEncryptionConfiguration?
+	/// Allows presentation to continue when a requested claim is missing from an otherwise matching credential.
+	///
+	/// When enabled, claims that are not present are skipped instead of failing the DCQL resolution.
+	/// By default, all requested claims remain mandatory.
+	public let allowPresentingPartialClaims: Bool
 
 	public init() {
 		self.clientIdSchemes = [.x509SanDns, .x509Hash, .redirectUri]
 		self.responseEncryptionConfiguration = nil
+		self.allowPresentingPartialClaims = false
 	}
 
-	public init(clientIdSchemes: [ClientIdScheme], responseEncryptionConfiguration: ResponseEncryptionConfiguration? = nil) {
+	public init(clientIdSchemes: [ClientIdScheme], responseEncryptionConfiguration: ResponseEncryptionConfiguration? = nil, allowPresentingPartialClaims: Bool = false) {
 		self.clientIdSchemes = clientIdSchemes
 		self.responseEncryptionConfiguration = responseEncryptionConfiguration
+		self.allowPresentingPartialClaims = allowPresentingPartialClaims
 	}
 }
 

--- a/Sources/EudiWalletKit/Models/OpenId4VpConfiguration.swift
+++ b/Sources/EudiWalletKit/Models/OpenId4VpConfiguration.swift
@@ -81,15 +81,17 @@ public struct OpenId4VpConfiguration: Sendable {
 	/// When enabled, claims that are not present are skipped instead of failing the DCQL resolution.
 	/// By default, all requested claims remain mandatory.
 	public let allowPresentingPartialClaims: Bool
+	
+	public static let defaultClientIdSchemes: [ClientIdScheme] = [.x509SanDns, .x509Hash, .redirectUri]
 
 	public init() {
-		self.clientIdSchemes = [.x509SanDns, .x509Hash, .redirectUri]
+		self.clientIdSchemes = Self.defaultClientIdSchemes
 		self.responseEncryptionConfiguration = nil
 		self.allowPresentingPartialClaims = false
 	}
 
-	public init(clientIdSchemes: [ClientIdScheme], responseEncryptionConfiguration: ResponseEncryptionConfiguration? = nil, allowPresentingPartialClaims: Bool = false) {
-		self.clientIdSchemes = clientIdSchemes
+	public init(clientIdSchemes: [ClientIdScheme]? = nil, responseEncryptionConfiguration: ResponseEncryptionConfiguration? = nil, allowPresentingPartialClaims: Bool = false) {
+		self.clientIdSchemes = clientIdSchemes ?? Self.defaultClientIdSchemes
 		self.responseEncryptionConfiguration = responseEncryptionConfiguration
 		self.allowPresentingPartialClaims = allowPresentingPartialClaims
 	}

--- a/Sources/EudiWalletKit/Services/OpenId4VpService.swift
+++ b/Sources/EudiWalletKit/Services/OpenId4VpService.swift
@@ -148,7 +148,8 @@ public final class OpenId4VpService: @unchecked Sendable, PresentationService {
 			let (fmtsReq, imap, zkSpecMap) = try OpenId4VpUtils.parseDcqlFormats(dcql, idsToDocTypes: transferInfo.idsToDocTypes, logger: logger)
 			formatsRequested = fmtsReq; inputDescriptorMap = imap; zkSpecsRequested = zkSpecMap
 			decodeDocuments()
-			let claimMapPath = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
+			let claimMapPath = try OpenId4VpUtils.resolveDcql(
+				dcql, queryable: dcqlQueryable, allowPresentingPartialClaims: openID4VpConfig.allowPresentingPartialClaims)
 			requestItems = OpenId4VpUtils.getRequestItems(claimMapPath, idsToDocTypes: transferInfo.idsToDocTypes, formatsRequested: formatsRequested)
 		}
 		self.transactionData = vp.transactionData

--- a/Sources/EudiWalletKit/Services/Openid4VpUtils.swift
+++ b/Sources/EudiWalletKit/Services/Openid4VpUtils.swift
@@ -209,7 +209,7 @@ extension OpenId4VpUtils {
 	/// - Returns: A dictionary mapping matched credential IDs to arrays of ClaimPath objects representing
 	///            the claims to disclose
 	/// - Throws: WalletError if the query cannot be satisfied, with details about the first missing claim
-	static func resolveDcql(_ dcql: DCQL, queryable: DcqlQueryable) throws -> [String: [ClaimsQuery]] {
+	static func resolveDcql(_ dcql: DCQL, queryable: DcqlQueryable, allowPresentingPartialClaims: Bool = false) throws -> [String: [ClaimsQuery]] {
 		var result: [String: [ClaimsQuery]] = [:]
 		var lastError: WalletError?
 		var credentialQueryResults: [QueryId: (matchedCredId: Document.ID, claimQueries: [ClaimsQuery])] = [:]
@@ -223,7 +223,7 @@ extension OpenId4VpUtils {
 			// Try to find a credential that satisfies the claim requirements
 			for credId in matchingCredIds {
 				do {
-					let claimPaths = try resolveClaimsForCredential(credQuery: credQuery, credId: credId, queryable: queryable)
+					let claimPaths = try resolveClaimsForCredential(credQuery: credQuery, credId: credId, queryable: queryable, allowPresentingPartialClaims: allowPresentingPartialClaims)
 					credentialQueryResults[credQuery.id] = (credId, claimPaths)
 				} catch {
 					lastError = error
@@ -279,7 +279,7 @@ extension OpenId4VpUtils {
 
 	/// Resolves claims for a specific credential query and credential
 	/// - Throws: WalletError if claims cannot be satisfied, with details about the first missing claim
-	private static func resolveClaimsForCredential(credQuery: CredentialQuery, credId: String, queryable: DcqlQueryable) throws(WalletError) -> [ClaimsQuery] {
+	private static func resolveClaimsForCredential(credQuery: CredentialQuery, credId: String, queryable: DcqlQueryable, allowPresentingPartialClaims: Bool) throws(WalletError) -> [ClaimsQuery] {
 		// If no claims specified, return empty array (only mandatory claims)
 		guard let claims = credQuery.claims, !claims.isEmpty else {
 			return []
@@ -329,6 +329,7 @@ extension OpenId4VpUtils {
 						throw WalletError(description: "Claim value mismatch for: \(claimPathStr)", code: .claimValueMismatch, context: ["claimPath": claimPathStr])
 					}
 				} else if !queryable.hasClaim(id: credId, claimPath: claim.path) {
+					if allowPresentingPartialClaims { continue } // do not throw, just skip this claim
 					let claimPathStr = claim.path.value.map(\.claimName).joined(separator: "/")
 					throw WalletError(description: "Claim not found: \(claimPathStr)", code: .claimNotFound, context: ["claimPath": claimPathStr])
 				}

--- a/Tests/EudiWalletKitTests/DcqlQueryTests.swift
+++ b/Tests/EudiWalletKitTests/DcqlQueryTests.swift
@@ -641,6 +641,34 @@ struct DcqlQueryTests {
 		}
 	}
 
+	@Test("DCQL partial claims mode suppresses missing claim errors", arguments: ["dcql-vehicle"])
+	func testAllowPresentingPartialClaimsSuppressesClaimNotFound(dcqlFile: String) throws {
+		let dcqlData = try loadTestResource(fileName: dcqlFile)
+		let wrapper = try JSONDecoder().decode(DCQL.self, from: dcqlData)
+		let dcql = try DCQL(credentials: wrapper.credentials)
+		let dcqlQueryable = DefaultDcqlQueryable(
+			credentials: ["cred1": ("org.iso.7367.1.mVRC", DocDataFormat.cbor)],
+			claimPaths: [
+				"cred1": [
+					ClaimPath([.claim(name: "org.iso.7367.1"), .claim(name: "vehicle_holder")])
+				]
+			]
+		)
+
+		let result = try OpenId4VpUtils.resolveDcql(
+			dcql,
+			queryable: dcqlQueryable,
+			allowPresentingPartialClaims: true
+		)
+
+		#expect(result.count == 1, "Should still resolve the matching credential")
+		#expect(result["cred1"]?.count == 1, "Should keep only the claims that are present")
+		#expect(
+			result["cred1"]?.first?.path.value == ClaimPath([.claim(name: "org.iso.7367.1"), .claim(name: "vehicle_holder")]).value,
+			"Should only include the available claim path"
+		)
+	}
+
 	@Test("WalletError has .credentialNotFound code when docType is missing", arguments: ["dcql-vehicle"])
 	func testErrorCodeCredentialNotFound(dcqlFile: String) throws {
 		let dcqlData = try loadTestResource(fileName: dcqlFile)

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,16 @@
+## v0.24.0
+
+### OpenID4VP Partial Claim Presentation
+- Added `allowPresentingPartialClaims` to `OpenId4VpConfiguration` to let DCQL-based OpenID4VP presentations continue when some requested claims are missing from an otherwise matching credential.
+- When enabled, unavailable claims are skipped from the disclosed claim set instead of causing DCQL resolution to fail.
+
+```swift
+let openId4VpConfig = OpenId4VpConfiguration(
+    clientIdSchemes: [.x509SanDns, .x509Hash, .redirectUri],
+    allowPresentingPartialClaims: true
+)
+```
+
 ## v0.23.7
 
 ### DPoP and Reissuance Improvements

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,40 @@
+## v0.23.7
+
+### DPoP and Reissuance Improvements
+- Added DPoP support to deferred issuance flows.
+- Reissuance now always refreshes access tokens as part of the process.
+
+## v0.23.6
+
+### Access Token Refresh Handling
+- Improved access token refresh handling.
+- Updated related dependency versions to support the refreshed token flow.
+
+## v0.23.5
+
+### Dependency Updates
+- Updated `eudi-lib-ios-siop-openid4vp-swift` to version 0.31.0.
+
+## v0.23.4
+
+### Transaction Logging and OpenID4VCI Enhancements
+- Added transaction logging for document deletion in `EudiWallet`.
+- Enhanced `OpenId4VCIService`.
+- Updated `eudi-lib-ios-openid4vci-swift` to version 0.33.0.
+
+## v0.23.3
+
+### Issuance Logging, Error Handling, and DCQL Improvements
+- Added issuance transaction logging to `OpenId4VciService`.
+- Added BLE-specific error codes and mapped transfer-layer errors to `WalletError.Code`.
+- Added wildcard-aware value matching for DCQL queries.
+- Updated libraries and fixed `CredentialQuery`.
+
+## v0.23.2
+
+### Structured DCQL Error Codes
+- Added structured error codes to `WalletError` for DCQL query failures.
+
 ## v0.23.1
 
 ### Background Reissuance and DPoP Propagation


### PR DESCRIPTION
Update the package to reflect the latest version of the eudi-lib-ios-openid4vci-swift library and introduce support for presenting partial claims in OpenId4VpConfiguration. This enhancement allows claims that are not present to be skipped during the resolution process, improving flexibility in credential presentations.