### PR TITLE
fix: support for the backgroundImageURL for the credential.

### DIFF
--- a/Sources/EudiWalletKit/Extensions.swift
+++ b/Sources/EudiWalletKit/Extensions.swift
@@ -43,7 +43,7 @@ func secCall<Result>(_ body: (_ resultPtr: UnsafeMutablePointer<Unmanaged<CFErro
 extension Display {
 	public var displayMetadata: MdocDataModel18013.DisplayMetadata {
 		let logoMetadata = LogoMetadata(urlString: logo?.uri?.absoluteString, alternativeText: logo?.alternativeText)
-		return MdocDataModel18013.DisplayMetadata(name: name, localeIdentifier: locale?.identifier, logo: logoMetadata, description: description, backgroundColor: backgroundColor, textColor: textColor)
+		return MdocDataModel18013.DisplayMetadata(name: name, localeIdentifier: locale?.identifier, logo: logoMetadata, description: description, backgroundColor: backgroundColor, textColor: textColor, backgroundImageURL: backgroundImage?.url.absoluteString)
 	}
 }
 


### PR DESCRIPTION
This PR introduces the support for the property, backgroundImageURL, to the DisplayMetadata struct.
This is needed for the background image from the credentialMetaData.

Here is the Issue: https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-kit/issues/334
