### PR TITLE
Refactor QR engagement method and update dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "413a8fc27b4ce5d5a8e2b97797c0745ee8487bec46516629c3d5908053aaa9ea",
+  "originHash" : "87b33ca51b82e26617d205f2c48f6e930434e4631936904b2bce151c269617f6",
   "pins" : [
     {
       "identity" : "cryptoswift",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git",
       "state" : {
-        "revision" : "8314b68ba9d5107076e73d1914d2843ec0003af4",
-        "version" : "0.20.0"
+        "revision" : "c72b2e622f987565927b67e67b754779df7b7e84",
+        "version" : "0.20.1"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git",
       "state" : {
-        "revision" : "3a5c2849ae151862ba9e9c80c93356783bcbc16e",
-        "version" : "0.20.1"
+        "revision" : "db189efd904e706e9483f53c350e642161ea84be",
+        "version" : "0.20.2"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-security.git",
       "state" : {
-        "revision" : "4337ad921a0f27f7e737fb318d374c078dcd8702",
-        "version" : "0.20.1"
+        "revision" : "9e200d0931ecb14e20bff61b3fee2533d8cadb90",
+        "version" : "0.20.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
 			targets: ["EudiWalletKit"])
 	],
 	dependencies: [
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git", exact: "0.20.1"),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git", exact: "0.20.2"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git", exact: "0.20.1"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift.git", exact: "0.14.3"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git", exact: "0.38.2"),

--- a/Sources/EudiWalletKit/Services/BlePresentationService.swift
+++ b/Sources/EudiWalletKit/Services/BlePresentationService.swift
@@ -76,7 +76,7 @@ public final class BlePresentationService: @unchecked Sendable, PresentationServ
 	// Create a new device engagement object and start the device engagement process.
 	///
 	/// ``qrCodePayload`` is set to QR code data corresponding to the device engagement.
-	public func performDeviceEngagement(secureArea: any SecureArea, crv: CoseEcCurve, rfus: [String]? = nil) async throws {
+	public func performDeviceEngagement(secureArea: any SecureArea, keyOptions: KeyOptions, rfus: [String]? = nil) async throws {
 		if unlockData == nil {
 			unlockData = [String: Data]()
 			for (id, key) in privateKeyObjects {
@@ -98,7 +98,7 @@ public final class BlePresentationService: @unchecked Sendable, PresentationServ
 			throw MdocHelpers.makeError(code: .invalidInputDocument)
 		}
 		deviceEngagement = DeviceEngagement(supportsCentralClientMode: bleTransferMode == .client || bleTransferMode == .both, supportsPeripheralServerMode: bleTransferMode == .server || bleTransferMode == .both, rfus: rfus)
-		try await deviceEngagement!.makePrivateKey(crv: crv, secureArea: secureArea)
+		try await deviceEngagement!.makePrivateKey(secureArea: secureArea, keyOptions: keyOptions)
 		sessionEncryption = nil
 #if os(iOS)
 		qrCodePayload = deviceEngagement!.getQrCodePayload()
@@ -123,8 +123,8 @@ public final class BlePresentationService: @unchecked Sendable, PresentationServ
 
 	/// The holder app should present the returned code to the verifier
 	/// - Returns: The image data for the QR code
-	public func startQrEngagement(secureAreaName: String?, crv: CoseEcCurve) async throws -> String {
-		try await performDeviceEngagement(secureArea: SecureAreaRegistry.shared.get(name: secureAreaName), crv: crv)
+	public func startQrEngagement(secureAreaName: String?, keyOptions: KeyOptions) async throws -> String {
+		try await performDeviceEngagement(secureArea: SecureAreaRegistry.shared.get(name: secureAreaName), keyOptions: keyOptions)
 		return status == .qrEngagementReady ? (qrCodePayload ?? "") : ""
 	}
 

--- a/Sources/EudiWalletKit/Services/FaultPresentationService.swift
+++ b/Sources/EudiWalletKit/Services/FaultPresentationService.swift
@@ -39,7 +39,7 @@ public final class FaultPresentationService: @unchecked Sendable, PresentationSe
 		TransactionLogUtils.setErrorTransactionLog(type: .presentation, error: error, transactionLog: &transactionLog)
 	}
 
-	public func startQrEngagement(secureAreaName: String?, crv: CoseEcCurve) async throws -> String {
+	public func startQrEngagement(secureAreaName: String?, keyOptions: KeyOptions) async throws -> String {
 		throw error
 	}
 

--- a/Sources/EudiWalletKit/Services/OpenId4VpService.swift
+++ b/Sources/EudiWalletKit/Services/OpenId4VpService.swift
@@ -83,7 +83,7 @@ public final class OpenId4VpService: @unchecked Sendable, PresentationService {
 		transactionLog = TransactionLogUtils.initializeTransactionLog(type: .presentation, dataFormat: .json)
 	}
 
-	public func startQrEngagement(secureAreaName: String?, crv: CoseEcCurve) async throws -> String {
+	public func startQrEngagement(secureAreaName: String?, keyOptions: KeyOptions) async throws -> String {
 		if unlockData == nil {
 			unlockData = [String: Data]()
 			for (id, key) in transferInfo.privateKeyObjects {
@@ -241,7 +241,7 @@ public final class OpenId4VpService: @unchecked Sendable, PresentationService {
 		}
 		zkpDocumentIds = [String]()
 		logger.info("Openid4vp request items: \(itemsToSend.mapValues { $0.mapValues { ar in ar.map(\.elementIdentifier) } })")
-		if unlockData == nil { _ = try await startQrEngagement(secureAreaName: nil, crv: .P256) }
+		if unlockData == nil { _ = try await startQrEngagement(secureAreaName: nil, keyOptions: KeyOptions(curve: .P256)) }
 		// tuples of inputDescriptor-id, docId and verifiable presentation
 		// the inputDescriptor-id is used to identify the input descriptor in the presentation submission
 		var inputToPresentations = [(String, String?, VerifiablePresentation)]()

--- a/Sources/EudiWalletKit/Services/PresentationService.swift
+++ b/Sources/EudiWalletKit/Services/PresentationService.swift
@@ -30,7 +30,7 @@ public protocol PresentationService: Sendable {
 	/// instance of a presentation ``FlowType``
 	var flow: FlowType { get }
 	/// Generate a QR code to be shown to verifier (optional)
-	func startQrEngagement(secureAreaName: String?, crv: CoseEcCurve) async throws -> String
+	func startQrEngagement(secureAreaName: String?, keyOptions: KeyOptions) async throws -> String
 	/// Receive request.
 	func receiveRequest() async throws -> UserRequestInfo
 

--- a/Sources/EudiWalletKit/Services/PresentationSession.swift
+++ b/Sources/EudiWalletKit/Services/PresentationSession.swift
@@ -132,7 +132,7 @@ public final class PresentationSession: @unchecked Sendable, ObservableObject {
 		// TODO: localizationKey is kept for backward compatibility — clients can migrate to use `code` instead
 		if docIdToPresentInfo.count == 0 { await setError(Self.NotAvailableStr, localizationKey: "request_data_no_document", code: .noDocumentsAvailable); return }
 		do {
-			let data = try await presentationService.startQrEngagement(secureAreaName: nil, crv: .P256)
+			let data = try await presentationService.startQrEngagement(secureAreaName: nil, keyOptions: KeyOptions(curve: .P256, accessControl: []))
 			await MainActor.run {
 				deviceEngagement = data
 				status = .qrEngagementReady


### PR DESCRIPTION
Refactor the `startQrEngagement` method to replace the `crv` parameter with `keyOptions`. Update the `eudi-lib-ios-iso18013-data-transfer` dependency to version 0.20.2.