### PR TITLE
Refine sd-jwt claim metadata handling to use exact claim paths for display names and mandatory status in JSON conversion

### DIFF
--- a/Sources/EudiWalletKit/Extensions.swift
+++ b/Sources/EudiWalletKit/Extensions.swift
@@ -175,8 +175,9 @@ extension Array where Element == DocClaimMetadata {
 		let groupIndex = keyPrefix?.count ?? 0
 		let arr = if let keyPrefix { filter { $0.claimPath.count > groupIndex && keyPrefix.elementsEqual($0.claimPath[0..<keyPrefix.count]) } } else { self }
 		let dictKeys = Dictionary(grouping: arr, by: { $0.claimPath[groupIndex]} )
-		let displayNames = dictKeys.compactMapValues { $0.first?.display?.getName(uiCulture) }
-		let mandatory =  dictKeys.compactMapValues { $0.first?.isMandatory }
+		let exactPathLength = groupIndex + 1
+		let displayNames = dictKeys.compactMapValues { $0.first(where: { $0.claimPath.count == exactPathLength })?.display?.getName(uiCulture) }
+		let mandatory =  dictKeys.compactMapValues { $0.first(where: { $0.claimPath.count == exactPathLength })?.isMandatory }
 		return (displayNames, mandatory, arr)
 	}
 }

--- a/Tests/EudiWalletKitTests/EudiWalletKitTests.swift
+++ b/Tests/EudiWalletKitTests/EudiWalletKitTests.swift
@@ -221,6 +221,58 @@ struct EudiWalletKitTests {
 			Issue.record("Expected .string data value for female sex claim")
 		}
 	}
+
+	@Test("JSON nested claim metadata labels only exact claim paths")
+	func testJsonNestedClaimMetadataUsesExactPathDisplay() throws {
+		let claimMetadata = [
+			DocClaimMetadata(
+				display: [DisplayMetadata(name: "Age over 12", localeIdentifier: "en", logo: nil, description: nil, backgroundColor: nil, textColor: nil)],
+				isMandatory: true,
+				claimPath: ["age_equal_or_over", "12"]
+			),
+			DocClaimMetadata(
+				display: [DisplayMetadata(name: "Age over 18", localeIdentifier: "en", logo: nil, description: nil, backgroundColor: nil, textColor: nil)],
+				isMandatory: true,
+				claimPath: ["age_equal_or_over", "18"]
+			),
+			DocClaimMetadata(
+				display: [DisplayMetadata(name: "Age over 21", localeIdentifier: "en", logo: nil, description: nil, backgroundColor: nil, textColor: nil)],
+				isMandatory: false,
+				claimPath: ["age_equal_or_over", "21"]
+			)
+		]
+		let json = JSON(parseJSON: """
+		{
+		  "age_equal_or_over": {
+		    "18": true,
+		    "21": true
+		  }
+		}
+		""")
+
+		let rootMetadata = claimMetadata.convertToJsonClaimMetadata("en", keyPrefix: [])
+		#expect(rootMetadata.displayNames["age_equal_or_over"] == nil)
+		#expect(rootMetadata.mandatory["age_equal_or_over"] == nil)
+
+		let childMetadata = claimMetadata.convertToJsonClaimMetadata("en", keyPrefix: ["age_equal_or_over"])
+		#expect(childMetadata.displayNames["18"] == "Age over 18")
+		#expect(childMetadata.displayNames["21"] == "Age over 21")
+		#expect(childMetadata.mandatory["18"] == true)
+		#expect(childMetadata.mandatory["21"] == false)
+
+		let claims = try #require(json.toClaimsArray(pathPrefix: [], claimMetadata, "en")?.0)
+		let ageEqualOrOver = try #require(claims.first { $0.name == "age_equal_or_over" })
+		#expect(ageEqualOrOver.displayName == nil)
+		#expect(ageEqualOrOver.isOptional)
+
+		let age18 = try #require(ageEqualOrOver.children?.first { $0.name == "18" })
+		#expect(age18.displayName == "Age over 18")
+		#expect(age18.isOptional == false)
+
+		let age21 = try #require(ageEqualOrOver.children?.first { $0.name == "21" })
+		#expect(age21.displayName == "Age over 21")
+		#expect(age21.isOptional)
+	}
 }
 
 // MARK: - Data Extension for Test Resources


### PR DESCRIPTION
Fixes issue #332