### PR TITLE
Add support for issuer metadata policy and update OpenID4VP dependency to v0.33.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6b17a909ae4d9b4768afc96f57f03e254ab5312ccf1e90b283be17a41211851e",
+  "originHash" : "07cc9229ecbf27b2eab540fed5781f267646f53c90734349293b75c0647c91e1",
   "pins" : [
     {
       "identity" : "cryptoswift",
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-siop-openid4vp-swift.git",
       "state" : {
-        "revision" : "4dcafc85cca592ed066da846b1195b59214a63b8",
-        "version" : "0.32.1"
+        "revision" : "ba1c25c75301bc3cbc140a63067426954d6d873c",
+        "version" : "0.33.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git", exact: "0.11.3"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift.git", exact: "0.14.1"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git", exact: "0.35.1"),
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-siop-openid4vp-swift.git", exact: "0.32.1"),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-siop-openid4vp-swift.git", exact: "0.33.0"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-statium-swift.git", exact: "0.4.0"),
 	],
 	targets: [

--- a/README.md
+++ b/README.md
@@ -145,14 +145,16 @@ The wallet now supports multiple OpenID4VCI issuer configurations for enhanced f
 let issuerConfigurations: [String: OpenId4VciConfiguration] = [
     "eudi_pid_issuer": OpenId4VciConfiguration(
         credentialIssuerURL: "https://pid.issuer.example.com",
-        useDpopIfSupported: true,
+    requireDpop: true,
+    issuerMetadataPolicy: .requireSigned,
         dpopKeyOptions: KeyOptions(
             secureAreaName: "SecureEnclave", curve: .P256, accessControl: .requireUserPresence
         )
     ),
     "mdl_issuer": OpenId4VciConfiguration(
         credentialIssuerURL: "https://mdl.issuer.example.com",
-        useDpopIfSupported: false
+    requireDpop: false,
+    issuerMetadataPolicy: .ignoreSigned
     )
 ]
 
@@ -170,7 +172,7 @@ try wallet.registerOpenId4VciServices([
 ])
 ```
 
-The `useDpopIfSupported` property controls whether to use DPoP when the issuer supports it. The `dpopKeyOptions` property allows you to specify key generation parameters for DPoP keys, including the secure area, curve type and user authentication options.
+The `requireDpop` property controls whether issuance should halt when DPoP is not available. The `issuerMetadataPolicy` property controls signed metadata handling per issuer (`.ignoreSigned` or `.requireSigned`). The `dpopKeyOptions` property allows you to specify key generation parameters for DPoP keys, including the secure area, curve type and user authentication options.
 
 ### OAuth 2.0 Attestation-Based Client Authentication
 
@@ -208,7 +210,8 @@ let config = OpenId4VciConfiguration(
         ),
         popKeyDuration: 300  // PoP JWT validity in seconds (default: 300)
     ),
-    useDpopIfSupported: true
+    requireDpop: true,
+    issuerMetadataPolicy: .requireSigned
 )
 
 let walletConfig = EudiWalletConfiguration(
@@ -390,15 +393,19 @@ let defaultOptions = try await wallet.getDefaultCredentialOptions(
 ```
 ### Resolving Credential offer
 
-The library provides the `resolveOfferUrlDocTypes(uriOffer:)` method that resolves the credential offer URI.
+The library provides the `resolveOfferUrlDocTypes(offerUri:authFlowRedirectionURI:issuerMetadataPolicy:)` method that resolves the credential offer URI.
 The method returns the resolved `OfferedIssuanceModel` object that contains the offer's data (offered document types, issuer name and transaction code specification for pre-authorized flow). The offer's data can be displayed to the
 user.
 
 The following example shows how to resolve a credential offer:
 
 ```swift
- func resolveOfferUrlDocTypes(uriOffer: String, authFlowRedirectionURI: URL?) async throws -> OfferedIssuanceModel {
-    return try await wallet.resolveOfferUrlDocTypes(uriOffer: uriOffer, authFlowRedirectionURI: authFlowRedirectionURI)
+ func resolveOfferUrlDocTypes(offerUri: String, authFlowRedirectionURI: URL?) async throws -> OfferedIssuanceModel {
+    return try await wallet.resolveOfferUrlDocTypes(
+      offerUri: offerUri,
+      authFlowRedirectionURI: authFlowRedirectionURI,
+      issuerMetadataPolicy: .requireSigned
+    )
   }
 ```
 
@@ -409,7 +416,7 @@ The following example shows how to issue documents by offer URL:
 
 ```swift
 // Resolve the offer to get document models with recommended credential options
-let offer = try await wallet.resolveOfferUrlDocTypes(uriOffer: offerUrl)
+let offer = try await wallet.resolveOfferUrlDocTypes(offerUri: offerUrl, authFlowRedirectionURI: nil)
 
 // Use the offered documents as-is with recommended settings, or customize them
 let customizedDocTypes = offer.docModels.map { docModel in
@@ -446,7 +453,7 @@ information. Specifically, the `txCodeSpec` field in the `OfferedIssuanceModel` 
 
 From the user's perspective, the application must provide a way to input the transaction code.
 
-After user acceptance of the offer, the selected documents can be issued using the `issueDocumentsByOfferUrl(offerUri:docTypes:docTypeKeyOptions:txCodeValue:)` method.
+After user acceptance of the offer, the selected documents can be issued using the `issueDocumentsByOfferUrl(offerUri:docTypes:txCodeValue:configuration:)` method.
 When the transaction code is provided, the issuance process can be resumed by calling the above-mentioned method and passing the transaction code in the `txCodeValue` parameter.
 
 ### Dynamic issuance

--- a/README.md
+++ b/README.md
@@ -436,7 +436,42 @@ let newDocs = try await wallet.issueDocumentsByOfferUrl(
 )
 ```
 
+#### Configuring Issuer Metadata Policy with Certificate Chain Trust
 
+When you need strict validation of issuer metadata signatures using certificate chains (such as IACA root certificates), you can configure the issuer's `OpenId4VciConfiguration` with a signed metadata policy and certificate chain trust validator:
+
+```swift
+// Create a certificate chain trust validator with IACA root certificates
+let trust: CertificateChainTrust = TrustedChainValidator(iacaRoots: [eudic])
+
+// Create an issuer metadata policy that requires signed metadata
+let issuerMetadataPolicy: IssuerMetadataPolicy = .requireSigned(
+  issuerTrust: .byCertificateChain(certificateChainTrust: trust)
+)
+
+// Configure the issuer with the strict signed metadata policy
+let config = OpenId4VciConfiguration(
+  credentialIssuerURL: "https://issuer.example.com",
+  clientId: "my-wallet",
+  issuerMetadataPolicy: issuerMetadataPolicy
+)
+
+// Use this configuration when initializing the wallet
+let walletConfig = EudiWalletConfiguration(
+  trustedReaderCertificates: [Data(name: "eudi_pid_issuer_ut", ext: "der")!]
+)
+let wallet = try EudiWallet(
+  eudiWalletConfig: walletConfig,
+  openID4VciConfigurations: ["trusted_issuer": config]
+)
+```
+
+The `IssuerMetadataPolicy` enum provides three validation strategies:
+- `.ignoreSigned`: Accept issuer metadata regardless of signature status (default)
+- `.preferSigned(issuerTrust:)`: Prefer signed metadata if available, fall back to unsigned
+- `.requireSigned(issuerTrust:)`: Strictly require signed metadata, reject unsigned metadata
+
+When using `.requireSigned`, the issuer's metadata signature must be valid against one of the IACA root certificates provided to the trust validator.
 
 ### Authorization code flow
 

--- a/README.md
+++ b/README.md
@@ -393,9 +393,11 @@ let defaultOptions = try await wallet.getDefaultCredentialOptions(
 ```
 ### Resolving Credential offer
 
-The library provides the `resolveOfferUrlDocTypes(offerUri:authFlowRedirectionURI:issuerMetadataPolicy:)` method that resolves the credential offer URI.
+The library provides the `resolveOfferUrlDocTypes(offerUri:authFlowRedirectionURI:)` method that resolves the credential offer URI.
 The method returns the resolved `OfferedIssuanceModel` object that contains the offer's data (offered document types, issuer name and transaction code specification for pre-authorized flow). The offer's data can be displayed to the
 user.
+
+When a pre-registered issuer can be resolved from `offerUri`, the method uses that issuer's `OpenId4VciConfiguration.issuerMetadataPolicy`.
 
 The following example shows how to resolve a credential offer:
 
@@ -403,8 +405,7 @@ The following example shows how to resolve a credential offer:
  func resolveOfferUrlDocTypes(offerUri: String, authFlowRedirectionURI: URL?) async throws -> OfferedIssuanceModel {
     return try await wallet.resolveOfferUrlDocTypes(
       offerUri: offerUri,
-      authFlowRedirectionURI: authFlowRedirectionURI,
-      issuerMetadataPolicy: .requireSigned
+      authFlowRedirectionURI: authFlowRedirectionURI
     )
   }
 ```

--- a/Sources/EudiWalletKit/EudiWallet.swift
+++ b/Sources/EudiWalletKit/EudiWallet.swift
@@ -273,8 +273,8 @@ public final class EudiWallet: ObservableObject, @unchecked Sendable {
 	/// - Parameters:
 	///   - uriOffer: url with offer
 	/// - Returns: Offered issue information model
-	public func resolveOfferUrlDocTypes(offerUri: String, authFlowRedirectionURI: URL?) async throws -> OfferedIssuanceModel {
-		let result = await CredentialOfferRequestResolver(fetcher: Fetcher<CredentialOfferRequestObject>(session: networkingVci), credentialIssuerMetadataResolver: OpenId4VciService.makeMetadataResolver(networkingVci), authorizationServerMetadataResolver: AuthorizationServerMetadataResolver(oidcFetcher: Fetcher<OIDCProviderMetadata>(session: networkingVci), oauthFetcher: Fetcher<AuthorizationServerMetadata>(session: networkingVci))).resolve(source: try .init(urlString: offerUri), policy: .ignoreSigned)
+	public func resolveOfferUrlDocTypes(offerUri: String, authFlowRedirectionURI: URL?, issuerMetadataPolicy: IssuerMetadataPolicy = .ignoreSigned) async throws -> OfferedIssuanceModel {
+		let result = await CredentialOfferRequestResolver(fetcher: Fetcher<CredentialOfferRequestObject>(session: networkingVci), credentialIssuerMetadataResolver: OpenId4VciService.makeMetadataResolver(networkingVci), authorizationServerMetadataResolver: AuthorizationServerMetadataResolver(oidcFetcher: Fetcher<OIDCProviderMetadata>(session: networkingVci), oauthFetcher: Fetcher<AuthorizationServerMetadata>(session: networkingVci))).resolve(source: try .init(urlString: offerUri), policy: issuerMetadataPolicy)
 		switch result {
 		case .success(let offer):
 			let credentialIssuerIdentifier = offer.credentialIssuerIdentifier
@@ -299,7 +299,8 @@ public final class EudiWallet: ObservableObject, @unchecked Sendable {
 	///  - configuration: Optional OpenId4VciConfiguration to override the default one for this issuance
 	/// - Returns: Array of issued and stored documents
 	public func issueDocumentsByOfferUrl(offerUri: String, docTypes: [OfferedDocModel], txCodeValue: String? = nil, promptMessage: String? = nil, configuration: OpenId4VciConfiguration? = nil) async throws -> [WalletStorage.Document] {
-		let result = await CredentialOfferRequestResolver(fetcher: Fetcher<CredentialOfferRequestObject>(session: networkingVci), credentialIssuerMetadataResolver: OpenId4VciService.makeMetadataResolver(networkingVci), authorizationServerMetadataResolver: AuthorizationServerMetadataResolver(oidcFetcher: Fetcher<OIDCProviderMetadata>(session: networkingVci), oauthFetcher: Fetcher<AuthorizationServerMetadata>(session: networkingVci))).resolve(source: try .init(urlString: offerUri), policy: .ignoreSigned)
+		let issuerMetadataPolicy = configuration?.issuerMetadataPolicy ?? .ignoreSigned
+		let result = await CredentialOfferRequestResolver(fetcher: Fetcher<CredentialOfferRequestObject>(session: networkingVci), credentialIssuerMetadataResolver: OpenId4VciService.makeMetadataResolver(networkingVci), authorizationServerMetadataResolver: AuthorizationServerMetadataResolver(oidcFetcher: Fetcher<OIDCProviderMetadata>(session: networkingVci), oauthFetcher: Fetcher<AuthorizationServerMetadata>(session: networkingVci))).resolve(source: try .init(urlString: offerUri), policy: issuerMetadataPolicy)
 		switch result {
 		case .success(let offer):
 			let urlString = offer.credentialIssuerIdentifier.url.absoluteString

--- a/Sources/EudiWalletKit/EudiWallet.swift
+++ b/Sources/EudiWalletKit/EudiWallet.swift
@@ -273,18 +273,22 @@ public final class EudiWallet: ObservableObject, @unchecked Sendable {
 	/// - Parameters:
 	///   - uriOffer: url with offer
 	/// - Returns: Offered issue information model
-	public func resolveOfferUrlDocTypes(offerUri: String, authFlowRedirectionURI: URL?, issuerMetadataPolicy: IssuerMetadataPolicy = .ignoreSigned) async throws -> OfferedIssuanceModel {
-		let result = await CredentialOfferRequestResolver(fetcher: Fetcher<CredentialOfferRequestObject>(session: networkingVci), credentialIssuerMetadataResolver: OpenId4VciService.makeMetadataResolver(networkingVci), authorizationServerMetadataResolver: AuthorizationServerMetadataResolver(oidcFetcher: Fetcher<OIDCProviderMetadata>(session: networkingVci), oauthFetcher: Fetcher<AuthorizationServerMetadata>(session: networkingVci))).resolve(source: try .init(urlString: offerUri), policy: issuerMetadataPolicy)
+	public func resolveOfferUrlDocTypes(offerUri: String, authFlowRedirectionURI: URL?) async throws -> OfferedIssuanceModel {
+		let vciServiceFromOfferUri = await resolveVCIServiceFromOfferUri(offerUri)
+		let policy: IssuerMetadataPolicy = if let vciServiceFromOfferUri { await vciServiceFromOfferUri.config.issuerMetadataPolicy } else { .ignoreSigned }
+		let result = await CredentialOfferRequestResolver(fetcher: Fetcher<CredentialOfferRequestObject>(session: networkingVci), credentialIssuerMetadataResolver: OpenId4VciService.makeMetadataResolver(networkingVci), authorizationServerMetadataResolver: AuthorizationServerMetadataResolver(oidcFetcher: Fetcher<OIDCProviderMetadata>(session: networkingVci), oauthFetcher: Fetcher<AuthorizationServerMetadata>(session: networkingVci))).resolve(source: try .init(urlString: offerUri), policy: policy)
 		switch result {
 		case .success(let offer):
 			let credentialIssuerIdentifier = offer.credentialIssuerIdentifier
 			let urlString = credentialIssuerIdentifier.url.absoluteString
 			// CHECK: Must be pre-registered in registry
-        	guard let vciService = await OpenId4VCIServiceRegistry.shared.getByIssuerURL(issuerURL: urlString) else {
+			let vciService = await OpenId4VCIServiceRegistry.shared.getByIssuerURL(issuerURL: urlString) ?? vciServiceFromOfferUri
+	        	guard let vciService,
+					await vciService.hasIssuerUrl(urlString) else {
             	// REJECT: Not pre-registered = untrusted
             	throw PresentationSession.makeError(str: "Issuer must be pre-configured. Only registered issuers are allowed.", localizationKey: "issuer_not_registered", code: .issuerNotRegistered, context: ["issuer": urlString])
         	}
-			return try await vciService.resolveOfferUrlDocTypes(offerUri: offerUri)
+			return try await vciService.resolveOfferDocTypes(offerUri: offerUri, offer: offer)
 		case .failure(let error):
 			throw PresentationSession.makeError(str: "Unable to resolve credential offer: \(error.localizedDescription)")
 		}

--- a/Sources/EudiWalletKit/EudiWalletKit.docc/GetStarted.md
+++ b/Sources/EudiWalletKit/EudiWalletKit.docc/GetStarted.md
@@ -39,17 +39,23 @@ The wallet now supports multiple OpenID4VCI issuer configurations for enhanced f
 let issuerConfigurations: [String: OpenId4VciConfiguration] = [
     "eudi_pid_issuer": OpenId4VciConfiguration(
         credentialIssuerURL: "https://pid.issuer.example.com",
-        useDpopIfSupported: true,
+        requireDpop: true,
+        issuerMetadataPolicy: .requireSigned,
         dpopKeyOptions: KeyOptions(
             secureAreaName: "SecureEnclave", curve: .P256, accessControl: .requireUserPresence
         )
     ),
     "mdl_issuer": OpenId4VciConfiguration(
         credentialIssuerURL: "https://mdl.issuer.example.com",
-        useDpopIfSupported: false
+        requireDpop: false,
+        issuerMetadataPolicy: .ignoreSigned
     )
 ]
 
 // Register additional issuers after initialization
 try wallet.registerOpenId4VciServices(issuerConfigurations)
 ```
+
+Use `issuerMetadataPolicy` to control signed metadata handling per issuer:
+- `.requireSigned` for issuers that require signed metadata validation
+- `.ignoreSigned` for environments that still use unsigned metadata

--- a/Sources/EudiWalletKit/EudiWalletKit.docc/IssueDocuments.md
+++ b/Sources/EudiWalletKit/EudiWalletKit.docc/IssueDocuments.md
@@ -97,15 +97,19 @@ let defaultOptions = try await wallet.getDefaultCredentialOptions(
 ```
 ### Resolving Credential offer
 
-The library provides the `resolveOfferUrlDocTypes(uriOffer:)` method that resolves the credential offer URI.
+The library provides the `resolveOfferUrlDocTypes(offerUri:authFlowRedirectionURI:issuerMetadataPolicy:)` method that resolves the credential offer URI.
 The method returns the resolved `OfferedIssuanceModel` object that contains the offer's data (offered document types, issuer name and transaction code specification for pre-authorized flow). The offer's data can be displayed to the
 user.
 
 The following example shows how to resolve a credential offer:
 
 ```swift
- func resolveOfferUrlDocTypes(uriOffer: String, authFlowRedirectionURI: URL?) async throws -> OfferedIssuanceModel {
-    return try await wallet.resolveOfferUrlDocTypes(uriOffer: uriOffer, authFlowRedirectionURI: authFlowRedirectionURI)
+ func resolveOfferUrlDocTypes(offerUri: String, authFlowRedirectionURI: URL?) async throws -> OfferedIssuanceModel {
+    return try await wallet.resolveOfferUrlDocTypes(
+      offerUri: offerUri,
+      authFlowRedirectionURI: authFlowRedirectionURI,
+      issuerMetadataPolicy: .requireSigned
+    )
   }
 ```
 
@@ -116,7 +120,7 @@ The following example shows how to issue documents by offer URL:
 
 ```swift
 // Resolve the offer to get document models with recommended credential options
-let offer = try await wallet.resolveOfferUrlDocTypes(uriOffer: offerUrl)
+let offer = try await wallet.resolveOfferUrlDocTypes(offerUri: offerUrl, authFlowRedirectionURI: nil)
 
 // Use the offered documents as-is with recommended settings, or customize them
 let customizedDocTypes = offer.docModels.map { docModel in
@@ -152,7 +156,7 @@ information. Specifically, the `txCodeSpec` field in the ``OfferedIssuanceModel`
 
 From the user's perspective, the application must provide a way to input the transaction code.
 
-After user acceptance of the offer, the selected documents can be issued using the `issueDocumentsByOfferUrl(offerUri:docTypes:docTypeKeyOptions:txCodeValue:)` method.
+After user acceptance of the offer, the selected documents can be issued using the `issueDocumentsByOfferUrl(offerUri:docTypes:txCodeValue:configuration:)` method.
 When the transaction code is provided, the issuance process can be resumed by calling the above-mentioned method and passing the transaction code in the `txCodeValue` parameter.
 
 ### Dynamic issuance

--- a/Sources/EudiWalletKit/EudiWalletKit.docc/IssueDocuments.md
+++ b/Sources/EudiWalletKit/EudiWalletKit.docc/IssueDocuments.md
@@ -97,9 +97,11 @@ let defaultOptions = try await wallet.getDefaultCredentialOptions(
 ```
 ### Resolving Credential offer
 
-The library provides the `resolveOfferUrlDocTypes(offerUri:authFlowRedirectionURI:issuerMetadataPolicy:)` method that resolves the credential offer URI.
+The library provides the `resolveOfferUrlDocTypes(offerUri:authFlowRedirectionURI:)` method that resolves the credential offer URI.
 The method returns the resolved `OfferedIssuanceModel` object that contains the offer's data (offered document types, issuer name and transaction code specification for pre-authorized flow). The offer's data can be displayed to the
 user.
+
+When a pre-registered issuer can be resolved from `offerUri`, the method uses that issuer's `OpenId4VciConfiguration.issuerMetadataPolicy`.
 
 The following example shows how to resolve a credential offer:
 
@@ -107,8 +109,7 @@ The following example shows how to resolve a credential offer:
  func resolveOfferUrlDocTypes(offerUri: String, authFlowRedirectionURI: URL?) async throws -> OfferedIssuanceModel {
     return try await wallet.resolveOfferUrlDocTypes(
       offerUri: offerUri,
-      authFlowRedirectionURI: authFlowRedirectionURI,
-      issuerMetadataPolicy: .requireSigned
+      authFlowRedirectionURI: authFlowRedirectionURI
     )
   }
 ```

--- a/Sources/EudiWalletKit/EudiWalletKit.docc/IssueDocuments.md
+++ b/Sources/EudiWalletKit/EudiWalletKit.docc/IssueDocuments.md
@@ -120,6 +120,23 @@ The `txCodeValue` parameter is not used in the case of the authorization code fl
 The following example shows how to issue documents by offer URL:
 
 ```swift
+// Configure issuer with signed metadata policy and certificate chain trust
+let trust: CertificateChainTrust = TrustedChainValidator(iacaRoots: [eudic])
+let issuerMetadataPolicy: IssuerMetadataPolicy = .requireSigned(
+  issuerTrust: .byCertificateChain(certificateChainTrust: trust)
+)
+
+let config = OpenId4VciConfiguration(
+  credentialIssuerURL: "https://issuer.example.com",
+  clientId: "my-wallet",
+  issuerMetadataPolicy: issuerMetadataPolicy
+)
+
+let wallet = try EudiWallet(
+  eudiWalletConfig: EudiWalletConfiguration(trustedReaderCertificates: []),
+  openID4VciConfigurations: ["trusted_issuer": config]
+)
+
 // Resolve the offer to get document models with recommended credential options
 let offer = try await wallet.resolveOfferUrlDocTypes(offerUri: offerUrl, authFlowRedirectionURI: nil)
 

--- a/Sources/EudiWalletKit/Extensions.swift
+++ b/Sources/EudiWalletKit/Extensions.swift
@@ -444,3 +444,27 @@ extension DocClaimsModelConfiguration {
 		)
 	}
 }
+
+extension EudiWallet {
+	/// Try to resolve a pre-registered VCI service directly from credential offer URL parameters.
+	func resolveVCIServiceFromOfferUri(_ offerUri: String) async -> OpenId4VciService? {
+		guard let issuerURL = Self.extractCredentialIssuerURL(from: offerUri) else { return nil }
+		return await OpenId4VCIServiceRegistry.shared.getByIssuerURL(issuerURL: issuerURL)
+	}
+
+	/// Extract credential issuer URL from an OpenID4VCI offer URL.
+	static func extractCredentialIssuerURL(from offerUri: String) -> String? {
+		guard let components = URLComponents(string: offerUri) else { return nil }
+		guard let encodedOffer = components.queryItems?.first(where: { $0.name == "credential_offer" })?.value else {
+			return nil
+		}
+		let decodedOffer = encodedOffer.removingPercentEncoding ?? encodedOffer
+		guard let offerData = decodedOffer.data(using: .utf8),
+			  let payload = try? JSONSerialization.jsonObject(with: offerData) as? [String: Any],
+			  let credentialIssuer = payload["credential_issuer"] as? String,
+			  !credentialIssuer.isEmpty else {
+			return nil
+		}
+		return credentialIssuer
+	}
+}

--- a/Sources/EudiWalletKit/Models/OpenId4VCIConfiguration.swift
+++ b/Sources/EudiWalletKit/Models/OpenId4VCIConfiguration.swift
@@ -40,12 +40,14 @@ public struct OpenId4VciConfiguration: Sendable {
 	public let requirePAR: Bool
 	/// Whether to require DPoP (Demonstrating Proof-of-Possession)
 	public let requireDpop: Bool
+	/// Policy that controls signed/unsigned issuer metadata handling.
+	public let issuerMetadataPolicy: IssuerMetadataPolicy
 	/// Whether user authentication is required for credential issuance
 	public let userAuthenticationRequired: Bool
 	/// Key options for generating DPoP keys, if DPoP is used
 	public let dpopKeyOptions: KeyOptions?
 
-	public init(credentialIssuerURL: String?, clientId: String? = nil, keyAttestationsConfig: KeyAttestationConfiguration? = nil, authFlowRedirectionURI: URL? = nil, authorizeIssuanceConfig: AuthorizeIssuanceConfig = .favorScopes, requirePAR: Bool = true, requireDpop: Bool = true, cacheIssuerMetadata: Bool = true, userAuthenticationRequired: Bool = false, dpopKeyOptions: KeyOptions? = nil, trustedIssuerCertificates: [x5chain]? = nil) {
+	public init(credentialIssuerURL: String?, clientId: String? = nil, keyAttestationsConfig: KeyAttestationConfiguration? = nil, authFlowRedirectionURI: URL? = nil, authorizeIssuanceConfig: AuthorizeIssuanceConfig = .favorScopes, requirePAR: Bool = true, requireDpop: Bool = true, issuerMetadataPolicy: IssuerMetadataPolicy = .ignoreSigned, cacheIssuerMetadata: Bool = true, userAuthenticationRequired: Bool = false, dpopKeyOptions: KeyOptions? = nil, trustedIssuerCertificates: [x5chain]? = nil) {
 		self.credentialIssuerURL = credentialIssuerURL
 		self.clientId = clientId ?? "wallet-dev"
 		self.keyAttestationsConfig = keyAttestationsConfig
@@ -53,6 +55,7 @@ public struct OpenId4VciConfiguration: Sendable {
 		self.authorizeIssuanceConfig = authorizeIssuanceConfig
 		self.requirePAR = requirePAR
 		self.requireDpop = requireDpop
+		self.issuerMetadataPolicy = issuerMetadataPolicy
 		self.userAuthenticationRequired = userAuthenticationRequired
 		self.dpopKeyOptions = dpopKeyOptions
 	}
@@ -122,7 +125,7 @@ extension OpenId4VciConfiguration {
 	func toOpenId4VCIConfig(credentialIssuerId: String, clientAttestationPopSigningAlgValuesSupported: [JWSAlgorithm]?) async throws -> OpenId4VCIConfig {
 		let client: Client = if let keyAttestationsConfig, clientAttestationPopSigningAlgValuesSupported != nil { try await makeAttestationClient(config: keyAttestationsConfig, credentialIssuerId: credentialIssuerId, algorithms: clientAttestationPopSigningAlgValuesSupported) } else { .public(id: clientId) }
 		let clientAttestationPoPBuilder: ClientAttestationPoPBuilder? = if keyAttestationsConfig != nil { DefaultClientAttestationPoPBuilder() } else { nil}
-		return OpenId4VCIConfig(client: client, authFlowRedirectionURI: authFlowRedirectionURI, authorizeIssuanceConfig: authorizeIssuanceConfig, requirePAR: requirePAR, clientAttestationPoPBuilder: clientAttestationPoPBuilder, requireDpop: requireDpop)
+		return OpenId4VCIConfig(client: client, authFlowRedirectionURI: authFlowRedirectionURI, authorizeIssuanceConfig: authorizeIssuanceConfig, requirePAR: requirePAR, clientAttestationPoPBuilder: clientAttestationPoPBuilder, issuerMetadataPolicy: issuerMetadataPolicy, requireDpop: requireDpop)
 	}
 
 	private func makeAttestationClient(config: KeyAttestationConfiguration, credentialIssuerId: String, algorithms: [JWSAlgorithm]?) async throws -> Client {

--- a/Sources/EudiWalletKit/Models/OpenId4VCIConfiguration.swift
+++ b/Sources/EudiWalletKit/Models/OpenId4VCIConfiguration.swift
@@ -40,7 +40,11 @@ public struct OpenId4VciConfiguration: Sendable {
 	public let requirePAR: Bool
 	/// Whether to require DPoP (Demonstrating Proof-of-Possession)
 	public let requireDpop: Bool
-	/// Policy that controls signed/unsigned issuer metadata handling.
+	/// Policy for handling signed issuer metadata fetched from `/.well-known/openid-credential-issuer`.
+	///
+	/// - `.ignoreSigned` (default): wallet sends `Accept: application/json` and only accepts plain JSON metadata. Backwards-compatible with all existing deployments.
+	/// - `.preferSigned(issuerTrust:)`: wallet sends `Accept: application/jwt, application/json`. If the issuer returns a signed JWT, the signature is verified against the supplied trust anchor; otherwise plain JSON is accepted as a fallback.
+	/// - `.requireSigned(issuerTrust:)`: wallet sends `Accept: application/jwt`. The issuer must return a signed JWT whose signature validates against the supplied trust anchor; plain JSON responses are rejected.
 	public let issuerMetadataPolicy: IssuerMetadataPolicy
 	/// Whether user authentication is required for credential issuance
 	public let userAuthenticationRequired: Bool

--- a/Sources/EudiWalletKit/Services/OpenId4VciService.swift
+++ b/Sources/EudiWalletKit/Services/OpenId4VciService.swift
@@ -153,7 +153,7 @@ public actor OpenId4VciService {
 	}
 
 	public func resolveOfferUrlDocTypes(offerUri: String) async throws -> OfferedIssuanceModel {
-		let result = await CredentialOfferRequestResolver(fetcher: Fetcher<CredentialOfferRequestObject>(session: networking), credentialIssuerMetadataResolver: Self.makeMetadataResolver(networking), authorizationServerMetadataResolver: AuthorizationServerMetadataResolver(oidcFetcher: Fetcher<OIDCProviderMetadata>(session: networking), oauthFetcher: Fetcher<AuthorizationServerMetadata>(session: networking))).resolve(source: try .init(urlString: offerUri), policy: .ignoreSigned)
+		let result = await CredentialOfferRequestResolver(fetcher: Fetcher<CredentialOfferRequestObject>(session: networking), credentialIssuerMetadataResolver: Self.makeMetadataResolver(networking), authorizationServerMetadataResolver: AuthorizationServerMetadataResolver(oidcFetcher: Fetcher<OIDCProviderMetadata>(session: networking), oauthFetcher: Fetcher<AuthorizationServerMetadata>(session: networking))).resolve(source: try .init(urlString: offerUri), policy: config.issuerMetadataPolicy)
 		switch result {
 		case .success(let offer):
 			return try await resolveOfferDocTypes(offerUri: offerUri, offer: offer)
@@ -197,7 +197,7 @@ public actor OpenId4VciService {
 
 	public func getIssuerMetadata() async throws -> CredentialIssuerMetadata {
 		let credentialIssuerIdentifier = try CredentialIssuerId(config.credentialIssuerURL!)
-		let issuerMetadata = try await Self.makeMetadataResolver(networking).resolve(source: .credentialIssuer(credentialIssuerIdentifier), policy: .ignoreSigned)
+		let issuerMetadata = try await Self.makeMetadataResolver(networking).resolve(source: .credentialIssuer(credentialIssuerIdentifier), policy: config.issuerMetadataPolicy)
 		switch issuerMetadata {
 			case .success(let metaData): return metaData
 			case .failure(let error):
@@ -290,7 +290,7 @@ public actor OpenId4VciService {
 			return cachedResult
 		}
 		let credentialIssuerIdentifier = try CredentialIssuerId(config.credentialIssuerURL!)
-		let issuerMetadata = try await Self.makeMetadataResolver(networking).resolve(source: .credentialIssuer(credentialIssuerIdentifier), policy: .ignoreSigned)
+		let issuerMetadata = try await Self.makeMetadataResolver(networking).resolve(source: .credentialIssuer(credentialIssuerIdentifier), policy: config.issuerMetadataPolicy)
 		switch issuerMetadata {
 		case .success(let metaData):
 			let result = (credentialIssuerIdentifier, metaData)

--- a/Sources/EudiWalletKit/Services/OpenId4VpService.swift
+++ b/Sources/EudiWalletKit/Services/OpenId4VpService.swift
@@ -100,7 +100,7 @@ public final class OpenId4VpService: @unchecked Sendable, PresentationService {
 	public func receiveRequest() async throws -> UserRequestInfo {
 		guard status != .error, let openid4VPURI = URL(string: openid4VPlink) else { throw PresentationSession.makeError(str: "Invalid link \(openid4VPlink)") }
 		openId4Vp = OpenID4VP(walletConfiguration: getWalletConf())
-		switch await openId4Vp.authorize(fetcher: Fetcher<String>(), url: openid4VPURI)  {
+		switch await openId4Vp.authorize(fetcher: Fetcher<String>(), poster: Poster(session: networking), url: openid4VPURI)  {
 		case .notSecured(data: let rrd):
 			if case .redirectUri = rrd.client { return try handleRequestData(rrd) }
 			else { throw PresentationSession.makeError(str: "Not secured request") }

--- a/Sources/EudiWalletKit/Services/TrustedChainValidator.swift
+++ b/Sources/EudiWalletKit/Services/TrustedChainValidator.swift
@@ -1,0 +1,46 @@
+/*
+Copyright (c) 2026 European Commission
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import Foundation
+import MdocSecurity18013
+import OpenID4VCI
+import X509
+
+public struct TrustedChainValidator: CertificateChainTrust {
+    private let iacaRoots: [x5chain]
+    public var readerCertificateIssuer: String?
+    public var validationMessages: [String] = []
+
+    public init(iacaRoots: [x5chain]) {
+        self.iacaRoots = iacaRoots
+    }
+
+    public func isValid(chain: [String]) -> Bool {
+        var isValid: Bool = false
+        let b64certs = chain
+        let certsData = b64certs.compactMap { Data(base64Encoded: $0) }
+        let certsDer = certsData.compactMap { SecCertificateCreateWithData(nil, $0 as CFData) }
+        guard certsDer.count > 0, certsDer.count == b64certs.count else { return false }
+        let policy = SecPolicyCreateBasicX509()
+        var trust: SecTrust?
+        let result = SecTrustCreateWithCertificates(certsDer as CFArray, policy, &trust)
+        guard result == errSecSuccess else {
+            logger.error("Chain verification error: \(result.message)")
+            return false
+        }
+        (isValid, _, _) = SecurityHelpers.isMdocX5cValid(secCerts: certsDer, usage: .mdocReaderAuth, rootIaca: iacaRoots)
+        return isValid
+    }
+}


### PR DESCRIPTION
Add support for issuer metadata policy. Upgrade the `eudi-lib-ios-siop-openid4vp-swift` dependency to version 0.33.0 and address an issue with the authorization signature handling in the OpenID4VP service.