### PR TITLE
Make issuer metadata policy configurable via EudiWalletConfiguration

### DIFF
--- a/Sources/EudiWalletKit/EudiWallet.swift
+++ b/Sources/EudiWalletKit/EudiWallet.swift
@@ -168,7 +168,7 @@ public final class EudiWallet: ObservableObject, @unchecked Sendable {
 
 	/// Register an OpenId4VCI service with a given name and configuration.
 	@discardableResult func registerOpenId4VciService(name: String, config: OpenId4VciConfiguration) throws -> OpenId4VciService {
-		let vciService = try OpenId4VciService(uiCulture: eudiWalletConfig.uiCulture, config: config, networking: self.networkingVci, storage: storage, storageService: storage.storageService, transactionLogger: transactionLogger)
+		let vciService = try OpenId4VciService(uiCulture: eudiWalletConfig.uiCulture, config: config, networking: self.networkingVci, storage: storage, storageService: storage.storageService, transactionLogger: transactionLogger, issuerMetadataPolicy: eudiWalletConfig.issuerMetadataPolicy)
 		OpenId4VCIServiceRegistry.shared.register(name: name, service: vciService)
 		return vciService
 	}
@@ -274,7 +274,7 @@ public final class EudiWallet: ObservableObject, @unchecked Sendable {
 	///   - uriOffer: url with offer
 	/// - Returns: Offered issue information model
 	public func resolveOfferUrlDocTypes(offerUri: String, authFlowRedirectionURI: URL?) async throws -> OfferedIssuanceModel {
-		let result = await CredentialOfferRequestResolver(fetcher: Fetcher<CredentialOfferRequestObject>(session: networkingVci), credentialIssuerMetadataResolver: OpenId4VciService.makeMetadataResolver(networkingVci), authorizationServerMetadataResolver: AuthorizationServerMetadataResolver(oidcFetcher: Fetcher<OIDCProviderMetadata>(session: networkingVci), oauthFetcher: Fetcher<AuthorizationServerMetadata>(session: networkingVci))).resolve(source: try .init(urlString: offerUri), policy: .ignoreSigned)
+		let result = await CredentialOfferRequestResolver(fetcher: Fetcher<CredentialOfferRequestObject>(session: networkingVci), credentialIssuerMetadataResolver: OpenId4VciService.makeMetadataResolver(networkingVci), authorizationServerMetadataResolver: AuthorizationServerMetadataResolver(oidcFetcher: Fetcher<OIDCProviderMetadata>(session: networkingVci), oauthFetcher: Fetcher<AuthorizationServerMetadata>(session: networkingVci))).resolve(source: try .init(urlString: offerUri), policy: eudiWalletConfig.issuerMetadataPolicy)
 		switch result {
 		case .success(let offer):
 			let credentialIssuerIdentifier = offer.credentialIssuerIdentifier
@@ -299,7 +299,7 @@ public final class EudiWallet: ObservableObject, @unchecked Sendable {
 	///  - configuration: Optional OpenId4VciConfiguration to override the default one for this issuance
 	/// - Returns: Array of issued and stored documents
 	public func issueDocumentsByOfferUrl(offerUri: String, docTypes: [OfferedDocModel], txCodeValue: String? = nil, promptMessage: String? = nil, configuration: OpenId4VciConfiguration? = nil) async throws -> [WalletStorage.Document] {
-		let result = await CredentialOfferRequestResolver(fetcher: Fetcher<CredentialOfferRequestObject>(session: networkingVci), credentialIssuerMetadataResolver: OpenId4VciService.makeMetadataResolver(networkingVci), authorizationServerMetadataResolver: AuthorizationServerMetadataResolver(oidcFetcher: Fetcher<OIDCProviderMetadata>(session: networkingVci), oauthFetcher: Fetcher<AuthorizationServerMetadata>(session: networkingVci))).resolve(source: try .init(urlString: offerUri), policy: .ignoreSigned)
+		let result = await CredentialOfferRequestResolver(fetcher: Fetcher<CredentialOfferRequestObject>(session: networkingVci), credentialIssuerMetadataResolver: OpenId4VciService.makeMetadataResolver(networkingVci), authorizationServerMetadataResolver: AuthorizationServerMetadataResolver(oidcFetcher: Fetcher<OIDCProviderMetadata>(session: networkingVci), oauthFetcher: Fetcher<AuthorizationServerMetadata>(session: networkingVci))).resolve(source: try .init(urlString: offerUri), policy: eudiWalletConfig.issuerMetadataPolicy)
 		switch result {
 		case .success(let offer):
 			let urlString = offer.credentialIssuerIdentifier.url.absoluteString

--- a/Sources/EudiWalletKit/Models/EudiWalletConfiguration.swift
+++ b/Sources/EudiWalletKit/Models/EudiWalletConfiguration.swift
@@ -17,6 +17,7 @@ limitations under the License.
 import Foundation
 import MdocDataModel18013
 import MdocSecurity18013
+import OpenID4VCI
 
 /// Configuration for EudiWallet
 public struct EudiWalletConfiguration: Sendable {
@@ -34,9 +35,15 @@ public struct EudiWalletConfiguration: Sendable {
 	public let uiCulture: String?
 	/// If not-nil, logging to the specified log file name will be configured
 	public let logFileName: String?
+	/// Policy for handling signed issuer metadata fetched from `/.well-known/openid-credential-issuer`.
+	///
+	/// - `.ignoreSigned` (default): wallet sends `Accept: application/json` and only accepts plain JSON metadata. Backwards-compatible with all existing deployments.
+	/// - `.preferSigned(issuerTrust:)`: wallet sends `Accept: application/jwt, application/json`. If the issuer returns a signed JWT, the signature is verified against the supplied trust anchor; otherwise plain JSON is accepted as a fallback.
+	/// - `.requireSigned(issuerTrust:)`: wallet sends `Accept: application/jwt`. The issuer must return a signed JWT whose signature validates against the supplied trust anchor; plain JSON responses are rejected.
+	public let issuerMetadataPolicy: IssuerMetadataPolicy
 	static let defaultServiceName: String = "eudiw"
 
-	public init(serviceName: String? = nil, accessGroup: String? = nil, userAuthenticationRequired: Bool = false, trustedReaderRootCertificates: [x5chain]? = nil, deviceAuthMethod: DeviceAuthMethod = .deviceSignature, uiCulture: String? = nil, logFileName: String? = nil) {
+	public init(serviceName: String? = nil, accessGroup: String? = nil, userAuthenticationRequired: Bool = false, trustedReaderRootCertificates: [x5chain]? = nil, deviceAuthMethod: DeviceAuthMethod = .deviceSignature, uiCulture: String? = nil, logFileName: String? = nil, issuerMetadataPolicy: IssuerMetadataPolicy = .ignoreSigned) {
 		self.serviceName = serviceName ?? Self.defaultServiceName
 		self.accessGroup = accessGroup
         self.userAuthenticationRequired = userAuthenticationRequired
@@ -44,5 +51,6 @@ public struct EudiWalletConfiguration: Sendable {
 		self.deviceAuthMethod = deviceAuthMethod
 		self.uiCulture = uiCulture
 		self.logFileName = logFileName
+		self.issuerMetadataPolicy = issuerMetadataPolicy
 	}
 }

--- a/Sources/EudiWalletKit/Services/OpenId4VciService.swift
+++ b/Sources/EudiWalletKit/Services/OpenId4VciService.swift
@@ -42,6 +42,9 @@ public actor OpenId4VciService {
 	let uiCulture: String?
 	let logger: Logger
 	var config: OpenId4VciConfiguration
+	/// Policy used when fetching `/.well-known/openid-credential-issuer`.
+	/// Wallet-wide setting injected from `EudiWalletConfiguration.issuerMetadataPolicy`.
+	let issuerMetadataPolicy: IssuerMetadataPolicy
 	static nonisolated(unsafe) var credentialOfferCache = [String: CredentialOffer]()
 	static nonisolated(unsafe) var issuerMetadataCache = [String: (CredentialIssuerId, CredentialIssuerMetadata)]()
 	var networking: Networking
@@ -53,7 +56,7 @@ public actor OpenId4VciService {
 	@MainActor var simpleAuthWebContext: SimpleAuthenticationPresentationContext!
 	typealias FuncKeyAttestationJWT = @Sendable (_ nonce: String?) async throws -> KeyAttestationJWT
 
-	init(uiCulture: String?, config: OpenId4VciConfiguration, networking: Networking, storage: StorageManager, storageService: any DataStorageService, transactionLogger: (any TransactionLogger)? = nil) throws {
+	init(uiCulture: String?, config: OpenId4VciConfiguration, networking: Networking, storage: StorageManager, storageService: any DataStorageService, transactionLogger: (any TransactionLogger)? = nil, issuerMetadataPolicy: IssuerMetadataPolicy = .ignoreSigned) throws {
 		logger = Logger(label: "OpenId4VCI")
 		guard config.credentialIssuerURL != nil else { throw PresentationSession.makeError(str: "credentialIssuerURL must be set in OpenId4VciConfiguration") }
 		self.uiCulture = uiCulture
@@ -62,6 +65,7 @@ public actor OpenId4VciService {
 		self.storageService = storageService
 		self.config = config
 		self.transactionLogger = transactionLogger
+		self.issuerMetadataPolicy = issuerMetadataPolicy
 	}
 
 	/// Prepare issuing by creating an issue request (id, private key) and an OpenId4VCI service instance
@@ -153,7 +157,7 @@ public actor OpenId4VciService {
 	}
 
 	public func resolveOfferUrlDocTypes(offerUri: String) async throws -> OfferedIssuanceModel {
-		let result = await CredentialOfferRequestResolver(fetcher: Fetcher<CredentialOfferRequestObject>(session: networking), credentialIssuerMetadataResolver: Self.makeMetadataResolver(networking), authorizationServerMetadataResolver: AuthorizationServerMetadataResolver(oidcFetcher: Fetcher<OIDCProviderMetadata>(session: networking), oauthFetcher: Fetcher<AuthorizationServerMetadata>(session: networking))).resolve(source: try .init(urlString: offerUri), policy: .ignoreSigned)
+		let result = await CredentialOfferRequestResolver(fetcher: Fetcher<CredentialOfferRequestObject>(session: networking), credentialIssuerMetadataResolver: Self.makeMetadataResolver(networking), authorizationServerMetadataResolver: AuthorizationServerMetadataResolver(oidcFetcher: Fetcher<OIDCProviderMetadata>(session: networking), oauthFetcher: Fetcher<AuthorizationServerMetadata>(session: networking))).resolve(source: try .init(urlString: offerUri), policy: issuerMetadataPolicy)
 		switch result {
 		case .success(let offer):
 			return try await resolveOfferDocTypes(offerUri: offerUri, offer: offer)
@@ -197,7 +201,7 @@ public actor OpenId4VciService {
 
 	public func getIssuerMetadata() async throws -> CredentialIssuerMetadata {
 		let credentialIssuerIdentifier = try CredentialIssuerId(config.credentialIssuerURL!)
-		let issuerMetadata = try await Self.makeMetadataResolver(networking).resolve(source: .credentialIssuer(credentialIssuerIdentifier), policy: .ignoreSigned)
+		let issuerMetadata = try await Self.makeMetadataResolver(networking).resolve(source: .credentialIssuer(credentialIssuerIdentifier), policy: issuerMetadataPolicy)
 		switch issuerMetadata {
 			case .success(let metaData): return metaData
 			case .failure(let error):
@@ -290,7 +294,7 @@ public actor OpenId4VciService {
 			return cachedResult
 		}
 		let credentialIssuerIdentifier = try CredentialIssuerId(config.credentialIssuerURL!)
-		let issuerMetadata = try await Self.makeMetadataResolver(networking).resolve(source: .credentialIssuer(credentialIssuerIdentifier), policy: .ignoreSigned)
+		let issuerMetadata = try await Self.makeMetadataResolver(networking).resolve(source: .credentialIssuer(credentialIssuerIdentifier), policy: issuerMetadataPolicy)
 		switch issuerMetadata {
 		case .success(let metaData):
 			let result = (credentialIssuerIdentifier, metaData)


### PR DESCRIPTION
## Summary

Exposes `IssuerMetadataPolicy` as a configurable field on `EudiWalletConfiguration`, allowing wallets to opt into signed issuer metadata validation as defined by the OpenID4VCI specification. **Fully backwards-compatible** — the default remains `.ignoreSigned` and every existing caller compiles and behaves identically.

## Motivation

`IssuerMetadataPolicy` was hardcoded to `.ignoreSigned` at five call sites across `EudiWallet` and `OpenId4VciService`. The underlying SDK (`eudi-lib-ios-openid4vci-swift`) already supports `.preferSigned` and `.requireSigned` policies with `IssuerTrust` anchoring (by JWK or certificate chain), but wallets had no way to consume those policies through `eudi-lib-ios-wallet-kit`. Surfacing the policy as configuration brings the iOS wallet kit on par with the equivalent Android SDK and lets integrators move from `.ignoreSigned` (acceptable for pilots) to `.preferSigned` / `.requireSigned` (required for production deployments).

## Changes

Three files modified, ~24 insertions / 8 deletions:

- `Models/EudiWalletConfiguration.swift` — new `issuerMetadataPolicy: IssuerMetadataPolicy` field with `.ignoreSigned` default; adds `import OpenID4VCI`.
- `Services/OpenId4VciService.swift` — new actor property `issuerMetadataPolicy`, init parameter with `.ignoreSigned` default; replaces three hardcoded `.ignoreSigned` literals at metadata fetch sites (`resolveOfferUrlDocTypes`, both cached and uncached paths of `getIssuerMetadata`).
- `EudiWallet.swift` — passes `eudiWalletConfig.issuerMetadataPolicy` into `OpenId4VciService` at registration; replaces two hardcoded `.ignoreSigned` literals at offer-URL resolution sites (`resolveOfferUrlDocTypes`, `issueDocumentsByOfferUrl`).

## Backwards compatibility — no breaking changes

Both new init parameters are added at the **end** of their respective signatures with `.ignoreSigned` as the **default value**:

- `EudiWalletConfiguration(serviceName:..., issuerMetadataPolicy: .ignoreSigned)`
- `OpenId4VciService(uiCulture:..., transactionLogger:..., issuerMetadataPolicy: .ignoreSigned)`

Every existing call site compiles unchanged. Every existing call site observes identical runtime behavior. No public type, method, or property is renamed, removed, or moved. The change is purely additive.

This means downstream wallets that consume the SDK pinned to a previous version can upgrade to this version without any code modification — they simply gain access to the new field if/when they want to use it.

## Usage example

```swift
let trust: CertificateChainTrust = MyChainValidator(roots: bundledIacaRoots)
let config = EudiWalletConfiguration(
    serviceName: "my_wallet",
    trustedReaderRootCertificates: bundledIacaRoots,
    issuerMetadataPolicy: .preferSigned(
        issuerTrust: .byCertificateChain(certificateChainTrust: trust)
    )
)
let wallet = try EudiWallet(eudiWalletConfig: config, ...)
```

## Testing

Verified against three live OpenID4VCI issuers covering different trust topologies. All three flows tested with `.preferSigned` + `IssuerTrust.byCertificateChain` against a `SecTrust`-based `CertificateChainTrust` implementation, anchoring on the certificates bundled with the wallet:

| Issuer | Topology | Trust anchor in bundle | Outcome |
|---|---|---|---|
| `issuer.eudiw.dev` (EUDI reference) | Two-tier — DSC `CN=PID DS - 03` chains to `CN=PID Issuer CA - UT 02` | `pidissuerca02_ut.der` (bundled IACA root) | Signed metadata validates and is accepted |
| `issuer-backend.eudiw.dev` (EUDI reference) | Two-tier — DSC `CN=PID DS - 04` chains to the same `CN=PID Issuer CA - UT 02` | `pidissuerca02_ut.der` (same bundled root) | Signed metadata validates and is accepted |
| A third-party issuer outside the EUDI reference deployment | Single-tier — self-signed metadata signing certificate, no CA hierarchy | The self-signed certificate itself, bundled directly as a trust anchor | Signed metadata validates and is accepted |

The third-party case is meaningful because it demonstrates that `IssuerTrust.byCertificateChain` works for issuers that don't operate a multi-tier PKI, in addition to issuers that do. Both topologies are valid uses of the policy.

End-to-end flow exercised in all three cases: wallet sends `Accept: application/jwt, application/json`, issuer responds with `Content-Type: application/jwt`, SDK extracts `x5c` from the JWT header, the wallet's `CertificateChainTrust` implementation validates via `SecTrust` against bundled roots, metadata is accepted, the document picker renders normally.

Plain JSON fallback also tested: issuers that don't yet support signed metadata respond with `Content-Type: application/json` and the wallet accepts the unsigned response per `.preferSigned` semantics — proving the gradual-rollout case where some issuers in the same wallet support signed metadata and others don't.

**Regression test against the default behavior:** with `.ignoreSigned` (the default, unchanged from before this PR), behavior is identical to the pre-change implementation. Existing test suites pass without modification.

## Notes

The change is the minimum needed to expose the existing capability. It does not modify any validation logic, content negotiation, or signature verification — those continue to live in `eudi-lib-ios-openid4vci-swift` and are reached unchanged by this plumbing.
