### PR TITLE
Refactor wallet attestation handling and update dependencies

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6d2a9b29d95897dcf8e4f898059951ec2ed89c7a4d4033a2a65e2416fb6fcae7",
+  "originHash" : "9af981b887f089a79ef9fef1f8f86c5048ae1cace66cc208c22ca1ab3004fa9d",
   "pins" : [
     {
       "identity" : "cryptoswift",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git",
       "state" : {
-        "revision" : "711161de6542cae30213051065c415ad1764036a",
-        "version" : "0.38.3"
+        "revision" : "2491fb8ce5f85193e583b006400af94434e0fcda",
+        "version" : "0.39.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git", exact: "0.20.3"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git", exact: "0.20.1"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift.git", exact: "0.14.4"),
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git", exact: "0.38.3"),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git", exact: "0.39.0"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-siop-openid4vp-swift.git", exact: "0.33.1"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-statium-swift.git", exact: "0.4.0"),
     	.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),

--- a/README.md
+++ b/README.md
@@ -184,9 +184,10 @@ To use attestation-based authentication, implement the `WalletAttestationsProvid
 ```swift
 // Implement the WalletAttestationsProvider protocol
 struct MyAttestationProvider: WalletAttestationsProvider {
-    func getWalletAttestation(key: any JWK) async throws -> String {
+    func getWalletAttestation(signingKey: SigningKeyProxy) async throws -> String {
         // Obtain wallet attestation JWT from your attestation service
-        // The attestation should be bound to the provided public key
+        // Use getPublicJWK() to get the public key bound to the attestation
+        let key = try signingKey.getPublicJWK()
         return try await attestationService.getWalletAttestation(for: key)
     }
     

--- a/Sources/EudiWalletKit/EudiWallet.swift
+++ b/Sources/EudiWalletKit/EudiWallet.swift
@@ -582,7 +582,7 @@ public final class EudiWallet: ObservableObject, @unchecked Sendable {
 		let docMetadata = Dictionary(uniqueKeysWithValues: idsToDocData.map(\.metadata))
 		let idsToDocTypes = Dictionary(uniqueKeysWithValues: docs.map { ($0.id, $0.docType) })
 		let docDisplayNames = Dictionary(uniqueKeysWithValues: docs.map { ($0.id, $0.getClaimDisplayNames(eudiWalletConfig.uiCulture)) })
-		let jwtHashingAlgs = Dictionary(uniqueKeysWithValues: docs.map { ($0.id, StorageManager.getHashingAlgorithm(doc: $0))}).compactMapValues { $0 }
+		let jwtHashingAlgs = Dictionary(uniqueKeysWithValues: docs.map { ($0.id, SdJwtUtils.getHashingAlgorithm(doc: $0))}).compactMapValues { $0 }
 		let iaca = eudiWalletConfig.trustedReaderRootCertificates ?? []
 		let dataFormats = Dictionary(uniqueKeysWithValues: idsToDocData.map(\.fmt))
 		let deviceAuthMethod = eudiWalletConfig.deviceAuthMethod.rawValue

--- a/Sources/EudiWalletKit/Extensions.swift
+++ b/Sources/EudiWalletKit/Extensions.swift
@@ -23,6 +23,9 @@ import WalletStorage
 import SwiftCBOR
 import SwiftyJSON
 import JOSESwift
+import protocol JSONWebAlgorithms.JWKRepresentable
+import struct JSONWebAlgorithms.SecKeyExtended
+import struct JSONWebKey.JWK
 import struct eudi_lib_sdjwt_swift.ClaimPath
 import eudi_lib_sdjwt_swift
 
@@ -448,6 +451,16 @@ extension CoseEcCurve {
 	}
 }
 
+extension ECCurveType {
+	var coseEcCurve: CoseEcCurve {
+		switch self {
+		case .P256: .P256
+		case .P384: .P384
+		case .P521: .P521
+		}
+	}
+}
+
 extension BindingKey {
 
   static func createSigner(with header: JWSHeader, and payload: Payload, for privateKey: SigningKeyProxy, and signatureAlgorithm: SignatureAlgorithm) async throws -> Signer {
@@ -519,6 +532,59 @@ extension DocClaimsModelConfiguration {
 			docClaims: docClaims, docDataFormat: docDataFormat,
 			hashingAlg: hashingAlg, nameSpaces: nameSpaces
 		)
+	}
+}
+
+extension MdocDataModel18013.CoseKey {
+	var jwk: JSONWebKey.JWK {
+		get throws {
+			guard let curve = JSONWebKey.JWK.CryptographicCurve(rawValue: crv.jwkName) else {
+				throw WalletError(description: "Unsupported CoseKey curve for JWK conversion: \(crv.jwkName)")
+			}
+			return JSONWebKey.JWK(keyType: .ellipticCurve, curve: curve, x: Data(x), y: Data(y))
+		}
+	}
+}
+
+extension SigningKeyProxy: @retroactive JWKRepresentable {
+	/// get the public JWK representation
+	public var jwkRepresentation: JSONWebKey.JWK {
+		switch self {
+		case .secKey(let secKey):
+			return try! SecKeyExtended(secKey: secKey).jwk()
+		case .custom(let signer):
+			return try! signer.publicKey.toJsonWebKeyJWK()
+		}
+	}
+	
+	/// get the public JWK key
+	public func getPublicJWK() throws -> any JOSESwift.JWK {
+		switch self {
+		case .secKey(let secKey):
+			return try SecKeyExtended(secKey: secKey).jwk().toJoseSwiftJWK()
+		case .custom(let signer):
+			return signer.publicKey
+		}
+	}
+}
+
+extension JSONWebKey.JWK {
+	/// Converts a jose-swift `JWK` struct to a JOSESwift `JWK` protocol existential.
+	func toJoseSwiftJWK() throws -> any JOSESwift.JWK {
+		let data = try JSONEncoder().encode(self)
+		return switch keyType {
+		case .ellipticCurve: try ECPublicKey(data: data)
+		case .rsa: try RSAPublicKey(data: data)
+		default: throw WalletError(description: "Unsupported JWK key type for JOSESwift conversion: \(keyType)")
+		}
+	}
+}
+
+extension JOSESwift.JWK {
+	/// Converts a JOSESwift `JWK` rotocol existential to a jose-swift `JWK` struct.
+	func toJsonWebKeyJWK() throws -> JSONWebKey.JWK {
+		let data = try JSONEncoder().encode(self)
+		return try JSONDecoder().decode(JSONWebKey.JWK.self, from: data)
 	}
 }
 

--- a/Sources/EudiWalletKit/Models/KeyAttestationConfiguration.swift
+++ b/Sources/EudiWalletKit/Models/KeyAttestationConfiguration.swift
@@ -15,10 +15,7 @@ limitations under the License.
 */
 
 import Foundation
-import OpenID4VCI
-import Security
 import MdocDataModel18013
-import JOSESwift
 import Copyable
 
 @Copyable
@@ -31,9 +28,4 @@ public struct KeyAttestationConfiguration: Sendable {
 	public let walletAttestationsProvider: (any WalletAttestationsProvider)
 	public let popKeyOptions: KeyOptions?
 	public let popKeyDuration: TimeInterval?
-}
-
-public protocol WalletAttestationsProvider: Sendable {
-	func getWalletAttestation(key: any JWK) async throws -> String
-	func getKeysAttestation(keys: [any JWK], nonce: String?) async throws -> String
 }

--- a/Sources/EudiWalletKit/Models/OpenId4VCIConfiguration.swift
+++ b/Sources/EudiWalletKit/Models/OpenId4VCIConfiguration.swift
@@ -98,7 +98,7 @@ extension OpenId4VciConfiguration {
 	/// Creates a PoP constructor based on the provided parameters and configuration.
 	func makePoPConstructor(popUsage: PopUsage, privateKeyId: String?, algorithms: [JWSAlgorithm]?, keyOptions: KeyOptions?) async throws -> DPoPConstructor? {
 		guard let algorithms = algorithms, !algorithms.isEmpty else { return nil }
-		let privateKeyProxy: SigningKeyProxy
+		let signingKeyProxy: SigningKeyProxy
 		let publicKey: SecKey
 		let jwsAlgorithm: JWSAlgorithm
 		let jwk: any JWK
@@ -118,7 +118,7 @@ extension OpenId4VciConfiguration {
 				(try await secureArea.createKeyBatch(id: keyId, credentialOptions: CredentialOptions(credentialPolicy: .rotateUse, batchSize: 1), keyOptions: keyOptions)).first! }
 			let unlockData = try await secureArea.unlockKey(id: keyId)
 			let signer = try SecureAreaSigner(secureArea: secureArea, id: keyId, index: 0, ecAlgorithm: ecAlgorithm, unlockData: unlockData)
-			privateKeyProxy = .custom(signer)
+			signingKeyProxy = .custom(signer)
 			publicKey = try publicCoseKey.toSecKey()
 		} else {
 			let setCommonJwsAlgorithmNames = Array(Set(algorithms.map(\.name)).intersection(Self.supportedDPoPAlgorithms.map(\.name))).sorted()
@@ -133,7 +133,7 @@ extension OpenId4VciConfiguration {
 			let bits: Int = switch jwsAlgorithm.name { case JWSAlgorithm(.ES256).name: 256; case JWSAlgorithm(.ES384).name: 384; case JWSAlgorithm(.ES512).name: 521; case JWSAlgorithm(.RS256).name: 2048; default: throw PresentationSession.makeError(str: "Unsupported DPoP algorithm: \(jwsAlgorithm.name)") }
 			let type: SecKey.KeyType = switch jwsAlgorithm.name { case JWSAlgorithm(.RS256).name: .rsa; default: .ellipticCurve }
 			let privateKey: SecKey = if let privateKeyId, let pk = SecKey.getExistingKey(type: type, keyId: privateKeyId) { pk } else { try SecKey.createRandomKey(type: type, bits: bits, keyId: privateKeyId) }
-			privateKeyProxy = .secKey(privateKey)
+			signingKeyProxy = .secKey(privateKey)
 			publicKey = try KeyController.generateECDHPublicKey(from: privateKey)
 		}
 		if jwsAlgorithm.name.starts(with: "RS") {
@@ -141,7 +141,7 @@ extension OpenId4VciConfiguration {
 		} else {
 			jwk = try ECPublicKey(publicKey: publicKey, additionalParameters: ["alg": jwsAlgorithm.name, "use": "sig", "kid": keyId])
 		}
-		return DPoPConstructor(algorithm: jwsAlgorithm, jwk: jwk, privateKey: privateKeyProxy)
+		return DPoPConstructor(algorithm: jwsAlgorithm, jwk: jwk, privateKey: signingKeyProxy)
 	}
 
 	func toOpenId4VCIConfig(credentialIssuerId: String, clientAttestationPopSigningAlgValuesSupported: [JWSAlgorithm]?) async throws -> OpenId4VCIConfig {

--- a/Sources/EudiWalletKit/Models/OpenId4VCIConfiguration.swift
+++ b/Sources/EudiWalletKit/Models/OpenId4VCIConfiguration.swift
@@ -116,8 +116,9 @@ extension OpenId4VciConfiguration {
 			let existingPublicKey: CoseKey? = if hasCompatibleExistingKey, let privateKeyId { try? await secureArea.getPublicKey(id: privateKeyId, index: 0, curve: ecCurve) } else { nil }
 			let publicCoseKey: CoseKey = if let existingPublicKey { existingPublicKey } else {
 				(try await secureArea.createKeyBatch(id: keyId, credentialOptions: CredentialOptions(credentialPolicy: .rotateUse, batchSize: 1), keyOptions: keyOptions)).first! }
+			let publicKeyJwk = try publicCoseKey.jwk
 			let unlockData = try await secureArea.unlockKey(id: keyId)
-			let signer = try SecureAreaSigner(secureArea: secureArea, id: keyId, index: 0, ecAlgorithm: ecAlgorithm, unlockData: unlockData)
+			let signer = try SecureAreaSigner(secureArea: secureArea, id: keyId, index: 0, publicKey: publicKeyJwk.toJoseSwiftJWK(), curve: ecCurve, ecAlgorithm: ecAlgorithm, unlockData: unlockData)
 			signingKeyProxy = .custom(signer)
 			publicKey = try publicCoseKey.toSecKey()
 		} else {
@@ -159,7 +160,7 @@ extension OpenId4VciConfiguration {
 		guard let popConstructor = try await makePoPConstructor(popUsage: .clientAttestation, privateKeyId: keyId, algorithms: algorithms, keyOptions: config.popKeyOptions) else {
 			throw PresentationSession.makeError(str: "Failed to create DPoP constructor for client attestation")
 		}
-		let attestation = try await config.walletAttestationsProvider.getWalletAttestation(key: popConstructor.jwk)
+		let attestation = try await config.walletAttestationsProvider.getWalletAttestation(signingKey: popConstructor.privateKey)
 		guard let signatureAlgorithm = SignatureAlgorithm(rawValue: popConstructor.algorithm.name) else {
 			throw PresentationSession.makeError(str: "Unsupported DPoP algorithm: \(popConstructor.algorithm.name) for client attestation")
 		}

--- a/Sources/EudiWalletKit/Models/WalletAttestationsProvider.swift
+++ b/Sources/EudiWalletKit/Models/WalletAttestationsProvider.swift
@@ -1,0 +1,24 @@
+/*
+Copyright (c) 2026 European Commission
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+import OpenID4VCI
+import JOSESwift
+
+public protocol WalletAttestationsProvider: Sendable {
+	func getWalletAttestation(signingKey: SigningKeyProxy) async throws -> String
+	func getKeysAttestation(keys: [any JWK], nonce: String?) async throws -> String
+}

--- a/Sources/EudiWalletKit/Services/OpenId4VciService.swift
+++ b/Sources/EudiWalletKit/Services/OpenId4VciService.swift
@@ -142,7 +142,7 @@ public actor OpenId4VciService {
 
 	func createBindingKey(_ publicKeyJWK: ECPublicKey, secureAreaSigningAlg: MdocDataModel18013.SigningAlgorithm, unlockData: Data?, index: Int, funcKeyAttestationJWT: FuncKeyAttestationJWT?) throws -> BindingKey {
 		let algType = Self.mapToJWSAlgorithmType(secureAreaSigningAlg)!
-		let signer = try SecureAreaSigner(secureArea: issueReq.secureArea, id: issueReq.id, index: index, ecAlgorithm: secureAreaSigningAlg, unlockData: unlockData)
+		let signer = try SecureAreaSigner(secureArea: issueReq.secureArea, id: issueReq.id, index: index, publicKey: publicKeyJWK, curve: publicKeyJWK.crv.coseEcCurve, ecAlgorithm: secureAreaSigningAlg, unlockData: unlockData)
 		let bindingKey: BindingKey
 		if funcKeyAttestationJWT == nil {
 			bindingKey = .jwt(algorithm: JWSAlgorithm(algType), jwk: publicKeyJWK, privateKey: .custom(signer), issuer: config.clientId)

--- a/Sources/EudiWalletKit/Services/OpenId4VciService.swift
+++ b/Sources/EudiWalletKit/Services/OpenId4VciService.swift
@@ -844,7 +844,7 @@ public actor OpenId4VciService {
 				docMetadata = cc.convertToDocMetadata(authorized: authorized, keyOptions: issueReq.keyOptions, credentialOptions: issueReq.credentialOptions, dpopKeyId: savedDpopKeyId)
 				let docTypeOrVctOrScope = docType ?? cc.docType ?? cc.scope ?? ""
 				dkInfo.batchSize = dataPairs.count
-				docTypeToSave = if format == .cbor, dataToSave.count > 0 { (try IssuerSigned(data: [UInt8](dataToSave))).issuerAuth.mso.docType } else if format == .sdjwt, dataToSave.count > 0 { StorageManager.getVctFromSdJwt(docData: dataToSave) ?? docTypeOrVctOrScope } else { docTypeOrVctOrScope }
+				docTypeToSave = if format == .cbor, dataToSave.count > 0 { (try IssuerSigned(data: [UInt8](dataToSave))).issuerAuth.mso.docType } else if format == .sdjwt, dataToSave.count > 0 { SdJwtUtils.getVctFromSdJwt(docData: dataToSave) ?? docTypeOrVctOrScope } else { docTypeOrVctOrScope }
 				displayName = cc.display.getName(uiCulture)
 				if dataPairs.count > 0 {
 					batch = (0..<dataPairs.count).map { WalletStorage.Document(id: issueReq.id, docType: docTypeToSave, docDataFormat: format, data: issueOutcome.getDataToSave(index: $0, format: format), docKeyInfo: nil, createdAt: Date(), metadata: nil, displayName: displayName, status: .issued) }
@@ -938,7 +938,7 @@ public actor OpenId4VciService {
 	}
 
 	private func validateSdJwtBindingKeys(_ serialized: String, publicCoseKeys: inout [CoseKey]) throws {
-		let (_, payload, _) = StorageManager.extractJWTParts(serialized)
+		let (_, payload, _) = SdJwtUtils.extractJWTParts(serialized)
 		guard let payloadData = Data(base64URLEncoded: payload) else {
 			throw PresentationSession.makeError(str: "Failed to decode SD-JWT payload")
 		}
@@ -1005,7 +1005,7 @@ public actor OpenId4VciService {
 	}
 
 	private func validateSdJwtIssuer(_ serialized: String, expectedIssuer: URL, requireIssuer: Bool = true) throws {
-		let (_, payload, _) = StorageManager.extractJWTParts(serialized)
+		let (_, payload, _) = SdJwtUtils.extractJWTParts(serialized)
 		guard let payloadData = Data(base64URLEncoded: payload) else {
 			throw PresentationSession.makeError(str: "Failed to decode SD-JWT payload")
 		}

--- a/Sources/EudiWalletKit/Services/OpenId4VpService.swift
+++ b/Sources/EudiWalletKit/Services/OpenId4VpService.swift
@@ -260,7 +260,9 @@ public final class OpenId4VpService: @unchecked Sendable, PresentationService {
 				let unlockData = try await dpk.secureArea.unlockKey(id: docId)
 				let keyInfo = try await dpk.secureArea.getKeyBatchInfo(id: docId)
 				let dsa = keyInfo.crv.defaultSigningAlgorithm
-				let signer = try SecureAreaSigner(secureArea: dpk.secureArea, id: docId, index: dpk.index, ecAlgorithm: dsa, unlockData: unlockData)
+				let publicKeyCose = try await dpk.secureArea.getPublicKey(id: docId, index: dpk.index, curve: keyInfo.crv)
+				let publicKeyJwk = try publicKeyCose.jwk
+				let signer = try SecureAreaSigner(secureArea: dpk.secureArea, id: docId, index: dpk.index, publicKey: publicKeyJwk.toJoseSwiftJWK(), curve: keyInfo.crv, ecAlgorithm: dsa, unlockData: unlockData)
 				let signAlg = try SecureAreaSigner.getSigningAlgorithm(dsa)
 				let hai = HashingAlgorithmIdentifier(rawValue: transferInfo.hashingAlgs[docId] ?? "") ?? .SHA3256
 				guard let presented = try await OpenId4VpUtils.getSdJwtPresentation(docSigned, hashingAlg: hai.hashingAlgorithm(), signer: signer, signAlg: signAlg, requestItems: items, nonce: vpNonce, aud: vpClientId, transactionData: transactionData) else {

--- a/Sources/EudiWalletKit/Services/SdJwtUtils.swift
+++ b/Sources/EudiWalletKit/Services/SdJwtUtils.swift
@@ -1,0 +1,148 @@
+/*
+ Copyright (c) 2026 European Commission
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+import MdocDataModel18013
+import WalletStorage
+import CryptoKit
+import Logging
+import eudi_lib_sdjwt_swift
+import SwiftyJSON
+import OpenID4VCI
+
+public final class SdJwtUtils {
+
+	public static func toSdJwtDocModel(doc: WalletStorage.Document, uiCulture: String?, modelFactory: (any DocClaimsDecodableFactory)? = nil) -> DocClaimsModel? {
+		var docClaims = [DocClaim]()
+		let docMetadata: DocMetadata? = DocMetadata(from: doc.metadata)
+		let docKeyInfo = DocKeyInfo(from: doc.docKeyInfo) ?? .default
+		let md = docMetadata?.getMetadata(uiCulture: uiCulture)
+		guard let recreatedClaims = recreateSdJwtClaims(docData: doc.data) else { return nil }
+		if let cs = recreatedClaims.json.toClaimsArray(pathPrefix: [], md?.claimMetadata, uiCulture)?.0 { docClaims.append(contentsOf: cs) }
+		var type = docClaims.first(where: { $0.name == "vct"})?.stringValue
+		if type == nil || type!.isEmpty { type = docClaims.first(where: { $0.name == "evidence"})?.children?.first(where: { $0.name == "type"})?.stringValue }
+		let validFrom: Date? = if case let .date(s) = docClaims.first(where: { $0.name == JWTClaimNames.issuedAt})?.dataValue { ISO8601DateFormatter().date(from: s) } else { nil }
+		let validUntil: Date? = if case let .date(s) = docClaims.first(where: { $0.name == JWTClaimNames.expirationTime})?.dataValue { ISO8601DateFormatter().date(from: s) } else { nil }
+		let statusJson = recreatedClaims.json["status"].dictionary
+		let statusListJson = statusJson?["status_list"]?.dictionary
+		let statusURI = statusListJson?["uri"]?.string
+		let statusIndex = statusListJson?["idx"]?.int32
+		let statusIdentifier: StatusIdentifier? = if let statusURI, let statusIndex { StatusIdentifier(idx: Int(statusIndex), uriString: statusURI) } else { nil }
+		let credentialIssuerIdentifier = md?.credentialIssuerIdentifier
+		let configurationIdentifier = md?.configurationIdentifier
+		let displayName = docMetadata?.getDisplayName(uiCulture)
+		let configuration = DocClaimsModelConfiguration(id: doc.id, createdAt: doc.createdAt, docType: doc.docType, displayName: displayName, display: docMetadata?.display, issuerDisplay: docMetadata?.issuerDisplay, credentialIssuerIdentifier: credentialIssuerIdentifier, configurationIdentifier: configurationIdentifier, validFrom: validFrom, validUntil: validUntil, statusIdentifier: statusIdentifier, credentialsUsageCounts: nil, credentialPolicy: docKeyInfo.credentialPolicy, secureAreaName: docKeyInfo.secureAreaName, modifiedAt: doc.modifiedAt, docClaims: docClaims, docDataFormat: .sdjwt, hashingAlg: recreatedClaims.hashingAlg)
+		return DocClaimsModel(configuration: configuration)
+	}
+
+	public static func getHashingAlgorithm(doc: WalletStorage.Document) -> String? {
+		guard doc.docDataFormat == .sdjwt else { return nil }
+		guard let recreatedClaims = recreateSdJwtClaims(docData: doc.data) else { return nil }
+		return recreatedClaims.hashingAlg
+	}
+
+	public static func getVctFromSdJwt(docData: Data) -> String? {
+		guard let recreatedClaims = recreateSdJwtClaims(docData: docData) else { return nil }
+		return recreatedClaims.json["vct"].stringValue
+	}
+
+	static func recreateSdJwtClaims(docData: Data) -> (json: JSON, hashingAlg: String)? {
+		let parser = CompactParser()
+		guard let serString = String(data: docData, encoding: .utf8) else { logger.error("Failed to convert document data to UTF8 string"); return nil}
+		guard let sdJwt = try? parser.getSignedSdJwt(serialisedString: serString) else { logger.error("Failed to parse serialized SDJWT"); return nil }
+		var recreatedClaims: JSON?; var hashingAlg: String?
+		do {
+			let result = try sdJwt.recreateClaims()
+			let (_, payload, _) = extractJWTParts(sdJwt.jwt.compactSerialization)
+			guard let paylodData = Data(base64URLEncoded: payload), let payload = try? JSON(data: paylodData) else { logger.error("Failed to base64url decode payload"); return nil }
+			hashingAlg = try payload.extractDigestAlgorithm()
+			recreatedClaims = resolveNestedSdClaims(result.recreatedClaims, disclosures: sdJwt.disclosures, hashingAlg: hashingAlg ?? "sha-256")
+		} catch { logger.error("Failed to recreate claims from SDJWT: \(error)") }
+		guard let recreatedClaims, let hashingAlg else { return nil }
+		return (recreatedClaims, hashingAlg)
+	}
+
+	/// Recursively resolve any remaining `_sd` digest arrays in the JSON tree using the raw disclosures.
+	static func resolveNestedSdClaims(_ json: JSON, disclosures: [String], hashingAlg: String) -> JSON {
+		// Build a map from base64url-encoded hash → decoded disclosure JSON
+		var hashToDisclosure: [String: JSON] = [:]
+		for disclosure in disclosures {
+			guard let hash = computeDisclosureHash(disclosure, alg: hashingAlg) else { continue }
+			guard let decoded = Data(base64URLEncoded: disclosure), let dJson = try? JSON(data: decoded) else { continue }
+			hashToDisclosure[hash] = dJson
+		}
+		return resolveNode(json, hashToDisclosure: hashToDisclosure, hashingAlg: hashingAlg)
+	}
+
+	private static func resolveNode(_ json: JSON, hashToDisclosure: [String: JSON], hashingAlg: String) -> JSON {
+		switch json.type {
+		case .dictionary:
+			var dict = json.dictionaryValue
+			// If this object has an _sd array, resolve the hashes into actual claims
+			if let sdArray = dict["_sd"]?.array {
+				for hashJson in sdArray {
+					let hashStr = hashJson.stringValue
+					if let disclosure = hashToDisclosure[hashStr], disclosure.arrayValue.count >= 3 {
+						let claimName = disclosure[1].stringValue
+						let claimValue = disclosure[2]
+						dict[claimName] = claimValue
+					}
+				}
+				dict.removeValue(forKey: "_sd")
+			}
+			dict.removeValue(forKey: "_sd_alg")
+			// Recursively resolve children
+			var result = JSON([:])
+			for (key, value) in dict {
+				result[key] = resolveNode(value, hashToDisclosure: hashToDisclosure, hashingAlg: hashingAlg)
+			}
+			return result
+		case .array:
+			let resolved = json.arrayValue.compactMap { element -> JSON? in
+				// Selectively disclosable array elements use {"...": "<digest>"}.
+				// If a matching disclosure exists, replace the element with its disclosed value.
+				// If no matching disclosure exists, the element is undisclosed and must be omitted.
+				if element.type == .dictionary, let dots = element["..."].string {
+					guard let disclosure = hashToDisclosure[dots], disclosure.arrayValue.count >= 2 else {
+						return nil
+					}
+					return resolveNode(disclosure[1], hashToDisclosure: hashToDisclosure, hashingAlg: hashingAlg)
+				}
+				return resolveNode(element, hashToDisclosure: hashToDisclosure, hashingAlg: hashingAlg)
+			}
+			return JSON(resolved)
+		default:
+			return json
+		}
+	}
+
+	private static func computeDisclosureHash(_ disclosure: String, alg: String) -> String? {
+		guard let data = disclosure.data(using: .ascii) else { return nil }
+		let digest: Data
+		switch alg {
+		case "sha-256": digest = Data(SHA256.hash(data: data))
+		case "sha-384": digest = Data(SHA384.hash(data: data))
+		case "sha-512": digest = Data(SHA512.hash(data: data))
+		default: digest = Data(SHA256.hash(data: data))
+		}
+		return digest.base64URLEncodedString()
+	}
+
+	static func extractJWTParts(_ jwt: String) -> (String, String, String) {
+		let parts = jwt.components(separatedBy: ".")
+		return (parts.count > 0 ? parts[0] : "", parts.count > 1 ? parts[1] : "" , parts.count > 2 ? parts[2] : "")
+	}
+}

--- a/Sources/EudiWalletKit/Services/SecureAreaSigner.swift
+++ b/Sources/EudiWalletKit/Services/SecureAreaSigner.swift
@@ -24,19 +24,23 @@ final class SecureAreaSigner: AsyncSignerProtocol {
 	let id: String
 	let index: Int
 	let secureArea: SecureArea
+	let curve: CoseEcCurve
+	public let publicKey: any JOSESwift.JWK
 	let ecAlgorithm: MdocDataModel18013.SigningAlgorithm
 	let algorithm: JOSESwift.SignatureAlgorithm
 	let signature: Data?
 	let unlockData: Data?
 
-	init(secureArea: SecureArea, id: String, index: Int, ecAlgorithm: MdocDataModel18013.SigningAlgorithm, unlockData: Data?) throws {
+	init(secureArea: SecureArea, id: String, index: Int, publicKey: any JOSESwift.JWK, curve: CoseEcCurve, ecAlgorithm: MdocDataModel18013.SigningAlgorithm, unlockData: Data?) throws {
 		self.id = id
 		self.index = index
 		self.secureArea = secureArea
+		self.curve = curve
 		self.ecAlgorithm = ecAlgorithm
 		self.algorithm = try Self.getSignatureAlgorithm(ecAlgorithm)
 		signature = nil
 		self.unlockData = unlockData
+		self.publicKey = publicKey
 	}
 
 	static func getSignatureAlgorithm(_ sa: MdocDataModel18013.SigningAlgorithm) throws -> JOSESwift.SignatureAlgorithm {

--- a/Sources/EudiWalletKit/Services/StorageManager.swift
+++ b/Sources/EudiWalletKit/Services/StorageManager.swift
@@ -19,9 +19,7 @@ import SwiftCBOR
 import MdocDataModel18013
 import WalletStorage
 import Logging
-import CryptoKit
 import eudi_lib_sdjwt_swift
-import SwiftyJSON
 import OpenID4VCI
 
 /// Storage manager. Provides services and view models
@@ -148,7 +146,7 @@ public final class StorageManager: ObservableObject, @unchecked Sendable {
 	public static func toClaimsModel(doc: WalletStorage.Document, uiCulture: String?, modelFactory: (any DocClaimsDecodableFactory)? = nil) -> DocClaimsModel? {
 		let model: DocClaimsModel? = switch doc.docDataFormat {
 		case .cbor: toCborMdocModel(doc: doc, uiCulture: uiCulture, modelFactory: modelFactory)
-		case .sdjwt: toSdJwtDocModel(doc: doc, uiCulture: uiCulture, modelFactory: modelFactory)
+		case .sdjwt: SdJwtUtils.toSdJwtDocModel(doc: doc, uiCulture: uiCulture, modelFactory: modelFactory)
 		}
 		guard let model else { return nil }
 		return reorderDocClaimsByMetadata(model, doc: doc, uiCulture: uiCulture)
@@ -204,127 +202,6 @@ public final class StorageManager: ObservableObject, @unchecked Sendable {
 		}.sorted(using: KeyPathComparator(\.order))
 		let configuration = DocClaimsModelConfiguration(from: model).withDocClaims(reorderedClaims)
 		return DocClaimsModel(configuration: configuration)
-	}
-
-	public static func toSdJwtDocModel(doc: WalletStorage.Document, uiCulture: String?, modelFactory: (any DocClaimsDecodableFactory)? = nil) -> DocClaimsModel? {
-		var docClaims = [DocClaim]()
-		let docMetadata: DocMetadata? = DocMetadata(from: doc.metadata)
-		let docKeyInfo = DocKeyInfo(from: doc.docKeyInfo) ?? .default
-		let md = docMetadata?.getMetadata(uiCulture: uiCulture)
-		guard let recreatedClaims = recreateSdJwtClaims(docData: doc.data) else { return nil }
-		if let cs = recreatedClaims.json.toClaimsArray(pathPrefix: [], md?.claimMetadata, uiCulture)?.0 { docClaims.append(contentsOf: cs) }
-		var type = docClaims.first(where: { $0.name == "vct"})?.stringValue
-		if type == nil || type!.isEmpty { type = docClaims.first(where: { $0.name == "evidence"})?.children?.first(where: { $0.name == "type"})?.stringValue }
-		let validFrom: Date? = if case let .date(s) = docClaims.first(where: { $0.name == JWTClaimNames.issuedAt})?.dataValue { ISO8601DateFormatter().date(from: s) } else { nil }
-		let validUntil: Date? = if case let .date(s) = docClaims.first(where: { $0.name == JWTClaimNames.expirationTime})?.dataValue { ISO8601DateFormatter().date(from: s) } else { nil }
-		let statusJson = recreatedClaims.json["status"].dictionary
-		let statusListJson = statusJson?["status_list"]?.dictionary
-		let statusURI = statusListJson?["uri"]?.string
-		let statusIndex = statusListJson?["idx"]?.int32
-		let statusIdentifier: StatusIdentifier? = if let statusURI, let statusIndex { StatusIdentifier(idx: Int(statusIndex), uriString: statusURI) } else { nil }
-		let credentialIssuerIdentifier = md?.credentialIssuerIdentifier
-		let configurationIdentifier = md?.configurationIdentifier
-		let displayName = docMetadata?.getDisplayName(uiCulture)
-		let configuration = DocClaimsModelConfiguration(id: doc.id, createdAt: doc.createdAt, docType: doc.docType, displayName: displayName, display: docMetadata?.display, issuerDisplay: docMetadata?.issuerDisplay, credentialIssuerIdentifier: credentialIssuerIdentifier, configurationIdentifier: configurationIdentifier, validFrom: validFrom, validUntil: validUntil, statusIdentifier: statusIdentifier, credentialsUsageCounts: nil, credentialPolicy: docKeyInfo.credentialPolicy, secureAreaName: docKeyInfo.secureAreaName, modifiedAt: doc.modifiedAt, docClaims: docClaims, docDataFormat: .sdjwt, hashingAlg: recreatedClaims.hashingAlg)
-		return DocClaimsModel(configuration: configuration)
-	}
-
-	public static func getHashingAlgorithm(doc: WalletStorage.Document) -> String? {
-		guard doc.docDataFormat == .sdjwt else { return nil }
-		guard let recreatedClaims = recreateSdJwtClaims(docData: doc.data) else { return nil }
-		return recreatedClaims.hashingAlg
-	}
-
-	public static func getVctFromSdJwt(docData: Data) -> String? {
-		guard let recreatedClaims = recreateSdJwtClaims(docData: docData) else { return nil }
-		return recreatedClaims.json["vct"].stringValue
-	}
-
-	static func recreateSdJwtClaims(docData: Data) -> (json: JSON, hashingAlg: String)? {
-		let parser = CompactParser()
-		guard let serString = String(data: docData, encoding: .utf8) else { logger.error("Failed to convert document data to UTF8 string"); return nil}
-		guard let sdJwt = try? parser.getSignedSdJwt(serialisedString: serString) else { logger.error("Failed to parse serialized SDJWT"); return nil }
-		var recreatedClaims: JSON?; var hashingAlg: String?
-		do {
-			let result = try sdJwt.recreateClaims()
-			let (_, payload, _) = extractJWTParts(sdJwt.jwt.compactSerialization)
-			guard let paylodData = Data(base64URLEncoded: payload), let payload = try? JSON(data: paylodData) else { logger.error("Failed to base64url decode payload"); return nil }
-			hashingAlg = try payload.extractDigestAlgorithm()
-			recreatedClaims = resolveNestedSdClaims(result.recreatedClaims, disclosures: sdJwt.disclosures, hashingAlg: hashingAlg ?? "sha-256")
-		} catch { logger.error("Failed to recreate claims from SDJWT: \(error)") }
-		guard let recreatedClaims, let hashingAlg else { return nil }
-		return (recreatedClaims, hashingAlg)
-	}
-
-	/// Recursively resolve any remaining `_sd` digest arrays in the JSON tree using the raw disclosures.
-	static func resolveNestedSdClaims(_ json: JSON, disclosures: [String], hashingAlg: String) -> JSON {
-		// Build a map from base64url-encoded hash → decoded disclosure JSON
-		var hashToDisclosure: [String: JSON] = [:]
-		for disclosure in disclosures {
-			guard let hash = computeDisclosureHash(disclosure, alg: hashingAlg) else { continue }
-			guard let decoded = Data(base64URLEncoded: disclosure), let dJson = try? JSON(data: decoded) else { continue }
-			hashToDisclosure[hash] = dJson
-		}
-		return resolveNode(json, hashToDisclosure: hashToDisclosure, hashingAlg: hashingAlg)
-	}
-
-	private static func resolveNode(_ json: JSON, hashToDisclosure: [String: JSON], hashingAlg: String) -> JSON {
-		switch json.type {
-		case .dictionary:
-			var dict = json.dictionaryValue
-			// If this object has an _sd array, resolve the hashes into actual claims
-			if let sdArray = dict["_sd"]?.array {
-				for hashJson in sdArray {
-					let hashStr = hashJson.stringValue
-					if let disclosure = hashToDisclosure[hashStr], disclosure.arrayValue.count >= 3 {
-						let claimName = disclosure[1].stringValue
-						let claimValue = disclosure[2]
-						dict[claimName] = claimValue
-					}
-				}
-				dict.removeValue(forKey: "_sd")
-			}
-			dict.removeValue(forKey: "_sd_alg")
-			// Recursively resolve children
-			var result = JSON([:])
-			for (key, value) in dict {
-				result[key] = resolveNode(value, hashToDisclosure: hashToDisclosure, hashingAlg: hashingAlg)
-			}
-			return result
-		case .array:
-			let resolved = json.arrayValue.compactMap { element -> JSON? in
-				// Selectively disclosable array elements use {"...": "<digest>"}.
-				// If a matching disclosure exists, replace the element with its disclosed value.
-				// If no matching disclosure exists, the element is undisclosed and must be omitted.
-				if element.type == .dictionary, let dots = element["..."].string {
-					guard let disclosure = hashToDisclosure[dots], disclosure.arrayValue.count >= 2 else {
-						return nil
-					}
-					return resolveNode(disclosure[1], hashToDisclosure: hashToDisclosure, hashingAlg: hashingAlg)
-				}
-				return resolveNode(element, hashToDisclosure: hashToDisclosure, hashingAlg: hashingAlg)
-			}
-			return JSON(resolved)
-		default:
-			return json
-		}
-	}
-
-	private static func computeDisclosureHash(_ disclosure: String, alg: String) -> String? {
-		guard let data = disclosure.data(using: .ascii) else { return nil }
-		let digest: Data
-		switch alg {
-		case "sha-256": digest = Data(SHA256.hash(data: data))
-		case "sha-384": digest = Data(SHA384.hash(data: data))
-		case "sha-512": digest = Data(SHA512.hash(data: data))
-		default: digest = Data(SHA256.hash(data: data))
-		}
-		return digest.base64URLEncodedString()
-	}
-
-	static func extractJWTParts(_ jwt: String) -> (String, String, String) {
-		let parts = jwt.components(separatedBy: ".")
-		return (parts.count > 0 ? parts[0] : "", parts.count > 1 ? parts[1] : "" , parts.count > 2 ? parts[2] : "")
 	}
 
 	public func getDocIdsToPresentInfo(documents: [WalletStorage.Document]? = nil) async throws -> [String: DocPresentInfo] {

--- a/Tests/EudiWalletKitTests/EudiWalletKitTests.swift
+++ b/Tests/EudiWalletKitTests/EudiWalletKitTests.swift
@@ -564,7 +564,7 @@ final class RecordingWalletAttestationsProvider: WalletAttestationsProvider, @un
 
 	private(set) var lastRequest: (keyThumbprints: [String], nonce: String?)?
 
-	func getWalletAttestation(key: any JWK) async throws -> String {
+	func getWalletAttestation(signingKey: SigningKeyProxy) async throws -> String {
 		Self.attestation
 	}
 

--- a/Tests/EudiWalletKitTests/EudiWalletKitTests.swift
+++ b/Tests/EudiWalletKitTests/EudiWalletKitTests.swift
@@ -61,7 +61,7 @@ struct EudiWalletKitTests {
 		let parser = CompactParser()
 		let sdJwt = try parser.getSignedSdJwt(serialisedString: String(data: data, encoding: .utf8)!)
 		let result = try sdJwt.recreateClaims()
-		let resolved = StorageManager.resolveNestedSdClaims(result.recreatedClaims, disclosures: sdJwt.disclosures, hashingAlg: "sha-256")
+		let resolved = SdJwtUtils.resolveNestedSdClaims(result.recreatedClaims, disclosures: sdJwt.disclosures, hashingAlg: "sha-256")
 		return (resolved, sdJwt.disclosures)
 	}
 
@@ -99,7 +99,7 @@ struct EudiWalletKitTests {
 		let hashFR = Data(SHA256.hash(data: Data(disclosureFR.utf8))).base64URLEncodedString()
 		// SD-JWT payload: two selective-disclosure array elements; only "DE" has a matching disclosure
 		let payload = JSON(parseJSON: "{\"nationalities\": [{\"...\": \"\(hashDE)\"}, {\"...\": \"\(hashFR)\"}]}")
-		let resolved = StorageManager.resolveNestedSdClaims(payload, disclosures: [disclosureDE], hashingAlg: "sha-256")
+		let resolved = SdJwtUtils.resolveNestedSdClaims(payload, disclosures: [disclosureDE], hashingAlg: "sha-256")
 		print("Nationalities disclosures — DE: \(disclosureDE), FR: \(disclosureFR)")
 		// The undisclosed element must be omitted, leaving only "DE"
 		let nationalities = resolved["nationalities"].arrayValue.map(\.stringValue)
@@ -125,7 +125,7 @@ struct EudiWalletKitTests {
 		let parser = CompactParser()
 		let sdJwt = try parser.getSignedSdJwt(serialisedString: serialized)
 		let result = try sdJwt.recreateClaims()
-		let resolved = StorageManager.resolveNestedSdClaims(result.recreatedClaims, disclosures: sdJwt.disclosures, hashingAlg: "sha-256")
+		let resolved = SdJwtUtils.resolveNestedSdClaims(result.recreatedClaims, disclosures: sdJwt.disclosures, hashingAlg: "sha-256")
 				// No DocClaim produced for the resolved array should carry an empty-object value
 		let metadata = [DocClaimMetadata(display: [DisplayMetadata(name: "nationalities", localeIdentifier: "en", logo: nil, description: nil, backgroundColor: nil, textColor: nil)], isMandatory: false, claimPath: ["nationalities"], valueType: nil)]
 		let docClaims = resolved.toClaimsArray(pathPrefix: [], metadata, "en")?.0 ?? []
@@ -157,7 +157,7 @@ struct EudiWalletKitTests {
 		let sdJwtData = try #require(Data(name: "sjwt-mdl", ext: "txt", from: Bundle.module))
 		let document = WalletStorage.Document(id: "sjwt-mdl", docType: configuration.docType, docDataFormat: .sdjwt, data: sdJwtData, docKeyInfo: nil, createdAt: .now, metadata: docMetadata.toData(), displayName: nil, status: .issued)
 
-		let model = try #require(StorageManager.toSdJwtDocModel(doc: document, uiCulture: "en"))
+		let model = try #require(SdJwtUtils.toSdJwtDocModel(doc: document, uiCulture: "en"))
 		#expect(model.docType == "org.iso.18013.5.1.mDL")
 		#expect(model.docDataFormat == .sdjwt)
 
@@ -441,7 +441,7 @@ struct EudiWalletKitTests {
 			publicKey = issuerSigned.issuerAuth.mso.deviceKeyInfo.deviceKey
 		} else {
 			let serialized = try #require(String(data: original, encoding: .utf8))
-			let (_, payload, _) = StorageManager.extractJWTParts(serialized)
+			let (_, payload, _) = SdJwtUtils.extractJWTParts(serialized)
 			let payloadData = try #require(Data(base64URLEncoded: payload))
 			let payloadJson = try JSON(data: payloadData)
 			let jwk = payloadJson["cnf"]["jwk"]
@@ -470,7 +470,7 @@ struct EudiWalletKitTests {
 	}
 
 	private func makeIssuerJwkData(from serialized: String) throws -> Data {
-		let (header, _, _) = StorageManager.extractJWTParts(serialized)
+		let (header, _, _) = SdJwtUtils.extractJWTParts(serialized)
 		let headerData = try #require(Data(base64URLEncoded: header))
 		let headerJson = try JSON(data: headerData)
 		let certificateBase64 = try #require(headerJson["x5c"].array?.first?.string)

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,19 @@
+## v0.31.0
+
+### Breaking Changes
+
+- **`WalletAttestationsProvider` protocol change**: The `getWalletAttestation` method signature changed:
+  - **Before**: `func getWalletAttestation(key: any JWK) async throws -> String`
+  - **After**: `func getWalletAttestation(signingKey: SigningKeyProxy) async throws -> String`
+  - The parameter is now a `SigningKeyProxy` (from the OpenID4VCI library) instead of a plain `JWK`. Use `signingKey.getPublicJWK()` to obtain the public JWK:
+
+```swift
+func getWalletAttestation(signingKey: SigningKeyProxy) async throws -> String {
+    let key = try signingKey.getPublicJWK()
+    return try await attestationService.getWalletAttestation(for: key)
+}
+```
+
 ## v0.30.0
 
 ### Usage Counter Refresh
@@ -393,7 +409,7 @@ public func resolveOfferUrlDocTypes(offerUri: String, authFlowRedirectionURI: UR
     - Property `popKeyDuration: TimeInterval?` - Optional duration for PoP JWT validity (default: 300 seconds)
   
   - **New protocol**: `WalletAttestationsProvider` with two required methods:
-    - `func getWalletAttestation(key: any JWK) async throws -> String` - Obtain wallet instance attestation JWT for a given public key
+    - `func getWalletAttestation(signingKey: SigningKeyProxy) async throws -> String` - Obtain wallet instance attestation JWT for a given signing key (use `signingKey.getPublicJWK()` to get the public key)
     - `func getKeysAttestation(keys: [any JWK], nonce: String?) async throws -> String` - Obtain unit attestation JWT for multiple keys 
 
 - **OpenId4VciConfiguration changes**:
@@ -427,7 +443,7 @@ let config = OpenId4VciConfiguration(
     - Property `popKeyDuration: TimeInterval?` - Optional duration for PoP JWT validity (default: 300 seconds)
   
   - **New protocol**: `WalletAttestationsProvider` with two required methods:
-    - `func getWalletAttestation(key: any JWK) async throws -> String` - Obtain wallet attestation JWT for a given public key
+    - `func getWalletAttestation(signingKey: SigningKeyProxy) async throws -> String` - Obtain wallet attestation JWT for a given signing key (use `signingKey.getPublicJWK()` to get the public key)
     - `func getKeysAttestation(keys: [any JWK], nonce: String?) async throws -> String` - Obtain key attestation JWT for multiple keys with optional nonce
 
 - **OpenId4VciConfiguration changes**:


### PR DESCRIPTION
Refactor the wallet attestation provider to utilize a signing key proxy. Update the dependency for the OpenID4VCI library to the latest version and revise related implementations accordingly. Additionally, clean up the documentation and README to reflect these changes.

Fixes #385