### PR TITLE
fix: preserve WalletError code in receiveRequest error handling

### DIFF
--- a/Sources/EudiWalletKit/Services/PresentationSession.swift
+++ b/Sources/EudiWalletKit/Services/PresentationSession.swift
@@ -172,7 +172,8 @@ public final class PresentationSession: @unchecked Sendable, ObservableObject {
 			try await decodeRequest(request)
 			return request
 		} catch {
-			await setError(error.localizedDescription)
+			let walletError = error as? WalletError
+			await setError(error.localizedDescription, localizationKey: walletError?.localizationKey, code: walletError?.code)
 			return nil
 		}
 	}


### PR DESCRIPTION
## Description

`PresentationSession.receiveRequest()` catches errors from the internal
presentation service and forwards them to `setError()`. Currently it only
passes `error.localizedDescription`, discarding the structured
`WalletError.code` (e.g. `.credentialNotFound`, `.noDocumentsAvailable`).

This prevents clients from programmatically distinguishing error types.
For example, when a verifier requests a credential that is not in the
wallet, the error code is lost and the UI cannot show a specific
"not available" message.

## Changes

- Propagate `WalletError.code` and `localizationKey` to `setError()`
  when the caught error is a `WalletError`.
- No behavioural change for non-`WalletError` errors (network, system, etc.).

## Regression risk

None. When the error is not a `WalletError`, `walletError` is nil and
the extra parameters are nil — identical to the current behaviour.