### PR TITLE
Download credential display images at issuance time

### DIFF
--- a/Sources/EudiWalletKit/Extensions.swift
+++ b/Sources/EudiWalletKit/Extensions.swift
@@ -218,6 +218,48 @@ extension DocMetadata {
 		guard let claims else { return (nil, nil, nil, nil, nil, nil) }
 		return (getDisplayName(uiCulture), display, issuerDisplay, credentialIssuerIdentifier: credentialIssuerIdentifier, configurationIdentifier: configurationIdentifier,  claims)
 	}
+
+	/// Downloads all remote images referenced in the credential `display` metadata and replaces their
+	/// URLs with inline `data:` URIs. This prevents issuers from learning when a user views a credential
+	/// (privacy) and eliminates network latency at display time. URLs that cannot be fetched are left unchanged.
+	func downloadingDisplayImages() async -> DocMetadata {
+		guard let display, display.contains(where: { $0.backgroundImageURL != nil || $0.logo?.urlString != nil }) else { return self }
+		let downloadedDisplay = await withTaskGroup(of: DisplayMetadata.self) { group in
+			for dm in display { group.addTask { await dm.downloadingImages() } }
+			var result: [DisplayMetadata] = []
+			for await dm in group { result.append(dm) }
+			return result
+		}
+		return DocMetadata(credentialIssuerIdentifier: credentialIssuerIdentifier, configurationIdentifier: configurationIdentifier, docType: docType, display: downloadedDisplay, issuerDisplay: issuerDisplay, claims: claims, authorizedRequestData: authorizedRequestData, keyOptions: keyOptions, credentialOptions: credentialOptions, dpopKeyId: dpopKeyId)
+	}
+}
+
+extension DisplayMetadata {
+	/// Returns a copy of this `DisplayMetadata` with any http(s) image URLs replaced by inline `data:` URIs.
+	func downloadingImages() async -> DisplayMetadata {
+		async let newBgURL = Self.fetchAsDataURI(urlString: backgroundImageURL)
+		async let newLogoURL = Self.fetchAsDataURI(urlString: logo?.urlString)
+		let (fetchedBg, fetchedLogo) = await (newBgURL, newLogoURL)
+		let newLogo = logo.map { LogoMetadata(urlString: fetchedLogo ?? $0.urlString, alternativeText: $0.alternativeText) }
+		return DisplayMetadata(name: name, localeIdentifier: localeIdentifier, logo: newLogo, description: description, backgroundColor: backgroundColor, textColor: textColor, backgroundImageURL: fetchedBg ?? backgroundImageURL)
+	}
+
+	/// Downloads data from `urlString` (http/https only) and encodes it as a `data:` URI.
+	/// Returns `nil` if the URL is already a data URI, is `nil`, is non-http, or the download fails.
+	private static func fetchAsDataURI(urlString: String?) async -> String? {
+		guard let urlString else { return nil }
+		// Already a data URI – nothing to do
+		if urlString.lowercased().hasPrefix("data:") { return nil }
+		guard let url = URL(string: urlString), url.scheme == "https" || url.scheme == "http" else { return nil }
+		do {
+			let (data, response) = try await URLSession.shared.data(from: url)
+			let mimeType = (response as? HTTPURLResponse)?.mimeType ?? "application/octet-stream"
+			return "data:\(mimeType);base64,\(data.base64EncodedString())"
+		} catch {
+			logger.warning("Failed to download display image from \(urlString): \(error.localizedDescription)")
+			return nil
+		}
+	}
 }
 
 extension DocKeyInfo {

--- a/Sources/EudiWalletKit/Services/OpenId4VciService.swift
+++ b/Sources/EudiWalletKit/Services/OpenId4VciService.swift
@@ -819,6 +819,8 @@ public actor OpenId4VciService {
 				docTypeToSave = docType ?? "PENDING"
 				displayName = pendingAuthModel.configuration.display.getName(uiCulture)
 			}
+			// Download credential display images eagerly at issuance time.
+			docMetadata = await docMetadata.downloadingDisplayImages()
 			let newDocStatus: WalletStorage.DocumentStatus = issueOutcome.isDeferred ? .deferred : (issueOutcome.isPending ? .pending : .issued)
 			let newDocument = WalletStorage.Document(id: issueReq.id, docType: docTypeToSave, docDataFormat: format, data: dataToSave, docKeyInfo: dkInfo.toData(), createdAt: Date(), metadata: docMetadata.toData(), displayName: displayName, status: newDocStatus)
 			if newDocStatus == .pending { await storage.appendDocModel(newDocument, uiCulture: uiCulture); return newDocument }

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,14 @@
+## v0.29.4
+### Credential Display Images Downloaded at Issuance Time
+- Credential background images (`backgroundImageURL`) and logo images referenced in display metadata are downloaded and stored as inline data URIs.
+- This prevents the issuer from observing when a user opens their wallet or views a credential (privacy improvement) and eliminates any network latency at viewing time. If an image download fails, the original URL is preserved.
+
+## v0.29.3
+- Fixes display of portrait image in SD-JWT when it is base64-data-url
+
+## v0.29.2
+- Enhance token refresh handling in authorization and document issuance
+
 ## v0.29.1
 The `bleTransferMode` property on ``EudiWallet`` controls the Bluetooth Low Energy (BLE) role used during proximity (ISO 18013-5) presentation. It can be set through ``EudiWalletConfiguration/bleTransferMode`` during initialization
 


### PR DESCRIPTION
Credential background images and logos are now downloaded and stored as inline data URIs during the issuance process. This change enhances user privacy by preventing issuers from tracking when a user views a credential and eliminates network latency at display time. If an image download fails, the original URL is preserved.

Fixes #348