### PR TITLE
Update the `eudi-lib-ios-openid4vci-swift` dependency to version 0.38.0 

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ab8ac1a97b9701380427a13a491dde2f8499bc03e2fbd9b4d96ab18b5147e7c9",
+  "originHash" : "013bcef92599f1466c4fc23bcc26b31da0aad37f2163da68643992064d0a9289",
   "pins" : [
     {
       "identity" : "cryptoswift",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git",
       "state" : {
-        "revision" : "eaced81de7af032de50cce9425259a23221f241a",
-        "version" : "0.36.2"
+        "revision" : "b2e50b28733f3491c0e82067fe5b22c7e2992a10",
+        "version" : "0.38.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git", exact: "0.11.3"),
     	.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift.git", exact: "0.14.1"),
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git", exact: "0.36.2"),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git", exact: "0.38.0"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-siop-openid4vp-swift.git", exact: "0.33.0"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-statium-swift.git", exact: "0.4.0"),
 	],

--- a/README.md
+++ b/README.md
@@ -546,7 +546,8 @@ The [presentation service protocol](https://eu-digital-identity-wallet.github.io
 
 ### BLE Transfer Mode
 
-The `bleTransferMode` property of `EudiWalletConfiguration` controls the Bluetooth Low Energy role the holder device plays during proximity presentation:
+The `bleTransferMode` property of `EudiWallet` controls the Bluetooth Low Energy role the holder device plays during proximity presentation.
+Set it in `EudiWalletConfiguration` at initialization time, or update it on the wallet instance before starting BLE presentation:
 
 | Mode | Description |
 |------|-------------|
@@ -560,6 +561,8 @@ let config = EudiWalletConfiguration(
     trustedReaderCertificates: [Data(name: "eudi_pid_issuer_ut", ext: "der")!],
     bleTransferMode: .server  // default
 )
+let wallet = try! EudiWallet(eudiWalletConfig: config)
+wallet.bleTransferMode = .client
 ```
 
 ```swift

--- a/Sources/EudiWalletKit/EudiWallet.swift
+++ b/Sources/EudiWalletKit/EudiWallet.swift
@@ -49,6 +49,8 @@ public final class EudiWallet: ObservableObject, @unchecked Sendable {
 	let networkingVp: OpenID4VPNetworking
 	/// Optional model factory type to create custom stronly-typed models
 	public private(set) var modelFactory: (any DocClaimsDecodableFactory)?
+	/// Ble transfer mode
+	public var bleTransferMode: BleTransferMode = .server
 	public var zkSystemRepository: ZkSystemRepository?
 	//public static let defaultOpenId4VCIConfig =
 	/// Initialize a wallet instance using a configuration object.
@@ -61,6 +63,7 @@ public final class EudiWallet: ObservableObject, @unchecked Sendable {
 	///   - secureAreas: An array of secure areas. Optional.
 	///   - transactionLogger: Transaction logger for logging wallet operations. Optional.
 	///   - modelFactory: The factory for creating Mdoc models. Optional.
+	///   - zkSystemRepository: Repository for zk system parameters. Optional.
 	///
 	/// - Throws: An error if initialization fails.
 	///
@@ -79,6 +82,7 @@ public final class EudiWallet: ObservableObject, @unchecked Sendable {
 		let storageServiceObj = storageService ?? KeyChainStorageService(serviceName: self.eudiWalletConfig.serviceName, accessGroup: self.eudiWalletConfig.accessGroup)
 		self.modelFactory = modelFactory
 		self.zkSystemRepository = zkSystemRepository
+		self.bleTransferMode = eudiWalletConfig.bleTransferMode
 		storage = StorageManager(storageService: storageServiceObj, modelFactory: modelFactory)
 		if let secureAreas, !secureAreas.isEmpty {
 			for asa in secureAreas { SecureAreaRegistry.shared.register(secureArea: asa) }
@@ -557,7 +561,7 @@ public final class EudiWallet: ObservableObject, @unchecked Sendable {
 			let docIdToPresentInfo = try await storage.getDocIdsToPresentInfo(documents: documents)
 			switch flow {
 			case .ble:
-				let bleSvc = try await BlePresentationService(parameters: parameters, bleTransferMode: eudiWalletConfig.bleTransferMode)
+				let bleSvc = try await BlePresentationService(parameters: parameters, bleTransferMode: bleTransferMode)
 				return PresentationSession(presentationService: bleSvc, storageManager: storage, storageService: storage.storageService, docIdToPresentInfo: docIdToPresentInfo, documentKeyIndexes: parameters.documentKeyIndexes, userAuthenticationRequired: eudiWalletConfig.userAuthenticationRequired, transactionLogger: sessionTransactionLogger ?? transactionLogger)
 			case .openid4vp(let qrCode):
 				let openIdSvc = try await OpenId4VpService(parameters: parameters, qrCode: qrCode, openID4VpConfig: self.openID4VpConfig, networking: networkingVp)

--- a/Sources/EudiWalletKit/EudiWalletKit.docc/GetStarted.md
+++ b/Sources/EudiWalletKit/EudiWalletKit.docc/GetStarted.md
@@ -32,7 +32,8 @@ The ``EudiWallet`` class provides a unified API for the two user attestation pre
 
 ### BLE Transfer Mode
 
-The `bleTransferMode` parameter of ``EudiWalletConfiguration`` controls the Bluetooth Low Energy role used during proximity (ISO 18013-5) presentation:
+The ``EudiWallet/bleTransferMode`` property controls the Bluetooth Low Energy role used during proximity (ISO 18013-5) presentation.
+You can set it during initialization via ``EudiWalletConfiguration/bleTransferMode`` or update it later on the wallet instance:
 
 - **`.server`** (default): The holder device acts as a GATT peripheral (server), advertising and waiting for the reader to connect.
 - **`.client`**: The holder device acts as a GATT central (client), scanning and connecting to the reader's peripheral.
@@ -45,6 +46,7 @@ let config = EudiWalletConfiguration(
     bleTransferMode: .server  // default; use .client or .both as needed
 )
 let wallet = try! EudiWallet(eudiWalletConfig: config)
+wallet.bleTransferMode = .client
 ```
 
 ### OpenID4VCI Configuration

--- a/Sources/EudiWalletKit/EudiWalletKit.docc/PresentationService.md
+++ b/Sources/EudiWalletKit/EudiWalletKit.docc/PresentationService.md
@@ -12,7 +12,8 @@ ShareView(presentationSession: session)
 
 ## BLE Transfer Mode
 
-For proximity presentation over BLE, the ``EudiWalletConfiguration/bleTransferMode`` property controls the role the holder device plays during BLE data transfer:
+For proximity presentation over BLE, the ``EudiWallet/bleTransferMode`` property controls the role the holder device plays during BLE data transfer.
+Set it through ``EudiWalletConfiguration/bleTransferMode`` during initialization, or change it on the wallet instance before starting a BLE presentation:
 
 - **`.server`** (default): The holder device acts as a GATT peripheral (server). It advertises and waits for the reader to connect.
 - **`.client`**: The holder device acts as a GATT central (client). It scans and connects to the reader's peripheral.
@@ -24,6 +25,7 @@ let config = EudiWalletConfiguration(
     bleTransferMode: .server  // default
 )
 let wallet = try! EudiWallet(eudiWalletConfig: config)
+wallet.bleTransferMode = .both
 ```
 
 ```swift

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ### BLE Transfer Mode
 
-The `bleTransferMode` parameter of ``EudiWalletConfiguration`` controls the Bluetooth Low Energy (BLE) role used during proximity (ISO 18013-5) presentation:
+The `bleTransferMode` property on ``EudiWallet`` controls the Bluetooth Low Energy (BLE) role used during proximity (ISO 18013-5) presentation. It can be set through ``EudiWalletConfiguration/bleTransferMode`` during initialization:
 
 - **`.server`** (default): The holder device acts as a GATT peripheral (server), advertising and waiting for the reader to connect.
 - **`.client`**: The holder device acts as a GATT central (client), scanning and connecting to the reader's peripheral.

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,11 @@
+## v0.29.1
+The `bleTransferMode` property on ``EudiWallet`` controls the Bluetooth Low Energy (BLE) role used during proximity (ISO 18013-5) presentation. It can be set through ``EudiWalletConfiguration/bleTransferMode`` during initialization
+
 ## v0.29.0
 
 ### BLE Transfer Mode
 
-The `bleTransferMode` property on ``EudiWallet`` controls the Bluetooth Low Energy (BLE) role used during proximity (ISO 18013-5) presentation. It can be set through ``EudiWalletConfiguration/bleTransferMode`` during initialization:
+You can specify ``EudiWalletConfiguration/bleTransferMode`` during initialization:
 
 - **`.server`** (default): The holder device acts as a GATT peripheral (server), advertising and waiting for the reader to connect.
 - **`.client`**: The holder device acts as a GATT central (client), scanning and connecting to the reader's peripheral.


### PR DESCRIPTION
Update the `eudi-lib-ios-openid4vci-swift` dependency to version 0.38.0 and enhance the documentation and implementation of the BLE transfer mode in the `EudiWallet` class. Clarifications added to the changelog regarding the usage of the `bleTransferMode` property.