### PR TITLE
Enhance Claim metadata handling and process image data from sd-jwt claims

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5c81fde5f84914c6a24b7a27a20fc2fc8ffe49a49b4ce5cb2c776298c6b269b8",
+  "originHash" : "72f8850e89451078a2bf8a9a9332ed339c802828084b5e6224cdac4a76c362c5",
   "pins" : [
     {
       "identity" : "cryptoswift",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git",
       "state" : {
-        "revision" : "ef6109faf36fbc310a3d9d32baf2e82470a57284",
-        "version" : "0.12.0"
+        "revision" : "7252e2070e608d693909ab0e9a873db7f801e61f",
+        "version" : "0.13.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git",
       "state" : {
-        "revision" : "952f7a9d2a46aa2846c136d7ad4d97df51e9cd6c",
-        "version" : "0.12.0"
+        "revision" : "7b0357c62827dac6f061d9662c88e710fbf6a5c5",
+        "version" : "0.13.0"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-security.git",
       "state" : {
-        "revision" : "e8fa624673650483c9ad8b536359846f776f44f1",
-        "version" : "0.12.0"
+        "revision" : "2f5a75e3fbef09b643ba5f4c638b8455f268f979",
+        "version" : "0.13.0"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git",
       "state" : {
-        "revision" : "9f42809488b56f588d8bf8a04c068b01ed6b9a3f",
-        "version" : "0.35.0"
+        "revision" : "225a3ae3fec28830c49382304551af829e98e070",
+        "version" : "0.35.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,10 +13,10 @@ let package = Package(
 			targets: ["EudiWalletKit"])
 	],
 	dependencies: [
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git", exact: "0.12.0"),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git", exact: "0.13.0"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git", exact: "0.11.3"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift.git", exact: "0.14.1"),
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git", exact: "0.35.0"),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git", exact: "0.35.1"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-siop-openid4vp-swift.git", exact: "0.32.1"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-statium-swift.git", exact: "0.4.0"),
 	],

--- a/Sources/EudiWalletKit/Extensions.swift
+++ b/Sources/EudiWalletKit/Extensions.swift
@@ -158,27 +158,29 @@ extension MdocDataModel18013.SignUpResponse {
 }
 
 extension Claim {
-	var metadata: DocClaimMetadata { DocClaimMetadata(display: display?.map(\.displayMetadata), isMandatory: mandatory, claimPath: path.value.map(\.description)) }
+	var metadata: DocClaimMetadata { DocClaimMetadata(display: display?.map(\.displayMetadata), isMandatory: mandatory, claimPath: path.value.map(\.description), valueType: valueType) }
 }
 
 extension Array where Element == DocClaimMetadata {
-	func convertToCborClaimMetadata(_ uiCulture: String?) -> (displayNames: [NameSpace: [String: String]], mandatory: [NameSpace: [String: Bool]]) {
-		guard allSatisfy({ $0.claimPath.count > 1 }) else { return ([:], [:]) } // sanity check
+	func convertToCborClaimMetadata(_ uiCulture: String?) -> (displayNames: [NameSpace: [String: String]], mandatory: [NameSpace: [String: Bool]], valueTypes: [NameSpace: [String: String]]) {
+		guard allSatisfy({ $0.claimPath.count > 1 }) else { return ([:], [:], [:]) } // sanity check
 		let dictNs = Dictionary(grouping: self, by: { $0.claimPath[0]})
 		let dictNsAndKeys = dictNs.mapValues { Dictionary(grouping: $0, by: { $0.claimPath[1]}) } // group by namespace and key
 		let displayNames = dictNsAndKeys.mapValues { nsv in nsv.compactMapValues { kv in kv.first?.display?.getName(uiCulture) } }
 		let mandatory = dictNsAndKeys.mapValues { nsv in nsv.compactMapValues { kv in kv.first?.isMandatory } }
-		return (displayNames, mandatory)
+		let valueTypes = dictNsAndKeys.mapValues { nsv in nsv.compactMapValues { kv in kv.first?.valueType } }
+		return (displayNames, mandatory, valueTypes)
 	}
 
-	func convertToJsonClaimMetadata(_ uiCulture: String?, keyPrefix: [String]?) -> (displayNames: [String: String], mandatory: [String: Bool], childMetadata: [DocClaimMetadata]) {
+	func convertToJsonClaimMetadata(_ uiCulture: String?, keyPrefix: [String]?) -> (displayNames: [String: String], mandatory: [String: Bool], valueTypes: [String: String], childMetadata: [DocClaimMetadata]) {
 		let groupIndex = keyPrefix?.count ?? 0
 		let arr = if let keyPrefix { filter { $0.claimPath.count > groupIndex && keyPrefix.elementsEqual($0.claimPath[0..<keyPrefix.count]) } } else { self }
 		let dictKeys = Dictionary(grouping: arr, by: { $0.claimPath[groupIndex]} )
 		let exactPathLength = groupIndex + 1
 		let displayNames = dictKeys.compactMapValues { $0.first(where: { $0.claimPath.count == exactPathLength })?.display?.getName(uiCulture) }
 		let mandatory =  dictKeys.compactMapValues { $0.first(where: { $0.claimPath.count == exactPathLength })?.isMandatory }
-		return (displayNames, mandatory, arr)
+		let valueTypes = dictKeys.compactMapValues { $0.first(where: { $0.claimPath.count == exactPathLength })?.valueType }
+		return (displayNames, mandatory, valueTypes, arr)
 	}
 }
 
@@ -231,7 +233,7 @@ extension URL {
 }
 
 extension JSON {
-	func getDataValue(name: String) -> (DocDataValue, String)? {
+	func getDataValue(name: String, valueType: String?) -> (DocDataValue, String)? {
 		switch type {
 		case .number:
 			if name == "sex", let isex = Int(stringValue), isex >= 0, isex <= 2 {
@@ -245,7 +247,9 @@ extension JSON {
 			}
 			return (.integer(UInt64(intValue)), stringValue)
 		case .string:
-			if name == "portrait" || name == "signature_usual_mark", let d = Data(base64urlEncoded: stringValue) { return (.bytes(d.bytes), "\(d.count) bytes") }
+			if isBase64ByteClaim(name: name, valueType: valueType), let d = Data(base64urlEncoded: stringValue) ?? Data(base64Encoded: stringValue) {
+				return (.bytes(d.bytes), "\(d.count) bytes")
+			}
 			if name == "sex", let isex = Int(stringValue), isex >= 0, isex <= 2 {
 				let locSexValue = NSLocalizedString(isex == 1 ? "male" : "female", comment: "")
 				return (.string(locSexValue), locSexValue)
@@ -259,16 +263,27 @@ extension JSON {
 		}
 	}
 
-	func toDocClaim(_ key: String, order n: Int, pathPrefix: [String], _ claimMetadata: [DocClaimMetadata]?, _ uiCulture: String?, _ displayName: String?, _ mandatory: Bool?) -> DocClaim? {
+	private func isBase64ByteClaim(name: String, valueType: String?) -> Bool {
+		if let valueType {
+			let normalized = valueType.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+			if ["jpeg", "jpg", "image/jpeg"].contains(normalized) {
+				return true
+			}
+		}
+		return name == "portrait" || name == "signature_usual_mark"
+	}
+
+	func toDocClaim(_ key: String, order n: Int, pathPrefix: [String], claimMetadata: [DocClaimMetadata]?, uiCulture: String?, valueType: String?, displayName: String?, mandatory: Bool?) -> DocClaim? {
 		if key == "_sd" || key == "_sd_alg" || key == "..." { return nil } // internal SD-JWT digest elements
 		if key == "cnf", type == .dictionary { return nil } // members used to identify the proof-of-possession key.
 		if key == "status", type == .dictionary, self["status_list"].type == .dictionary { return nil } // status list.
 		if key == "assurance_level" || key == JWTClaimNames.issuer || key == JWTClaimNames.audience, type == .string {  return nil }
 		if key == "vct", type == .string  { return nil }
-		guard let pair = getDataValue(name: key) else { return nil}
-		let ch = toClaimsArray(pathPrefix: pathPrefix + [key], claimMetadata, uiCulture)
+		let path = pathPrefix + [key]
+		guard let pair = getDataValue(name: key, valueType: valueType) else { return nil}
+		let ch = toClaimsArray(pathPrefix: path, claimMetadata, uiCulture)
 		let isMandatory = mandatory ?? false
-		return DocClaim(name: key, path: pathPrefix + [key], displayName: displayName, dataValue: pair.0, stringValue: ch?.1 ?? pair.1, isOptional: !isMandatory, order: n, namespace: nil, children: ch?.0)
+		return DocClaim(name: key, path: path, displayName: displayName, dataValue: pair.0, stringValue: ch?.1 ?? pair.1, isOptional: !isMandatory, order: n, namespace: nil, children: ch?.0)
 	}
 
 	func toClaimsArray(pathPrefix: [String], _ claimMetadata: [DocClaimMetadata]?, _ uiCulture: String?) -> ([DocClaim], String)? {
@@ -279,7 +294,7 @@ extension JSON {
 				let isArray = type == .array
 				let n2 = if isArray { String(n) } else { key }
 				let cmd = claimMetadata?.convertToJsonClaimMetadata(uiCulture, keyPrefix: pathPrefix)
-				if let di = subJson.toDocClaim(n2, order: n, pathPrefix: pathPrefix, claimMetadata, uiCulture, cmd?.displayNames[key], cmd?.mandatory[key]) {
+				if let di = subJson.toDocClaim(n2, order: n, pathPrefix: pathPrefix, claimMetadata: claimMetadata, uiCulture: uiCulture, valueType: cmd?.valueTypes[key], displayName: cmd?.displayNames[key], mandatory: cmd?.mandatory[key]) {
 					a.append(di)
 				}
 			}

--- a/Sources/EudiWalletKit/Extensions.swift
+++ b/Sources/EudiWalletKit/Extensions.swift
@@ -247,7 +247,7 @@ extension JSON {
 			}
 			return (.integer(UInt64(intValue)), stringValue)
 		case .string:
-			if isBase64ByteClaim(name: name, valueType: valueType), let d = Data(base64urlEncoded: stringValue) ?? Data(base64Encoded: stringValue) {
+			if isBase64ByteClaim(name: name, valueType: valueType), let d = decodeBase64ByteClaim(stringValue) {
 				return (.bytes(d.bytes), "\(d.count) bytes")
 			}
 			if name == "sex", let isex = Int(stringValue), isex >= 0, isex <= 2 {
@@ -266,14 +266,30 @@ extension JSON {
 	private func isBase64ByteClaim(name: String, valueType: String?) -> Bool {
 		if let valueType {
 			let normalized = valueType.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-			if ["jpeg", "jpg", "image/jpeg"].contains(normalized) {
+			if ["jpeg", "jpg", "image/jpeg", "png", "image/png"].contains(normalized) {
 				return true
 			}
 		}
 		return name == "portrait" || name == "signature_usual_mark"
 	}
 
-	func toDocClaim(_ key: String, order n: Int, pathPrefix: [String], claimMetadata: [DocClaimMetadata]?, uiCulture: String?, valueType: String?, displayName: String?, mandatory: Bool?) -> DocClaim? {
+	private func decodeBase64ByteClaim(_ value: String) -> Data? {
+		if let dataUrlPayload = dataUrlBase64Payload(from: value) {
+			return Data(base64Encoded: dataUrlPayload, options: .ignoreUnknownCharacters) ?? Data(base64urlEncoded: dataUrlPayload)
+		}
+		return Data(base64urlEncoded: value) ?? Data(base64Encoded: value)
+	}
+
+	private func dataUrlBase64Payload(from value: String) -> String? {
+		let prefix = String(value.prefix(5))
+		guard prefix.caseInsensitiveCompare("data:") == .orderedSame, let commaIndex = value.firstIndex(of: ",") else { return nil }
+		let metadataStartIndex = value.index(value.startIndex, offsetBy: 5)
+		let metadata = value[metadataStartIndex..<commaIndex].lowercased()
+		guard metadata.split(separator: ";").contains("base64") else { return nil }
+		return String(value[value.index(after: commaIndex)...])
+	}
+
+	func toDocClaim(key: String, order n: Int, pathPrefix: [String], claimMetadata: [DocClaimMetadata]?, uiCulture: String?, displayName: String?, mandatory: Bool?, valueType: String?) -> DocClaim? {
 		if key == "_sd" || key == "_sd_alg" || key == "..." { return nil } // internal SD-JWT digest elements
 		if key == "cnf", type == .dictionary { return nil } // members used to identify the proof-of-possession key.
 		if key == "status", type == .dictionary, self["status_list"].type == .dictionary { return nil } // status list.
@@ -294,7 +310,7 @@ extension JSON {
 				let isArray = type == .array
 				let n2 = if isArray { String(n) } else { key }
 				let cmd = claimMetadata?.convertToJsonClaimMetadata(uiCulture, keyPrefix: pathPrefix)
-				if let di = subJson.toDocClaim(n2, order: n, pathPrefix: pathPrefix, claimMetadata: claimMetadata, uiCulture: uiCulture, valueType: cmd?.valueTypes[key], displayName: cmd?.displayNames[key], mandatory: cmd?.mandatory[key]) {
+				if let di = subJson.toDocClaim(key: n2, order: n, pathPrefix: pathPrefix, claimMetadata: claimMetadata, uiCulture: uiCulture, displayName: cmd?.displayNames[key], mandatory: cmd?.mandatory[key], valueType: cmd?.valueTypes[key]) {
 					a.append(di)
 				}
 			}

--- a/Tests/EudiWalletKitTests/EudiWalletKitTests.swift
+++ b/Tests/EudiWalletKitTests/EudiWalletKitTests.swift
@@ -25,6 +25,7 @@ import SwiftCBOR
 @testable import JOSESwift
 import eudi_lib_sdjwt_swift
 import SwiftyJSON
+import OpenID4VCI
 import OpenID4VP
 import enum OpenID4VP.ClaimPathElement
 import struct OpenID4VP.ClaimPath
@@ -50,6 +51,18 @@ struct EudiWalletKitTests {
 		return (resolved, sdJwt.disclosures)
 	}
 
+	private func firstClaim(named name: String, in claims: [DocClaim]) -> DocClaim? {
+		for claim in claims {
+			if claim.name == name {
+				return claim
+			}
+			if let children = claim.children, let childClaim = firstClaim(named: name, in: children) {
+				return childClaim
+			}
+		}
+		return nil
+	}
+
 	@Test("Get claims from sd-jwt", arguments: ["mdl", "pid", "pid-address"])
 	func testParseJwt(dt: String) async throws {
 		let (claims, _) = try parseSdJwtClaims(for: dt)
@@ -57,6 +70,43 @@ struct EudiWalletKitTests {
 			let family_name = try #require(claims["family_name"].string)
 			let given_name = try #require(claims["given_name"].string)
 			print(family_name, given_name)
+		}
+	}
+
+	@Test("Dev Python issuer metadata decodes SD-JWT mDL portrait as bytes")
+	func testDevPythonIssuerMetadataDecodesSdJwtMdlPortraitAsBytes() throws {
+		let issuerData = try #require(Data(name: "dev-python-openid-credential-issuer", ext: "json", from: Bundle.module))
+		let issuerMetadata = try JSONDecoder().decode(CredentialIssuerMetadata.self, from: issuerData)
+		let configurationIdentifier = try CredentialConfigurationIdentifier(value: "eu.europa.ec.eudi.mdl_mdoc")
+		let credentialSupported = try #require(issuerMetadata.credentialsSupported[configurationIdentifier])
+
+		guard case .msoMdoc(let configuration) = credentialSupported else {
+			Issue.record("Expected mso_mdoc metadata for \(configurationIdentifier.value)")
+			return
+		}
+
+		let credentialMetadata = try #require(configuration.credentialMetadata)
+		let claimMetadata = credentialMetadata.claims.map(\.metadata)
+		let portraitMetadata = try #require(claimMetadata.first { $0.claimPath == ["org.iso.18013.5.1", "portrait"] })
+		#expect(portraitMetadata.valueType == "jpeg")
+
+		let docMetadata = DocMetadata(credentialIssuerIdentifier: issuerMetadata.credentialIssuerIdentifier.url.absoluteString, configurationIdentifier: configurationIdentifier.value, docType: configuration.docType, display: credentialMetadata.display.map(\.displayMetadata), issuerDisplay: issuerMetadata.display.map(\.displayMetadata), claims: claimMetadata, authorizedRequestData: nil, keyOptions: nil, credentialOptions: nil)
+		let sdJwtData = try #require(Data(name: "sjwt-mdl", ext: "txt", from: Bundle.module))
+		let document = WalletStorage.Document(id: "sjwt-mdl", docType: configuration.docType, docDataFormat: .sdjwt, data: sdJwtData, docKeyInfo: nil, createdAt: .now, metadata: docMetadata.toData(), displayName: nil, status: .issued)
+
+		let model = try #require(StorageManager.toSdJwtDocModel(doc: document, uiCulture: "en"))
+		#expect(model.docType == "org.iso.18013.5.1.mDL")
+		#expect(model.docDataFormat == .sdjwt)
+
+		let portrait = try #require(firstClaim(named: "portrait", in: model.docClaims))
+		#expect(portrait.path == ["verified_claims", "claims", "org.iso.18013.5.1", "portrait"])
+		#expect(portrait.stringValue == "10369 bytes")
+
+		if case .bytes(let bytes) = portrait.dataValue {
+			#expect(bytes.count == 10369)
+			#expect(Array(bytes.prefix(4)) == [0xff, 0xd8, 0xff, 0xe0])
+		} else {
+			Issue.record("Expected portrait to decode as bytes, got \(portrait.dataValue)")
 		}
 	}
 
@@ -85,7 +135,7 @@ struct EudiWalletKitTests {
 				guard let name = d["name"].string else { return nil }
 				return DisplayMetadata(name: name, localeIdentifier: d["locale"].string, logo: nil, description: nil, backgroundColor: nil, textColor: nil)
 			}
-			return DocClaimMetadata(display: displayArr, isMandatory: claimJson["mandatory"].bool, claimPath: path)
+			return DocClaimMetadata(display: displayArr, isMandatory: claimJson["mandatory"].bool, claimPath: path, valueType: claimJson["value_type"].string)
 		}
 		#expect(!claimMetadata.isEmpty)
 
@@ -144,7 +194,7 @@ struct EudiWalletKitTests {
 			.filter { meta in docClaims.contains { $0.path == meta.claimPath } }
 			.map { $0.claimPath.last! }
 
-		let actualOrder = reordered.docClaims.map(\.name)
+		let actualOrder = reordered.docClaims.map { $0.name }
 		#expect(actualOrder == expectedOrder)
 
 		// Verify order values are sequential
@@ -178,6 +228,47 @@ struct EudiWalletKitTests {
 	    #expect(keySign.publicKey.isValidSignature(ecdsaSignature, for: signingInput), "Signature is invalid")
 	}
 
+	@Test("Data URL byte claims decode as bytes")
+	func testDataUrlByteClaimDecodesAsBytes() throws {
+		let claimMetadata = [DocClaimMetadata(display: nil, isMandatory: true, claimPath: ["photo"], valueType: "jpeg")]
+		let json = JSON(parseJSON: #"{ "photo": "data:image/jpeg;base64,/9j/4A==" }"#)
+		let claims = try #require(json.toClaimsArray(pathPrefix: [], claimMetadata, nil)?.0)
+		let photo = try #require(claims.first { $0.name == "photo" })
+		#expect(photo.stringValue == "4 bytes")
+		#expect(photo.isOptional == false)
+		if case .bytes(let bytes) = photo.dataValue {
+			#expect(bytes == [0xff, 0xd8, 0xff, 0xe0])
+		} else {
+			Issue.record("Expected data URL photo claim to decode as bytes, got \(photo.dataValue)")
+		}
+	}
+
+	@Test("Wrapped PNG data URL byte claims decode as bytes")
+	func testWrappedPngDataUrlByteClaimDecodesAsBytes() throws {
+		let claimMetadata = [DocClaimMetadata(display: nil, isMandatory: true, claimPath: ["photo"], valueType: "image/png")]
+		let dataUrl = """
+		data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAIAA
+		AC0Ujn1AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAA
+		DsMAAA7DAcdvqGQAAAEDSURBVEhLtZJBEoMwDAP7lr6nn+0LqUGChsVOwoG
+		dvTSSNRz6Wh7jxvT7+wn9Y4LZae0e+rXLeBqjh45rBtOYgy4V9KYxlOpqRj
+		mNiY4+uJBP41gOI5BM40w620AknTVwGgfSWQMK0tnOaRpV6ewCatLZxn8aJ
+		emsAGXp7JhGLBX1wYlUtE4jkIpnwKGM9xeepG7mwblMpl2/CUbCJ7+6CnQz
+		Aw5lvD/8DxGIpbMClKWzdjpASTq7gJp0tnGaDlCVzhpQkM52OB3gQDrbQCS
+		dNSTTAc7kMAL5dIDjjj64UE4HmEh1NaM3HWAIulQwmA4wd+i4ZjwdYDR00G
+		qWsyPrizLD76QCPOHqP2cAAAAAElFTkSuQmCC
+		""".removeWhitespaceAndNewlines()
+		let json = JSON(["photo": dataUrl])
+		let claims = try #require(json.toClaimsArray(pathPrefix: [], claimMetadata, nil)?.0)
+		let photo = try #require(claims.first { $0.name == "photo" })
+		#expect(photo.stringValue == "365 bytes")
+		if case .bytes(let bytes) = photo.dataValue {
+			#expect(bytes.count == 365)
+			#expect(Array(bytes.prefix(8)) == [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+			#expect(Array(bytes[16..<24]) == [0x00, 0x00, 0x00, 0x1e, 0x00, 0x00, 0x00, 0x1e])
+		} else {
+			Issue.record("Expected wrapped PNG data URL photo claim to decode as bytes, got \(photo.dataValue)")
+		}
+	}
 
 	@Test("Sex field displays male/female for both number and string JSON types")
 	func testSexFieldConversion() throws {
@@ -228,17 +319,20 @@ struct EudiWalletKitTests {
 			DocClaimMetadata(
 				display: [DisplayMetadata(name: "Age over 12", localeIdentifier: "en", logo: nil, description: nil, backgroundColor: nil, textColor: nil)],
 				isMandatory: true,
-				claimPath: ["age_equal_or_over", "12"]
+				claimPath: ["age_equal_or_over", "12"],
+				valueType: nil
 			),
 			DocClaimMetadata(
 				display: [DisplayMetadata(name: "Age over 18", localeIdentifier: "en", logo: nil, description: nil, backgroundColor: nil, textColor: nil)],
 				isMandatory: true,
-				claimPath: ["age_equal_or_over", "18"]
+				claimPath: ["age_equal_or_over", "18"],
+				valueType: nil
 			),
 			DocClaimMetadata(
 				display: [DisplayMetadata(name: "Age over 21", localeIdentifier: "en", logo: nil, description: nil, backgroundColor: nil, textColor: nil)],
 				isMandatory: false,
-				claimPath: ["age_equal_or_over", "21"]
+				claimPath: ["age_equal_or_over", "21"],
+				valueType: nil
 			)
 		]
 		let json = JSON(parseJSON: """

--- a/Tests/EudiWalletKitTests/Resources/dev-python-openid-credential-issuer.json
+++ b/Tests/EudiWalletKitTests/Resources/dev-python-openid-credential-issuer.json
@@ -1,0 +1,7313 @@
+{
+	"batch_credential_issuance": {
+		"batch_size": 100
+	},
+	"credential_configurations_supported": {
+		"eu.europa.ec.eudi.cor_mdoc": {
+			"credential_alg_values_supported": [
+				-7
+			],
+			"credential_crv_values_supported": [
+				1
+			],
+			"credential_metadata": {
+				"claims": [
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Given Name"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.cor.1",
+							"given_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Family Name"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.cor.1",
+							"family_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Birth Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.cor.1",
+							"birth_date"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Resident Address"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.cor.1",
+							"residence_address"
+						],
+						"value_type": "residence_address_attributes"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Gender"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.cor.1",
+							"gender"
+						],
+						"value_type": "uint"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Birth Place"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.cor.1",
+							"birth_place"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Nationality"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.cor.1",
+							"nationality"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Arrival Date"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.cor.1",
+							"arrival_date"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Expiry Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.cor.1",
+							"expiry_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuance Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.cor.1",
+							"issuance_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Country"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.cor.1",
+							"issuing_country"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Authority"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.cor.1",
+							"issuing_authority"
+						]
+					}
+				],
+				"display": [
+					{
+						"locale": "en",
+						"logo": {
+							"alt_text": "A square figure of a Certificate of Residence",
+							"uri": "https://examplestate.com/public/cor.png"
+						},
+						"name": "Certificate of Residence (MSO Mdoc)"
+					}
+				]
+			},
+			"credential_signing_alg_values_supported": [
+				-7
+			],
+			"cryptographic_binding_methods_supported": [
+				"jwk",
+				"cose_key"
+			],
+			"doctype": "eu.europa.ec.eudi.cor.1",
+			"format": "mso_mdoc",
+			"policy": {
+				"batch_size": 15,
+				"one_time_use": true
+			},
+			"proof_types_supported": {
+				"jwt": {
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				}
+			},
+			"scope": "eu.europa.ec.eudi.cor_mdoc"
+		},
+		"eu.europa.ec.eudi.diploma_vc_sd_jwt": {
+			"credential_metadata": {
+				"claims": [
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Identifier"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"identifier"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Scoped Affiliation"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"scoped_affiliation"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Personal Unique Code"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"personal_unique_code"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Personal Unique ID"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"personal_unique_id"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Home Organization"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"home_organization"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Family Name"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"family_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "First Name"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"first_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Display Name"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"display_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Birth Date"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"date_of_birth"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Birth Name"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"common_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Email"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"email"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Principal Name"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"principal_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Primary Affiliation"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"primary_affiliation"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Affiliations"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"affiliations"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Assurance"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"assurance"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Profile Image"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"image"
+						],
+						"value_type": "jpeg"
+					}
+				],
+				"display": [
+					{
+						"locale": "en",
+						"logo": {
+							"alt_text": "A square figure of a PID",
+							"uri": "https://examplestate.com/public/pid.png"
+						},
+						"name": "Diploma (SD-JWT VC)"
+					}
+				]
+			},
+			"credential_signing_alg_values_supported": [
+				"ES256"
+			],
+			"cryptographic_binding_methods_supported": [
+				"jwk",
+				"cose_key"
+			],
+			"format": "dc+sd-jwt",
+			"proof_types_supported": {
+				"attestation": {
+					"key_attestations_required": {},
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				},
+				"jwt": {
+					"key_attestations_required": {},
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				}
+			},
+			"scope": "eu.europa.ec.eudi.diploma_vc_sd_jwt",
+			"vct": "urn:eu.europa.ec.eudi:diploma:1:1"
+		},
+		"eu.europa.ec.eudi.ehic_mdoc": {
+			"credential_metadata": {
+				"claims": [
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Credential Holder"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.ehic.1",
+							"credential_holder"
+						],
+						"value_type": "credential_holder_attributes"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Subject"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.ehic.1",
+							"subject"
+						],
+						"value_type": "subject_attributes"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Social Security Pin"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.ehic.1",
+							"social_security_pin"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Starting Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.ehic.1",
+							"starting_date"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Ending Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.ehic.1",
+							"ending_date"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Document ID"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.ehic.1",
+							"document_id"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Institution ID"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.ehic.1",
+							"competent_institution"
+						],
+						"value_type": "competent_institution_attributes"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuance Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.ehic.1",
+							"issuance_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Expiry Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.ehic.1",
+							"expiry_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuance Authority"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.ehic.1",
+							"issuing_authority"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Country"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.ehic.1",
+							"issuing_country"
+						]
+					}
+				],
+				"display": [
+					{
+						"locale": "en",
+						"logo": {
+							"alt_text": "A square figure of a PID",
+							"uri": "https://examplestate.com/public/pid.png"
+						},
+						"name": "EHIC (MSO Mdoc)"
+					}
+				]
+			},
+			"credential_signing_alg_values_supported": [
+				-7
+			],
+			"cryptographic_binding_methods_supported": [
+				"jwk",
+				"cose_key"
+			],
+			"doctype": "eu.europa.ec.eudi.ehic.1",
+			"format": "mso_mdoc",
+			"policy": {
+				"batch_size": 15,
+				"one_time_use": true
+			},
+			"proof_types_supported": {
+				"attestation": {
+					"key_attestations_required": {},
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				},
+				"jwt": {
+					"key_attestations_required": {},
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				}
+			},
+			"scope": "eu.europa.ec.eudi.ehic_mdoc"
+		},
+		"eu.europa.ec.eudi.ehic_sd_jwt_vc": {
+			"credential_metadata": {
+				"claims": [
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Personal Administrative Number"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"personal_administrative_number"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Authority"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"issuing_authority"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Authority ID"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"issuing_authority",
+							"id"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Authority Name"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"issuing_authority",
+							"name"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Country"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"issuing_country"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Expiry date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"date_of_expiry"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issue date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"date_of_issuance"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Authentic Source"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"authentic_source"
+						],
+						"value_type": "authentic_source_attributes"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Authentic Source ID"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"authentic_source",
+							"id"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Authentic Source Name"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"authentic_source",
+							"name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Starting Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"starting_date"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Ending Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"ending_date"
+						],
+						"value_type": "full-date"
+					}
+				],
+				"display": [
+					{
+						"locale": "en",
+						"logo": {
+							"alt_text": "A square figure of a PID",
+							"uri": "https://examplestate.com/public/pid.png"
+						},
+						"name": "EHIC (SD-JWT VC)"
+					}
+				]
+			},
+			"credential_signing_alg_values_supported": [
+				"ES256"
+			],
+			"cryptographic_binding_methods_supported": [
+				"jwk",
+				"cose_key"
+			],
+			"format": "dc+sd-jwt",
+			"proof_types_supported": {
+				"jwt": {
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				}
+			},
+			"scope": "eu.europa.ec.eudi.ehic_sd_jwt_vc",
+			"vct": "urn:eudi:ehic:1"
+		},
+		"eu.europa.ec.eudi.employee_mdoc": {
+			"credential_metadata": {
+				"claims": [
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Given Name(s)"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.employee.1",
+							"given_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Family Name(s)"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.employee.1",
+							"family_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Birth Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.employee.1",
+							"birth_date"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Employee ID"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.employee.1",
+							"employee_id"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Employer Name"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.employee.1",
+							"employer_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Employment Start Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.employee.1",
+							"employment_start_date"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Employment Type"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.employee.1",
+							"employment_type"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Country Code"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.employee.1",
+							"country_code"
+						],
+						"value_type": "string"
+					}
+				],
+				"display": [
+					{
+						"locale": "en",
+						"logo": {
+							"alt_text": "A square figure of a PID",
+							"uri": "https://examplestate.com/public/pid.png"
+						},
+						"name": "Employee ID (MSO Mdoc)"
+					}
+				]
+			},
+			"credential_signing_alg_values_supported": [
+				-7
+			],
+			"cryptographic_binding_methods_supported": [
+				"jwk",
+				"cose_key"
+			],
+			"doctype": "eu.europa.ec.eudi.employee.1",
+			"format": "mso_mdoc",
+			"policy": {
+				"batch_size": 15,
+				"one_time_use": true
+			},
+			"proof_types_supported": {
+				"jwt": {
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				}
+			},
+			"scope": "eu.europa.ec.eudi.employee_mdoc"
+		},
+		"eu.europa.ec.eudi.hiid_mdoc": {
+			"credential_metadata": {
+				"claims": [
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Health Insurance ID"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.hiid.1",
+							"health_insurance_id"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Patient ID"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.hiid.1",
+							"patient_id"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Tax Number"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.hiid.1",
+							"tax_number"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "One Time Token"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.hiid.1",
+							"one_time_token"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Affiliation Country"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.hiid.1",
+							"affiliation_country"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuance Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.hiid.1",
+							"issuance_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Expiry Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.hiid.1",
+							"expiry_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Matching Institution ID"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.hiid.1",
+							"matching_institution-id"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Matching Registered Family Name"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.hiid.1",
+							"matching_registered_family_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Matching Registered Given Name"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.hiid.1",
+							"matching_registered_given_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Matching Resident Address"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.hiid.1",
+							"matching_resident_address"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Mathing Birth Place"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.hiid.1",
+							"matching_birth_place"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Matching Birth Date"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.hiid.1",
+							"matching_birth_date"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Authority"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.hiid.1",
+							"issuing_authority"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Document Number"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.hiid.1",
+							"document_number"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Administrative_Number"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.hiid.1",
+							"administrative_number"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing_Country"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.hiid.1",
+							"issuing_country"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Jurisdiction"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.hiid.1",
+							"issuing_jurisdiction"
+						]
+					}
+				],
+				"display": [
+					{
+						"locale": "en",
+						"logo": {
+							"alt_text": "A square figure of a hiid",
+							"uri": "https://examplestate.com/public/hiid.png"
+						},
+						"name": "Health ID (MSO Mdoc)"
+					}
+				]
+			},
+			"credential_signing_alg_values_supported": [
+				-7
+			],
+			"cryptographic_binding_methods_supported": [
+				"jwk",
+				"cose_key"
+			],
+			"doctype": "eu.europa.ec.eudi.hiid.1",
+			"format": "mso_mdoc",
+			"policy": {
+				"batch_size": 15,
+				"one_time_use": true
+			},
+			"proof_types_supported": {
+				"cwt": {
+					"proof_alg_values_supported": [
+						-7
+					],
+					"proof_crv_values_supported": [
+						1
+					],
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				},
+				"jwt": {
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				}
+			},
+			"scope": "eu.europa.ec.eudi.hiid_mdoc"
+		},
+		"eu.europa.ec.eudi.hiid_sd_jwt_vc": {
+			"credential_metadata": {
+				"claims": [
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Health Insurance ID"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"health_insurance_id"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Patient ID"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"patient_id"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Tax Number"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"tax_number"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "One Time Token"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"one_time_token"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Affiliation Country"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"affiliation_country"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuance Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"issuance_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Expiry Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"expiry_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Matching Institution ID"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"matching_institution-id"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Matching Registered Family Name"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"matching_registered_family_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Matching Registered Given Name"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"matching_registered_given_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Matching Resident Address"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"matching_resident_address"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Mathing Birth Place"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"matching_birth_place"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Matching Birth Date"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"matching_birth_date"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Authority"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"issuing_authority"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Document Number"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"document_number"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Administrative_Number"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"administrative_number"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing_Country"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"issuing_country"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Jurisdiction"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"issuing_jurisdiction"
+						]
+					}
+				],
+				"display": [
+					{
+						"locale": "en",
+						"logo": {
+							"alt_text": "A square figure of a PID",
+							"uri": "https://examplestate.com/public/pid.png"
+						},
+						"name": "Health ID (SD-JWT VC)"
+					}
+				]
+			},
+			"credential_signing_alg_values_supported": [
+				"ES256"
+			],
+			"cryptographic_binding_methods_supported": [
+				"jwk",
+				"cose_key"
+			],
+			"format": "dc+sd-jwt",
+			"proof_types_supported": {
+				"cwt": {
+					"proof_alg_values_supported": [
+						-7
+					],
+					"proof_crv_values_supported": [
+						1
+					],
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				},
+				"jwt": {
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				}
+			},
+			"scope": "eu.europa.ec.eudi.hiid_sd_jwt_vc",
+			"vct": "urn:eu.europa.ec.eudi:hiid:1"
+		},
+		"eu.europa.ec.eudi.iban_mdoc": {
+			"credential_metadata": {
+				"claims": [
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "IBAN"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.iban.1",
+							"iban"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "National Account Number"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.iban.1",
+							"national_account_number"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Account Product"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.iban.1",
+							"account_product"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Account Name"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.iban.1",
+							"account_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Account Type"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.iban.1",
+							"account_type"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Currency"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.iban.1",
+							"currency"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Bank Account Status"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.iban.1",
+							"bank_account_status"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Payment Possibility"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.iban.1",
+							"payment_possibility"
+						],
+						"value_type": "bool"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Registered Family Name"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.iban.1",
+							"registered_family_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Registered Given Name"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.iban.1",
+							"registered_given_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Date of Birth"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.iban.1",
+							"date_of_birth"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Account Holder Owner"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.iban.1",
+							"account_holder_owner"
+						],
+						"value_type": "bool"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Coowner"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.iban.1",
+							"coowner"
+						],
+						"value_type": "bool"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Disponent"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.iban.1",
+							"disponent"
+						],
+						"value_type": "bool"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Organization"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.iban.1",
+							"issuing_organization"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "National Bank Code"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.iban.1",
+							"national_bank_code"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuance Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.iban.1",
+							"issuance_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Expiry Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.iban.1",
+							"expiry_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Credential Type"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.iban.1",
+							"credential_type"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Bussiness Identifier Code"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.iban.1",
+							"business_identifier_code"
+						],
+						"value_type": "string"
+					}
+				],
+				"display": [
+					{
+						"locale": "en",
+						"logo": {
+							"alt_text": "A square figure of a iban",
+							"uri": "https://examplestate.com/public/iban.png"
+						},
+						"name": "IBAN (MSO Mdoc)"
+					}
+				]
+			},
+			"credential_signing_alg_values_supported": [
+				-7
+			],
+			"cryptographic_binding_methods_supported": [
+				"jwk",
+				"cose_key"
+			],
+			"doctype": "eu.europa.ec.eudi.iban.1",
+			"format": "mso_mdoc",
+			"policy": {
+				"batch_size": 15,
+				"one_time_use": true
+			},
+			"proof_types_supported": {
+				"jwt": {
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				}
+			},
+			"scope": "eu.europa.ec.eudi.iban_mdoc"
+		},
+		"eu.europa.ec.eudi.iban_sd_jwt_vc": {
+			"credential_metadata": {
+				"claims": [
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "IBAN"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"iban"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "National Account Number"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"national_account_number"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Account Product"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"account_product"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Account Name"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"account_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Account Type"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"account_type"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Currency"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"currency"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Bank Account Status"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"bank_account_status"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Payment Possibility"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"payment_possibility"
+						],
+						"value_type": "bool"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Registered Family Name"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"registered_family_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Registered Given Name"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"registered_given_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Date of Birth"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"date_of_birth"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Account Holder Owner"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"account_holder_owner"
+						],
+						"value_type": "bool"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Coowner"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"coowner"
+						],
+						"value_type": "bool"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Disponent"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"disponent"
+						],
+						"value_type": "bool"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Organization"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"issuing_organization"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "National Bank Code"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"national_bank_code"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuance Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"issuance_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Expiry Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"expiry_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Credential Type"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"credential_type"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Bussiness Identifier Code"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"business_identifier_code"
+						],
+						"value_type": "string"
+					}
+				],
+				"display": [
+					{
+						"locale": "en",
+						"logo": {
+							"alt_text": "A square figure of a PID",
+							"uri": "https://examplestate.com/public/pid.png"
+						},
+						"name": "IBAN (SD-JWT VC)"
+					}
+				]
+			},
+			"credential_signing_alg_values_supported": [
+				"ES256"
+			],
+			"cryptographic_binding_methods_supported": [
+				"jwk",
+				"cose_key"
+			],
+			"format": "dc+sd-jwt",
+			"proof_types_supported": {
+				"jwt": {
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				}
+			},
+			"scope": "eu.europa.ec.eudi.iban_sd_jwt_vc",
+			"vct": "urn:eu.europa.ec.eudi:iban:1"
+		},
+		"eu.europa.ec.eudi.learning_credential_vc_sd_jwt": {
+			"credential_metadata": {
+				"claims": [
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Family Name"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"family_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Given Name"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"given_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Achievement Title"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"achievement_title"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Achievement Description"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"achievement_description"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Learning Outcomes"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"learning_outcomes"
+						],
+						"value_type": "list_string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Assessment Grade"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"assessment_grade"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Language of Classes"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"language_of_classes"
+						],
+						"value_type": "list_string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Learner Identification"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"learner_identification"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Expected Study Time"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"expected_study_time"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Level of Learning Experience"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"level_of_learning_experience"
+						],
+						"value_type": "uint"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Types of Quality Assurance"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"types_of_quality_assurance"
+						],
+						"value_type": "list_string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Prerequisites to Enroll"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"prerequisites_to_enroll"
+						],
+						"value_type": "list_string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Integration Stackability Options"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"integration_stackability_options"
+						],
+						"value_type": "bool"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuance Authority"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"issuing_authority"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Country"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"issuing_country"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issue date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"date_of_issuance"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Expiry date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"date_of_expiry"
+						]
+					}
+				],
+				"display": [
+					{
+						"locale": "en",
+						"logo": {
+							"alt_text": "A square figure of a Learning Credential",
+							"uri": "https://examplestate.com/public/pid.png"
+						},
+						"name": "Learning Credential (SD-JWT VC)"
+					}
+				]
+			},
+			"credential_signing_alg_values_supported": [
+				"ES256"
+			],
+			"cryptographic_binding_methods_supported": [
+				"jwk",
+				"cose_key"
+			],
+			"format": "dc+sd-jwt",
+			"proof_types_supported": {
+				"jwt": {
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				}
+			},
+			"scope": "eu.europa.ec.eudi.learning_credential_vc_sd_jwt",
+			"vct": "urn:eu.europa.ec.eudi:learning:credential:1"
+		},
+		"eu.europa.ec.eudi.loyalty_mdoc": {
+			"credential_metadata": {
+				"claims": [
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Given Name"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.loyalty.1",
+							"given_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Family Name"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.loyalty.1",
+							"family_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Loyalty Card Company"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.loyalty.1",
+							"company"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Client ID"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.loyalty.1",
+							"client_id"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuance Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.loyalty.1",
+							"issuance_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Expiry Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.loyalty.1",
+							"expiry_date"
+						]
+					}
+				],
+				"display": [
+					{
+						"locale": "en",
+						"logo": {
+							"alt_text": "A square figure of a PID",
+							"uri": "https://examplestate.com/public/pid.png"
+						},
+						"name": "Loyalty (MSO Mdoc)"
+					}
+				]
+			},
+			"credential_signing_alg_values_supported": [
+				-7
+			],
+			"cryptographic_binding_methods_supported": [
+				"jwk",
+				"cose_key"
+			],
+			"doctype": "eu.europa.ec.eudi.loyalty.1",
+			"format": "mso_mdoc",
+			"proof_types_supported": {
+				"jwt": {
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				}
+			},
+			"scope": "eu.europa.ec.eudi.loyalty_mdoc"
+		},
+		"eu.europa.ec.eudi.mdl_mdoc": {
+			"credential_metadata": {
+				"claims": [
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Family name"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"org.iso.18013.5.1",
+							"family_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Given name"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"org.iso.18013.5.1",
+							"given_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Date of birth"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"org.iso.18013.5.1",
+							"birth_date"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Date of issue"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"org.iso.18013.5.1",
+							"issue_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Expiry Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"org.iso.18013.5.1",
+							"expiry_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing country"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"org.iso.18013.5.1",
+							"issuing_country"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing authority"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"org.iso.18013.5.1",
+							"issuing_authority"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Licence number"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"org.iso.18013.5.1",
+							"document_number"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Portrait"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"org.iso.18013.5.1",
+							"portrait"
+						],
+						"value_type": "jpeg"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Driving Privileges"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"org.iso.18013.5.1",
+							"driving_privileges"
+						],
+						"value_type": "driving_privileges"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "UN distinguishing sign"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"org.iso.18013.5.1",
+							"un_distinguishing_sign"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Administrative number"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.18013.5.1",
+							"administrative_number"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Sex"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.18013.5.1",
+							"sex"
+						],
+						"value_type": "uint"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Height (cm)"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.18013.5.1",
+							"height"
+						],
+						"value_type": "uint"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Weight (kg)"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.18013.5.1",
+							"weight"
+						],
+						"value_type": "uint"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Eye colour"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.18013.5.1",
+							"eye_colour"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Hair colour"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.18013.5.1",
+							"hair_colour"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Place of birth"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.18013.5.1",
+							"birth_place"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Permanent place of residence"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.18013.5.1",
+							"resident_address"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Portrait image timestamp"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.18013.5.1",
+							"portrait_capture_date"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Age in Years"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.18013.5.1",
+							"age_in_years"
+						],
+						"value_type": "uint"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Birth Year"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.18013.5.1",
+							"age_birth_year"
+						],
+						"value_type": "uint"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Age Over 18"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.18013.5.1",
+							"age_over_18"
+						],
+						"value_type": "bool"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing jurisdiction"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.18013.5.1",
+							"issuing_jurisdiction"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Nationality"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.18013.5.1",
+							"nationality"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Resident city"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.18013.5.1",
+							"resident_city"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Resident State"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.18013.5.1",
+							"resident_state"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Resident Postal Code"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.18013.5.1",
+							"resident_postal_code"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Resident Country"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.18013.5.1",
+							"resident_country"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Family name in national characters"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.18013.5.1",
+							"family_name_national_character"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Given name in national characters"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.18013.5.1",
+							"given_name_national_character"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Signature / usual mark"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.18013.5.1",
+							"signature_usual_mark"
+						],
+						"value_type": "jpeg"
+					}
+				],
+				"display": [
+					{
+						"locale": "en",
+						"logo": {
+							"alt_text": "A square figure of a mDL",
+							"uri": "https://examplestate.com/public/mdl.png"
+						},
+						"name": "mDL (MSO Mdoc)"
+					}
+				]
+			},
+			"credential_signing_alg_values_supported": [
+				-7
+			],
+			"cryptographic_binding_methods_supported": [
+				"jwk",
+				"cose_key"
+			],
+			"doctype": "org.iso.18013.5.1.mDL",
+			"format": "mso_mdoc",
+			"proof_types_supported": {
+				"jwt": {
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				}
+			},
+			"scope": "eu.europa.ec.eudi.mdl_mdoc"
+		},
+		"eu.europa.ec.eudi.msisdn_mdoc": {
+			"credential_metadata": {
+				"claims": [
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Phone Number"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.msisdn.1",
+							"phone_number"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Registered Family Name"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.msisdn.1",
+							"registered_family_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Registered Given Name"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.msisdn.1",
+							"registered_given_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Contract Owner"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.msisdn.1",
+							"contract_owner"
+						],
+						"value_type": "bool"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "End User"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.msisdn.1",
+							"end_user"
+						],
+						"value_type": "bool"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Mobile Operator"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.msisdn.1",
+							"mobile_operator"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuance Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.msisdn.1",
+							"issuance_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Expiry Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.msisdn.1",
+							"expiry_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Credential Type"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.msisdn.1",
+							"credential_type"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Organization"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.msisdn.1",
+							"issuing_organization"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Phone Number in Use"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.msisdn.1",
+							"phone_number_in_use"
+						],
+						"value_type": "uint"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Document Number"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.msisdn.1",
+							"document_number"
+						]
+					}
+				],
+				"display": [
+					{
+						"locale": "en",
+						"logo": {
+							"alt_text": "A square figure of a msisdn",
+							"uri": "https://examplestate.com/public/msisdn.png"
+						},
+						"name": "MSISDN (MSO Mdoc)"
+					}
+				]
+			},
+			"credential_signing_alg_values_supported": [
+				-7
+			],
+			"cryptographic_binding_methods_supported": [
+				"jwk",
+				"cose_key"
+			],
+			"doctype": "eu.europa.ec.eudi.msisdn.1",
+			"format": "mso_mdoc",
+			"policy": {
+				"batch_size": 15,
+				"one_time_use": true
+			},
+			"proof_types_supported": {
+				"cwt": {
+					"proof_alg_values_supported": [
+						-7
+					],
+					"proof_crv_values_supported": [
+						1
+					],
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				},
+				"jwt": {
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				}
+			},
+			"scope": "eu.europa.ec.eudi.msisdn_mdoc"
+		},
+		"eu.europa.ec.eudi.msisdn_sd_jwt_vc": {
+			"credential_metadata": {
+				"claims": [
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Phone Number"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"phone_number"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Registered Family Name"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"registered_family_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Registered Given Name"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"registered_given_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Contract Owner"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"contract_owner"
+						],
+						"value_type": "bool"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "End User"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"end_user"
+						],
+						"value_type": "bool"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Mobile Operator"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"mobile_operator"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuance Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"issuance_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Expiry Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"expiry_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Credential Type"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"credential_type"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Organization"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"issuing_organization"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Phone Number in Use"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"phone_number_in_use"
+						],
+						"value_type": "uint"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Document Number"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"document_number"
+						]
+					}
+				],
+				"display": [
+					{
+						"locale": "en",
+						"logo": {
+							"alt_text": "A square figure of a PID",
+							"uri": "https://examplestate.com/public/pid.png"
+						},
+						"name": "MSISDN (SD-JWT VC)"
+					}
+				]
+			},
+			"credential_signing_alg_values_supported": [
+				"ES256"
+			],
+			"cryptographic_binding_methods_supported": [
+				"jwk",
+				"cose_key"
+			],
+			"format": "dc+sd-jwt",
+			"proof_types_supported": {
+				"jwt": {
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				}
+			},
+			"scope": "eu.europa.ec.eudi.msisdn_sd_jwt_vc",
+			"vct": "urn:eu.europa.ec.eudi:msisdn:1"
+		},
+		"eu.europa.ec.eudi.pda1_mdoc": {
+			"credential_metadata": {
+				"claims": [
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Credential Holder"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.pda1.1",
+							"credential_holder"
+						],
+						"value_type": "credential_holder_attributes"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Social Security Pin"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.pda1.1",
+							"social_security_pin"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Employment Details"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.pda1.1",
+							"employment_details"
+						],
+						"value_type": "employment_details_attributes"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Places of Work"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.pda1.1",
+							"places_of_work"
+						],
+						"value_type": "places_of_work_attributes"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Legislation"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.pda1.1",
+							"legislation"
+						],
+						"value_type": "legislation_attributes"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Status Confirmation"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.pda1.1",
+							"status_confirmation"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Document ID"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.pda1.1",
+							"document_id"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Institution ID"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.pda1.1",
+							"competent_institution"
+						],
+						"value_type": "competent_institution_attributes"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuance Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.pda1.1",
+							"issuance_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Expiry Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.pda1.1",
+							"expiry_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuance Authority"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.pda1.1",
+							"issuing_authority"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Country"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.pda1.1",
+							"issuing_country"
+						]
+					}
+				],
+				"display": [
+					{
+						"locale": "en",
+						"logo": {
+							"alt_text": "A square figure of a PID",
+							"uri": "https://examplestate.com/public/pid.png"
+						},
+						"name": "PDA1 (MSO Mdoc)"
+					}
+				]
+			},
+			"credential_signing_alg_values_supported": [
+				-7
+			],
+			"cryptographic_binding_methods_supported": [
+				"jwk",
+				"cose_key"
+			],
+			"doctype": "eu.europa.ec.eudi.pda1.1",
+			"format": "mso_mdoc",
+			"policy": {
+				"batch_size": 15,
+				"one_time_use": true
+			},
+			"proof_types_supported": {
+				"jwt": {
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				}
+			},
+			"scope": "eu.europa.ec.eudi.pda1_mdoc"
+		},
+		"eu.europa.ec.eudi.pda1_sd_jwt_vc": {
+			"credential_metadata": {
+				"claims": [
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Credential Holder"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"credential_holder"
+						],
+						"value_type": "credential_holder_attributes"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Family Name"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"credential_holder",
+							"family_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Given Name"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"credential_holder",
+							"given_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Birth Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"credential_holder",
+							"birth_date"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Social Security Pin"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"social_security_pin"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Employment Details"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"employment_details"
+						],
+						"value_type": "employment_details_attributes"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Employment Type"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"employment_details",
+							"employment_type"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Name"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"employment_details",
+							"name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Employment ID"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"employment_details",
+							"employer_id"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "ID Type"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"employment_details",
+							"id_type"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Street"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"employment_details",
+							"street"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Town"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"employment_details",
+							"town"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Postal Code"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"employment_details",
+							"postal_code"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Country Code"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"employment_details",
+							"country_code"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Places of Work"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"places_of_work"
+						],
+						"value_type": "places_of_work_attributes"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Place of Work"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"places_of_work",
+							"place_of_work"
+						],
+						"value_type": "place_of_work_attributes"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "No Fixed Place"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"places_of_work",
+							"no_fixed_place"
+						],
+						"value_type": "no_fixed_place_attributes"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Company"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"places_of_work",
+							"place_of_work",
+							"company"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Flag Base Home State"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"places_of_work",
+							"place_of_work",
+							"flag_base_home_state"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Company ID"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"places_of_work",
+							"place_of_work",
+							"company_id"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "ID Type"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"places_of_work",
+							"place_of_work",
+							"id_type"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Street"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"places_of_work",
+							"place_of_work",
+							"street"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Town"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"places_of_work",
+							"place_of_work",
+							"town"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Postal Code"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"places_of_work",
+							"place_of_work",
+							"postal_code"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Country Code"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"places_of_work",
+							"place_of_work",
+							"country_code"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Country Code"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"places_of_work",
+							"no_fixed_place",
+							"country_code"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Legislation"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"legislation"
+						],
+						"value_type": "legislation_attributes"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Member State"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"legislation",
+							"member_state"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Transitional Rules"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"legislation",
+							"transitional_rules"
+						],
+						"value_type": "boolean"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Starting Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"legislation",
+							"starting_date"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Ending Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"legislation",
+							"ending_date"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Status Confirmation"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"status_confirmation"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Document ID"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"document_id"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Competent Institution"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"competent_institution"
+						],
+						"value_type": "competent_institution_attributes"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Institution ID"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"competent_institution",
+							"institution_id"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Institution Name"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"competent_institution",
+							"institution_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Country Code"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"competent_institution",
+							"country_code"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuance Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"issuance_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Expiry Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"expiry_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuance Authority"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"issuing_authority"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Country"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"issuing_country"
+						]
+					}
+				],
+				"display": [
+					{
+						"locale": "en",
+						"logo": {
+							"alt_text": "A square figure of a PID",
+							"uri": "https://examplestate.com/public/pid.png"
+						},
+						"name": "PDA1 (SD-JWT VC)"
+					}
+				]
+			},
+			"credential_signing_alg_values_supported": [
+				"ES256"
+			],
+			"cryptographic_binding_methods_supported": [
+				"jwk",
+				"cose_key"
+			],
+			"format": "dc+sd-jwt",
+			"proof_types_supported": {
+				"cwt": {
+					"proof_alg_values_supported": [
+						-7
+					],
+					"proof_crv_values_supported": [
+						1
+					],
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				},
+				"jwt": {
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				}
+			},
+			"scope": "eu.europa.ec.eudi.pda1_sd_jwt_vc",
+			"vct": "urn:eu.europa.ec.eudi:pda1:1"
+		},
+		"eu.europa.ec.eudi.photoid": {
+			"credential_metadata": {
+				"claims": [
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Portrait Image"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"org.iso.23220.photoid.1",
+							"portrait"
+						],
+						"value_type": "jpeg"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Portrait Capture Date"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.23220.photoid.1",
+							"portrait_capture_date"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Family Name"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"org.iso.23220.photoid.1",
+							"family_name_unicode"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Given Name"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"org.iso.23220.photoid.1",
+							"given_name_unicode"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Family Name"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.23220.photoid.1",
+							"family_name_latin1"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Given Name"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.23220.photoid.1",
+							"given_name_latin1"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Date of Birth"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"org.iso.23220.photoid.1",
+							"birth_date"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Age over 18"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"org.iso.23220.photoid.1",
+							"age_over_18"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Age in Years"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.23220.photoid.1",
+							"age_in_years"
+						],
+						"value_type": "uint"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Birth Year"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.23220.photoid.1",
+							"age_birth_year"
+						],
+						"value_type": "uint"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Birthplace"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.23220.photoid.1",
+							"birthplace"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Family Name at Birth"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.23220.photoid.1",
+							"name_at_birth"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Resident Address"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.23220.photoid.1",
+							"resident_address_unicode"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Resident City"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.23220.photoid.1",
+							"resident_city_unicode"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Resident Postal Code"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.23220.photoid.1",
+							"resident_postal_code"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Resident Country"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.23220.photoid.1",
+							"resident_country"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Resident City"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.23220.photoid.1",
+							"resident_city_latin1"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Sex"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.23220.photoid.1",
+							"sex"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Nationality"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.23220.photoid.1",
+							"nationality"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Document Number"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.23220.photoid.1",
+							"document_number"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Subdivision"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"org.iso.23220.photoid.1",
+							"issuing_subdivision"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuance Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"org.iso.23220.photoid.1",
+							"issuance_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Expiry Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"org.iso.23220.photoid.1",
+							"expiry_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Authority"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"org.iso.23220.photoid.1",
+							"issuing_authority_unicode"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Country"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"org.iso.23220.photoid.1",
+							"issuing_country"
+						]
+					}
+				],
+				"display": [
+					{
+						"locale": "en",
+						"logo": {
+							"alt_text": "A square figure of a mDL",
+							"uri": "https://examplestate.com/public/mdl.png"
+						},
+						"name": "Photo ID (MSO Mdoc)"
+					}
+				]
+			},
+			"credential_signing_alg_values_supported": [
+				-7
+			],
+			"cryptographic_binding_methods_supported": [
+				"jwk",
+				"cose_key"
+			],
+			"doctype": "org.iso.23220.2.photoid.1",
+			"format": "mso_mdoc",
+			"proof_types_supported": {
+				"jwt": {
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				}
+			},
+			"scope": "eu.europa.ec.eudi.photoid"
+		},
+		"eu.europa.ec.eudi.pid_mdoc": {
+			"credential_metadata": {
+				"claims": [
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Family Name(s)"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"family_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Given Name(s)"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"given_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Birth Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"birth_date"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Birth Family Name(s)"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"family_name_birth"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Birth Given Name(s)"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"given_name_birth"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Birth Place"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"place_of_birth"
+						],
+						"value_type": "places"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Resident Address"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"resident_address"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Resident Country"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"resident_country"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Resident State"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"resident_state"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Resident City"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"resident_city"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Resident Postal Code"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"resident_postal_code"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Resident Street"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"resident_street"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Resident House Number"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"resident_house_number"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Personal Administrative Number"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"personal_administrative_number"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Sex"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"sex"
+						],
+						"value_type": "uint"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Email Address"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"email_address"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Mobile Phone Number"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"mobile_phone_number"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Nationality"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"nationality"
+						],
+						"value_type": "nationalities"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuance Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"issuance_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Expiry Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"expiry_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuance Authority"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"issuing_authority"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Document Number"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"document_number"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Trust Anchor"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"trust_anchor"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Country"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"issuing_country"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Portrait Image"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"portrait"
+						],
+						"value_type": "jpeg"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Jurisdiction"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"issuing_jurisdiction"
+						]
+					}
+				],
+				"display": [
+					{
+						"locale": "en",
+						"logo": {
+							"alt_text": "A square figure of a PID",
+							"uri": "https://examplestate.com/public/pid.png"
+						},
+						"name": "PID (MSO Mdoc)"
+					}
+				]
+			},
+			"credential_signing_alg_values_supported": [
+				-7
+			],
+			"cryptographic_binding_methods_supported": [
+				"jwk",
+				"cose_key"
+			],
+			"doctype": "eu.europa.ec.eudi.pid.1",
+			"format": "mso_mdoc",
+			"policy": {
+				"batch_size": 15,
+				"one_time_use": true
+			},
+			"proof_types_supported": {
+				"jwt": {
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				}
+			},
+			"scope": "eu.europa.ec.eudi.pid_mdoc"
+		},
+		"eu.europa.ec.eudi.pid_mdoc_deferred": {
+			"credential_metadata": {
+				"claims": [
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Family Name(s)"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"family_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Given Name(s)"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"given_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Birth Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"birth_date"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Birth Family Name(s)"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"family_name_birth"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Birth Given Name(s)"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"given_name_birth"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Birth Place"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"place_of_birth"
+						],
+						"value_type": "places"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Resident Address"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"resident_address"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Resident Country"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"resident_country"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Resident State"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"resident_state"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Resident City"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"resident_city"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Resident Postal Code"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"resident_postal_code"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Resident Street"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"resident_street"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Resident House Number"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"resident_house_number"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Personal Administrative Number"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"personal_administrative_number"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Sex"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"sex"
+						],
+						"value_type": "uint"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Email Address"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"email_address"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Mobile Phone Number"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"mobile_phone_number"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Nationality"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"nationality"
+						],
+						"value_type": "nationalities"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuance Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"issuance_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Expiry Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"expiry_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuance Authority"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"issuing_authority"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Document Number"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"document_number"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Trust Anchor"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"trust_anchor"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Country"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"issuing_country"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Portrait Image"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"portrait"
+						],
+						"value_type": "jpeg"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Jurisdiction"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.pid.1",
+							"issuing_jurisdiction"
+						]
+					}
+				],
+				"display": [
+					{
+						"locale": "en",
+						"logo": {
+							"alt_text": "A square figure of a PID",
+							"uri": "https://examplestate.com/public/pid.png"
+						},
+						"name": "PID (MSO Mdoc Deferred)"
+					}
+				]
+			},
+			"credential_signing_alg_values_supported": [
+				-7
+			],
+			"cryptographic_binding_methods_supported": [
+				"jwk",
+				"cose_key"
+			],
+			"doctype": "eu.europa.ec.eudi.pid.1",
+			"format": "mso_mdoc",
+			"policy": {
+				"batch_size": 15,
+				"one_time_use": true
+			},
+			"proof_types_supported": {
+				"jwt": {
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				}
+			},
+			"scope": "eu.europa.ec.eudi.pid_mdoc_deferred"
+		},
+		"eu.europa.ec.eudi.pid_vc_sd_jwt": {
+			"credential_metadata": {
+				"claims": [
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Family Name(s)"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"family_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Given Name(s)"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"given_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Birth Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"birthdate"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Birth Place"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"place_of_birth"
+						],
+						"value_type": "list"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Nationalities"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"nationalities"
+						],
+						"value_type": "list"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Address"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"address"
+						],
+						"value_type": "test"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Street"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"address",
+							"street_address"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Locality"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"address",
+							"locality"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Region"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"address",
+							"region"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Postal Code"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"address",
+							"postal_code"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Country"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"address",
+							"country"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Full Address"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"address",
+							"formatted"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "House Number"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"address",
+							"house_number"
+						],
+						"value_type": "uint"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Personal Administrative Number"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"personal_administrative_number"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Portrait Image"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"picture"
+						],
+						"value_type": "jpeg"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Birth Family Name(s)"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"birth_family_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Birth Given Name(s)"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"birth_given_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Sex"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"sex"
+						],
+						"value_type": "uint"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Email Address"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"email_address"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Mobile Phone Number"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"mobile_phone_number"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuance Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"date_of_issuance"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Expiry Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"date_of_expiry"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuance Authority"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"issuing_authority"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Document Number"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"document_number"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Trust Anchor"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"trust_anchor"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Country"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"issuing_country"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Jurisdiction"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"issuing_jurisdiction"
+						]
+					}
+				],
+				"display": [
+					{
+						"locale": "en",
+						"logo": {
+							"alt_text": "A square figure of a PID",
+							"uri": "https://examplestate.com/public/pid.png"
+						},
+						"name": "PID (SD-JWT VC)"
+					}
+				]
+			},
+			"credential_signing_alg_values_supported": [
+				"ES256"
+			],
+			"cryptographic_binding_methods_supported": [
+				"jwk",
+				"cose_key"
+			],
+			"format": "dc+sd-jwt",
+			"proof_types_supported": {
+				"jwt": {
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				}
+			},
+			"scope": "eu.europa.ec.eudi.pid_vc_sd_jwt",
+			"vct": "urn:eudi:pid:1"
+		},
+		"eu.europa.ec.eudi.por_mdoc": {
+			"credential_metadata": {
+				"claims": [
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Legal Person Identifier"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.por.1",
+							"legal_person_identifier"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Legal Name"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.por.1",
+							"legal_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Full Powers"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.por.1",
+							"full_powers"
+						],
+						"value_type": "bool"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "eService"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.por.1",
+							"eService"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Effective From Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.por.1",
+							"effective_from_date"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Effective Until Date"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.por.1",
+							"effective_until_date"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuance Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.por.1",
+							"issuance_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Expiry Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.por.1",
+							"expiry_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Authority"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.por.1",
+							"issuing_authority"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Jurisdiction"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.por.1",
+							"issuing_jurisdiction"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Country"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.por.1",
+							"issuing_country"
+						]
+					}
+				],
+				"display": [
+					{
+						"locale": "en",
+						"logo": {
+							"alt_text": "A square figure of a PoR",
+							"uri": "https://examplestate.com/public/por.png"
+						},
+						"name": "Power Of Representation (MSO Mdoc)"
+					}
+				]
+			},
+			"credential_signing_alg_values_supported": [
+				-7
+			],
+			"cryptographic_binding_methods_supported": [
+				"jwk",
+				"cose_key"
+			],
+			"doctype": "eu.europa.ec.eudi.por.1",
+			"format": "mso_mdoc",
+			"policy": {
+				"batch_size": 15,
+				"one_time_use": true
+			},
+			"proof_types_supported": {
+				"cwt": {
+					"proof_alg_values_supported": [
+						-7
+					],
+					"proof_crv_values_supported": [
+						1
+					],
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				},
+				"jwt": {
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				}
+			},
+			"scope": "eu.europa.ec.eudi.por_mdoc"
+		},
+		"eu.europa.ec.eudi.por_sd_jwt_vc": {
+			"credential_metadata": {
+				"claims": [
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Legal Person Identifier"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"legal_person_identifier"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Legal Name"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"legal_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Full Powers"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"full_powers"
+						],
+						"value_type": "bool"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "eService"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eService"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Effective From Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"effective_from_date"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Effective Until Date"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"effective_until_date"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuance Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"issuance_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Expiry Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"expiry_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Authority"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"issuing_authority"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Jurisdiction"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"issuing_jurisdiction"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Country"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"issuing_country"
+						]
+					}
+				],
+				"display": [
+					{
+						"locale": "en",
+						"logo": {
+							"alt_text": "A square figure of a PID",
+							"uri": "https://examplestate.com/public/pid.png"
+						},
+						"name": "Power Of Representation (SD-JWT VC)"
+					}
+				]
+			},
+			"credential_signing_alg_values_supported": [
+				"ES256"
+			],
+			"cryptographic_binding_methods_supported": [
+				"jwk",
+				"cose_key"
+			],
+			"format": "dc+sd-jwt",
+			"proof_types_supported": {
+				"cwt": {
+					"proof_alg_values_supported": [
+						-7
+					],
+					"proof_crv_values_supported": [
+						1
+					],
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				},
+				"jwt": {
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				}
+			},
+			"scope": "eu.europa.ec.eudi.por_sd_jwt_vc",
+			"vct": "urn:eu.europa.ec.eudi:por:1"
+		},
+		"eu.europa.ec.eudi.seafarer_mdoc": {
+			"credential_metadata": {
+				"claims": [
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Family Name(s)"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.seafarer.1",
+							"family_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Given Name(s)"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.seafarer.1",
+							"given_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Birth Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.seafarer.1",
+							"birth_date"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Date of issue"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.seafarer.1",
+							"issue_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Place of Issue"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.seafarer.1",
+							"issue_place"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Expiry Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.seafarer.1",
+							"expiry_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Country"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.seafarer.1",
+							"issuing_country"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuance Authority"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.seafarer.1",
+							"issuing_authority"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuance Authority Logo"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.seafarer.1",
+							"issuing_authority_logo"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Document Name"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.seafarer.1",
+							"document_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Document Number"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.seafarer.1",
+							"document_number"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Portrait Image"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.seafarer.1",
+							"portrait"
+						],
+						"value_type": "jpeg"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Capacities"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.seafarer.1",
+							"capacities"
+						],
+						"value_type": "capacities_attributes"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Family Name Issuing Officer"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.seafarer.1",
+							"family_name_issuing_officer"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Given Name Issuing Officer"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.seafarer.1",
+							"given_name_issuing_officer"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Officer Signature"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.seafarer.1",
+							"signature_usual_mark_issuing_officer"
+						],
+						"value_type": "jpeg"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Title Issuing Officer"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.seafarer.1",
+							"title_issuing_officer"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "STCW Code"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.seafarer.1",
+							"stcw_code"
+						],
+						"value_type": "string"
+					}
+				],
+				"display": [
+					{
+						"locale": "en",
+						"logo": {
+							"alt_text": "A square figure of a PID",
+							"uri": "https://examplestate.com/public/pid.png"
+						},
+						"name": "Seafarer (MSO Mdoc)"
+					}
+				]
+			},
+			"credential_signing_alg_values_supported": [
+				-7
+			],
+			"cryptographic_binding_methods_supported": [
+				"jwk",
+				"cose_key"
+			],
+			"doctype": "eu.europa.ec.eudi.seafarer.1",
+			"format": "mso_mdoc",
+			"policy": {
+				"batch_size": 15,
+				"one_time_use": true
+			},
+			"proof_types_supported": {
+				"jwt": {
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				}
+			},
+			"scope": "eu.europa.ec.eudi.seafarer_mdoc"
+		},
+		"eu.europa.ec.eudi.tax_mdoc": {
+			"credential_metadata": {
+				"claims": [
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Tax Number"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.tax.1",
+							"tax_number"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Affiliation Country"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.tax.1",
+							"affiliation_country"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Registered Given Name"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.tax.1",
+							"registered_given_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Registered Family Name"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.tax.1",
+							"registered_family_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Resident Address"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.tax.1",
+							"resident_address"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Birth Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.tax.1",
+							"birth_date"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Church Tax ID"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.tax.1",
+							"church_tax_ID"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "IBAN"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.tax.1",
+							"iban"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Credential Type"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.tax.1",
+							"credential_type"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuance Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.tax.1",
+							"issuance_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Expiry Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.tax.1",
+							"expiry_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Authority"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.tax.1",
+							"issuing_authority"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Jurisdiction"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"eu.europa.ec.eudi.tax.1",
+							"issuing_jurisdiction"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Country"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"eu.europa.ec.eudi.tax.1",
+							"issuing_country"
+						]
+					}
+				],
+				"display": [
+					{
+						"locale": "en",
+						"logo": {
+							"alt_text": "A square figure of a tax",
+							"uri": "https://examplestate.com/public/tax.png"
+						},
+						"name": "Tax Number (MSO Mdoc)"
+					}
+				]
+			},
+			"credential_signing_alg_values_supported": [
+				"ES256"
+			],
+			"cryptographic_binding_methods_supported": [
+				"jwk",
+				"cose_key"
+			],
+			"doctype": "eu.europa.ec.eudi.tax.1",
+			"format": "mso_mdoc",
+			"policy": {
+				"batch_size": 15,
+				"one_time_use": true
+			},
+			"proof_types_supported": {
+				"cwt": {
+					"proof_alg_values_supported": [
+						-7
+					],
+					"proof_crv_values_supported": [
+						1
+					],
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				},
+				"jwt": {
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				}
+			},
+			"scope": "eu.europa.ec.eudi.tax_mdoc"
+		},
+		"eu.europa.ec.eudi.tax_residency_vc_sd_jwt": {
+			"credential_metadata": {
+				"claims": [
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Taxpayer type"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"taxpayer_type"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Name"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Birth Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"date_of_birth"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Address"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"address"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Identification Number"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"identification_number"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Legal Framework"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"legal_framework"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Source Country Competent Authority"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"source_country_competent_authority"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Start Date Residency"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"start_date_of_residency_requested_period"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "End Date Residency"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"end_date_of_residency_requested_period"
+						],
+						"value_type": "full-date"
+					}
+				],
+				"display": [
+					{
+						"locale": "en",
+						"logo": {
+							"alt_text": "A square figure of a PID",
+							"uri": "https://examplestate.com/public/pid.png"
+						},
+						"name": "Tax Residency (SD-JWT VC)"
+					}
+				]
+			},
+			"credential_signing_alg_values_supported": [
+				"ES256"
+			],
+			"cryptographic_binding_methods_supported": [
+				"jwk",
+				"cose_key"
+			],
+			"format": "dc+sd-jwt",
+			"proof_types_supported": {
+				"jwt": {
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				}
+			},
+			"scope": "eu.europa.ec.eudi.tax_residency_vc_sd_jwt",
+			"vct": "urn:eu.europa.ec.eudi:tax:1:1"
+		},
+		"eu.europa.ec.eudi.tax_sd_jwt_vc": {
+			"credential_metadata": {
+				"claims": [
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Tax Number"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"tax_number"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Affiliation Country"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"affiliation_country"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Registered Given Name"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"registered_given_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Registered Family Name"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"registered_family_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Resident Address"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"resident_address"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Birth Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"birth_date"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Church Tax ID"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"church_tax_ID"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "IBAN"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"iban"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Credential Type"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"credential_type"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuance Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"issuance_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Expiry Date"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"expiry_date"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Authority"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"issuing_authority"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Jurisdiction"
+							}
+						],
+						"mandatory": false,
+						"path": [
+							"issuing_jurisdiction"
+						]
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Issuing Country"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"issuing_country"
+						]
+					}
+				],
+				"display": [
+					{
+						"locale": "en",
+						"logo": {
+							"alt_text": "A square figure of a PID",
+							"uri": "https://examplestate.com/public/pid.png"
+						},
+						"name": "Tax Number (SD-JWT VC)"
+					}
+				]
+			},
+			"credential_signing_alg_values_supported": [
+				"ES256"
+			],
+			"cryptographic_binding_methods_supported": [
+				"jwk",
+				"cose_key"
+			],
+			"format": "dc+sd-jwt",
+			"proof_types_supported": {
+				"cwt": {
+					"proof_alg_values_supported": [
+						-7
+					],
+					"proof_crv_values_supported": [
+						1
+					],
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				},
+				"jwt": {
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				}
+			},
+			"scope": "eu.europa.ec.eudi.tax_sd_jwt_vc",
+			"vct": "urn:eu.europa.ec.eudi:tax:1"
+		},
+		"org.iso.18013.5.1.reservation_mdoc": {
+			"credential_alg_values_supported": [
+				-7
+			],
+			"credential_crv_values_supported": [
+				1
+			],
+			"credential_metadata": {
+				"claims": [
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "The booking service providing the booking reservation."
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"org.iso.18013.5.reservation.1",
+							"booking_service_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "The identifier of the booking reservation from the booking service."
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"org.iso.18013.5.reservation.1",
+							"reservation_id"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Date of the reservation."
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"org.iso.18013.5.reservation.1",
+							"reservation_date"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "The name of the service provider (e.g. Hotel) the reservation refers to "
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"org.iso.18013.5.reservation.1",
+							"service_provider_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "The location or place the reservation refers to (e.g. city, service provider place, etc.)"
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"org.iso.18013.5.reservation.1",
+							"location"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "The check-in date for the reservation."
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"org.iso.18013.5.reservation.1",
+							"check_in_date"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "The check-out date for the reservation."
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"org.iso.18013.5.reservation.1",
+							"check_out_date"
+						],
+						"value_type": "full-date"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "The guest of the reservation (num of adults, num of children, etc)."
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"org.iso.18013.5.reservation.1",
+							"guests"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Indicates inclusion of car rental in the reservation."
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"org.iso.18013.5.reservation.1",
+							"car_rental"
+						],
+						"value_type": "bool"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "The number of rooms the reservation refers to."
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"org.iso.18013.5.reservation.1",
+							"num_of_rooms"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Current last name(s) or surname(s) of the holder. "
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"org.iso.18013.5.reservation.1",
+							"family_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Current first name(s), including middle name(s), of the holder. "
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"org.iso.18013.5.reservation.1",
+							"given_name"
+						],
+						"value_type": "string"
+					},
+					{
+						"display": [
+							{
+								"locale": "en",
+								"name": "Day, month, and year on which the holder was born."
+							}
+						],
+						"mandatory": true,
+						"path": [
+							"org.iso.18013.5.reservation.1",
+							"birth_date"
+						],
+						"value_type": "full-date"
+					}
+				],
+				"display": [
+					{
+						"locale": "en",
+						"logo": {
+							"alt_text": "A square figure of a PID",
+							"uri": "https://examplestate.com/public/pid.png"
+						},
+						"name": "Reservation"
+					}
+				]
+			},
+			"credential_signing_alg_values_supported": [
+				-7
+			],
+			"cryptographic_binding_methods_supported": [
+				"jwk",
+				"cose_key"
+			],
+			"doctype": "org.iso.18013.5.1.reservation",
+			"format": "mso_mdoc",
+			"policy": {
+				"batch_size": 15,
+				"one_time_use": true
+			},
+			"proof_types_supported": {
+				"jwt": {
+					"proof_signing_alg_values_supported": [
+						"ES256"
+					]
+				}
+			},
+			"scope": "org.iso.18013.5.1.reservation_mdoc"
+		}
+	},
+	"credential_endpoint": "https://dev.issuer.eudiw.dev/credential",
+	"credential_issuer": "https://ec.dev.issuer.eudiw.dev",
+	"credential_request_encryption": {
+		"enc_values_supported": [
+			"A128GCM",
+			"A256GCM",
+			"A128CBC-HS256",
+			"A256CBC-HS512",
+			"ECDH-ES"
+		],
+		"encryption_required": false,
+		"jwks": {
+			"keys": [
+				{
+					"alg": "ECDH-ES",
+					"crv": "P-256",
+					"kid": "D6KSZ43BrxnLwBAajruJpB1t7TrsWuE-mAn6ihHqT8w",
+					"kty": "EC",
+					"use": "enc",
+					"x": "xuUPSgobyy2Pxw-rUgmYHe92K4JuuFIAKu1vbIw6pgo",
+					"y": "HoYHVVdZdEdVYZWf_ryHhgd4ak5-6xykpvFgZaK_Z8Q"
+				}
+			]
+		}
+	},
+	"credential_response_encryption": {
+		"alg_values_supported": [
+			"RSA-OAEP",
+			"RSA-OAEP-256",
+			"ECDH-ES"
+		],
+		"enc_values_supported": [
+			"A128CBC-HS256",
+			"A192CBC-HS384",
+			"A256CBC-HS512",
+			"A128GCM",
+			"A192GCM",
+			"A256GCM"
+		],
+		"encryption_required": false
+	},
+	"deferred_credential_endpoint": "https://dev.issuer.eudiw.dev/deferred_credential",
+	"display": [
+		{
+			"locale": "en",
+			"logo": {
+				"alt_text": "EU Digital Identity Wallet Logo",
+				"uri": "https://ec.dev.issuer.eudiw.dev/ic-logo.png"
+			},
+			"name": "Digital Credentials Issuer"
+		}
+	],
+	"nonce_endpoint": "https://dev.issuer.eudiw.dev/nonce",
+	"notification_endpoint": "https://dev.issuer.eudiw.dev/notification"
+}


### PR DESCRIPTION
Update dependencies for `eudi-lib-ios-iso18013-data-transfer` and `eudi-lib-ios-openid4vci-swift`. Enhance Claim metadata to include value types and improve JSON conversion methods. Decode jpeg and png string values as image data. Add tests for SD-JWT claims.