### PR TITLE
396 dcql multiple selections

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f4758a3bf606aaf114be624e1e4132445ac8dbf32696830affaf7c06c5a12e63",
+  "originHash" : "9e8113c7bfd718febb64a91d2ad6dd9f568ae0f35281c1b8de460361b1fac357",
   "pins" : [
     {
       "identity" : "cryptoswift",
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-siop-openid4vp-swift.git",
       "state" : {
-        "revision" : "1f871d732600fa1237b52e90ab514066522ea297",
-        "version" : "0.33.1"
+        "revision" : "b567cef2e6237b821785089197e1f0af6c0f21ee",
+        "version" : "0.34.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b444c5f59aa2659d14749bda55aae8705d3ebcae217b3eb0b91c57bb1315ceed",
+  "originHash" : "bf99bd2a7ea6535b77b5770da6ace6fb0262657b3a00fa01278028026851b6e1",
   "pins" : [
     {
       "identity" : "cryptoswift",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git",
       "state" : {
-        "revision" : "9cab3808444df17a2f8cc02f9dd638363413a37d",
-        "version" : "0.21.2"
+        "revision" : "07f650d99c9f52b9204ebd9f769dfeb3446c6fb0",
+        "version" : "0.21.3"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "bf99bd2a7ea6535b77b5770da6ace6fb0262657b3a00fa01278028026851b6e1",
+  "originHash" : "f4758a3bf606aaf114be624e1e4132445ac8dbf32696830affaf7c06c5a12e63",
   "pins" : [
     {
       "identity" : "cryptoswift",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git",
       "state" : {
-        "revision" : "fb96c519101c1dc9cb0266689555ee53db230e9f",
-        "version" : "0.40.0"
+        "revision" : "e073913d582c1bdeddc0bc9c8653de0c79e787ac",
+        "version" : "0.40.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6d945c2f64d1c7326de372108526290aa31ea0e61e5351305c2a0b72d98d80d9",
+  "originHash" : "b444c5f59aa2659d14749bda55aae8705d3ebcae217b3eb0b91c57bb1315ceed",
   "pins" : [
     {
       "identity" : "cryptoswift",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git",
       "state" : {
-        "revision" : "2491fb8ce5f85193e583b006400af94434e0fcda",
-        "version" : "0.39.0"
+        "revision" : "fb96c519101c1dc9cb0266689555ee53db230e9f",
+        "version" : "0.40.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git", exact: "0.21.3"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git", exact: "0.21.2"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift.git", exact: "0.14.4"),
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git", exact: "0.40.0"),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git", exact: "0.40.1"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-siop-openid4vp-swift.git", exact: "0.33.1"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-statium-swift.git", exact: "0.4.0"),
     	.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git", exact: "0.21.2"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git", exact: "0.21.2"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift.git", exact: "0.14.4"),
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git", exact: "0.39.0"),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git", exact: "0.40.0"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-siop-openid4vp-swift.git", exact: "0.33.1"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-statium-swift.git", exact: "0.4.0"),
     	.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
 			targets: ["EudiWalletKit"])
 	],
 	dependencies: [
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git", exact: "0.21.2"),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git", exact: "0.21.3"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git", exact: "0.21.2"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift.git", exact: "0.14.4"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git", exact: "0.40.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git", exact: "0.21.2"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift.git", exact: "0.14.4"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git", exact: "0.40.1"),
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-siop-openid4vp-swift.git", exact: "0.33.1"),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-siop-openid4vp-swift.git", exact: "0.34.1"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-statium-swift.git", exact: "0.4.0"),
     	.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
 	],

--- a/README.md
+++ b/README.md
@@ -580,13 +580,16 @@ On view appearance the attestations are presented with the receiveRequest method
 	 _ = await presentationSession.receiveRequest()
 }
 ```
-After the request is received the ``presentationSession.disclosedDocuments`` contains the requested attested items. The selected state of the items can be modified via UI binding. Finally, the response is sent with the following code: 
+After the request is received the ``presentationSession.disclosedDocumentSets`` contains an array of credential selection options. Each element is a `[DocElements]` representing one valid combination of credentials that satisfies the query. The selected state of the items can be modified via UI binding. Finally, the response is sent with the following code: 
 
 ```swift
+// Use the first credential selection option (or let the user choose)
+let selectedOption = presentationSession.disclosedDocumentSets.first ?? []
+
 // Send the disclosed document items after biometric authentication (FaceID or TouchID)
 // if the user cancels biometric authentication, onCancel method is called
  await presentationSession.sendResponse(userAccepted: true,
-  itemsToSend: presentationSession.disclosedDocuments.items, onCancel: { dismiss() }, onSuccess: {
+  itemsToSend: selectedOption.items, onCancel: { dismiss() }, onSuccess: {
 			if let url = $0 { 
         // handle URL
        }

--- a/Sources/EudiWalletKit/EudiWalletKit.docc/PresentationService.md
+++ b/Sources/EudiWalletKit/EudiWalletKit.docc/PresentationService.md
@@ -56,13 +56,20 @@ On view appearance the attestations are presented with the ``PresentationService
 }
 ```
 
-After the request is received the ``PresentationSession/disclosedDocuments`` contains the requested attested items that can be satisfied by the selected credential. When partial-claim presentation is enabled, this includes only the claims that are both requested and available. The selected state of the items can be modified via UI binding. Finally, the response is sent with the following code: 
+## Credential Selection
+
+After the request is received, ``PresentationSession/disclosedDocumentSets`` contains an array of credential selection options. Each element is a `[DocElements]` array representing one valid combination of credentials that satisfies the verifier's DCQL query. When credential sets or the `multiple` flag produce multiple satisfiable combinations, the UI should allow the user to pick which option to present.
+
+When partial-claim presentation is enabled, each option includes only the claims that are both requested and available. The selected state of the items can be modified via UI binding.
 
 ```swift
+// Example: use the first credential selection option
+let selectedOption = presentationSession.disclosedDocumentSets.first ?? []
+
 // Send the disclosed document items after biometric authentication (FaceID or TouchID)
 // if the user cancels biometric authentication, onCancel method is called
 await presentationSession.sendResponse(userAccepted: true,
-  itemsToSend: presentationSession.disclosedDocuments.items, onCancel: { dismiss() }, onSuccess: {
+  itemsToSend: selectedOption.items, onCancel: { dismiss() }, onSuccess: {
     if let url = $0 {
       // handle URL
     }

--- a/Sources/EudiWalletKit/Models/CredentialSelection.swift
+++ b/Sources/EudiWalletKit/Models/CredentialSelection.swift
@@ -17,50 +17,27 @@
 import Foundation
 import MdocDataModel18013
 import OpenID4VP
+import OrderedCollections
 import struct WalletStorage.Document
 
-public typealias CredentialSelections = [Document.ID: CredentialSelection]
-public typealias CredentialSelectionSet = Set<CredentialSelection>
-public typealias CredentialSelectionSetOptions = [String: CredentialSelectionSet]
+public typealias CredentialSelectionSet = OrderedSet<CredentialSelection>
+public typealias CredentialSelectionSetOptions = OrderedDictionary<String, CredentialSelectionSet>
 
-extension CredentialSelectionSet {
-	public subscript(credentialId: Document.ID) -> CredentialSelection? {
-		first { $0.credentialId == credentialId }
-	}
-}
 
-extension CredentialSelectionSetOptions {
-	/// Finds a CredentialSelection by credential ID across all sets.
-	public subscript(credentialId: Document.ID) -> CredentialSelection? {
-		values.lazy.compactMap { $0[credentialId] }.first
-	}
-
-	/// Total number of unique credentials across all sets.
-	public var count: Int {
-		Set(values.flatMap { $0.map(\.credentialId) }).count
-	}
-}
-
-public struct CredentialSelection: Sendable, Hashable, RandomAccessCollection {
-	public typealias Element = ClaimsQuery
-	public typealias Index = Array<ClaimsQuery>.Index
-
+public struct CredentialSelection: Sendable, Hashable {
 	public let credentialId: Document.ID
 	public let docType: DocType
 	public let queryId: QueryId
+	public let optionId: String
 	public let claimQueries: [ClaimsQuery]
 
-	public init(credentialId: Document.ID, docType: DocType, queryId: QueryId, claimQueries: [ClaimsQuery]) {
+	public init(credentialId: Document.ID, docType: DocType, queryId: QueryId, optionId: String, claimQueries: [ClaimsQuery]) {
 		self.credentialId = credentialId
 		self.docType = docType
 		self.queryId = queryId
+		self.optionId = optionId
 		self.claimQueries = claimQueries
 	}
-
-	public var startIndex: Index { claimQueries.startIndex }
-	public var endIndex: Index { claimQueries.endIndex }
-	public func index(after i: Index) -> Index { claimQueries.index(after: i) }
-	public subscript(position: Index) -> ClaimsQuery { claimQueries[position] }
 
 	public static func == (lhs: CredentialSelection, rhs: CredentialSelection) -> Bool {
 		lhs.credentialId == rhs.credentialId

--- a/Sources/EudiWalletKit/Models/CredentialSelection.swift
+++ b/Sources/EudiWalletKit/Models/CredentialSelection.swift
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2023-2024 European Commission
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import Foundation
+import MdocDataModel18013
+import OpenID4VP
+import struct WalletStorage.Document
+
+public struct CredentialSelection: Sendable {
+
+	public let credentialId: Document.ID
+	public let docType: DocType
+	public let queryId: QueryId
+	public let claimQueries: [ClaimsQuery]
+
+	public init(credentialId: Document.ID, docType: DocType, queryId: QueryId, claimQueries: [ClaimsQuery]) {
+		self.credentialId = credentialId
+		self.docType = docType
+		self.queryId = queryId
+		self.claimQueries = claimQueries
+	}
+}

--- a/Sources/EudiWalletKit/Models/CredentialSelection.swift
+++ b/Sources/EudiWalletKit/Models/CredentialSelection.swift
@@ -19,7 +19,31 @@ import MdocDataModel18013
 import OpenID4VP
 import struct WalletStorage.Document
 
-public struct CredentialSelection: Sendable {
+public typealias CredentialSelections = [Document.ID: CredentialSelection]
+public typealias CredentialSelectionSet = Set<CredentialSelection>
+public typealias CredentialSelectionSetOptions = [String: CredentialSelectionSet]
+
+extension CredentialSelectionSet {
+	public subscript(credentialId: Document.ID) -> CredentialSelection? {
+		first { $0.credentialId == credentialId }
+	}
+}
+
+extension CredentialSelectionSetOptions {
+	/// Finds a CredentialSelection by credential ID across all sets.
+	public subscript(credentialId: Document.ID) -> CredentialSelection? {
+		values.lazy.compactMap { $0[credentialId] }.first
+	}
+
+	/// Total number of unique credentials across all sets.
+	public var count: Int {
+		Set(values.flatMap { $0.map(\.credentialId) }).count
+	}
+}
+
+public struct CredentialSelection: Sendable, Hashable, RandomAccessCollection {
+	public typealias Element = ClaimsQuery
+	public typealias Index = Array<ClaimsQuery>.Index
 
 	public let credentialId: Document.ID
 	public let docType: DocType
@@ -31,5 +55,18 @@ public struct CredentialSelection: Sendable {
 		self.docType = docType
 		self.queryId = queryId
 		self.claimQueries = claimQueries
+	}
+
+	public var startIndex: Index { claimQueries.startIndex }
+	public var endIndex: Index { claimQueries.endIndex }
+	public func index(after i: Index) -> Index { claimQueries.index(after: i) }
+	public subscript(position: Index) -> ClaimsQuery { claimQueries[position] }
+
+	public static func == (lhs: CredentialSelection, rhs: CredentialSelection) -> Bool {
+		lhs.credentialId == rhs.credentialId
+	}
+
+	public func hash(into hasher: inout Hasher) {
+		hasher.combine(credentialId)
 	}
 }

--- a/Sources/EudiWalletKit/Models/OpenId4VCIConfiguration.swift
+++ b/Sources/EudiWalletKit/Models/OpenId4VCIConfiguration.swift
@@ -38,7 +38,7 @@ public struct OpenId4VciConfiguration: Sendable {
 	/// Configuration that determines how authorization issuance should be handled
 	public let authorizeIssuanceConfig: AuthorizeIssuanceConfig
 	/// Whether to use Pushed Authorization Request (PAR) for enhanced security
-	public let requirePAR: ParUsage
+	public let parUsage: ParUsage
 	/// Whether to require DPoP (Demonstrating Proof-of-Possession)
 	public let requireDpop: Bool
 	/// Policy for handling signed issuer metadata fetched from `/.well-known/openid-credential-issuer`.
@@ -58,7 +58,7 @@ public struct OpenId4VciConfiguration: Sendable {
 		keyAttestationsConfig: KeyAttestationConfiguration? = nil,
 		authFlowRedirectionURI: URL? = nil,
 		authorizeIssuanceConfig: AuthorizeIssuanceConfig = .favorScopes,
-		requirePAR: ParUsage = .required(authorizationCodeDPoPBinding: true),
+		parUsage: ParUsage = .required(authorizationCodeDPoPBinding: true),
 		requireDpop: Bool = true,
 		issuerMetadataPolicy: IssuerMetadataPolicy = .ignoreSigned,
 		cacheIssuerMetadata: Bool = true,
@@ -71,7 +71,7 @@ public struct OpenId4VciConfiguration: Sendable {
 		self.keyAttestationsConfig = keyAttestationsConfig
 		self.authFlowRedirectionURI = authFlowRedirectionURI ?? URL(string: "eudi-openid4ci://authorize")!
 		self.authorizeIssuanceConfig = authorizeIssuanceConfig
-		self.requirePAR = requirePAR
+		self.parUsage = parUsage
 		self.requireDpop = requireDpop
 		self.issuerMetadataPolicy = issuerMetadataPolicy
 		self.userAuthenticationRequired = userAuthenticationRequired
@@ -168,7 +168,7 @@ extension OpenId4VciConfiguration {
 				.public(id: clientId)
 			}
 		let clientAttestationPoPBuilder: ClientAttestationPoPBuilder? = if keyAttestationsConfig != nil { DefaultClientAttestationPoPBuilder() } else { nil }
-		return OpenId4VCIConfig(client: client, authFlowRedirectionURI: authFlowRedirectionURI, authorizeIssuanceConfig: authorizeIssuanceConfig, requirePAR: requirePAR, clientAttestationPoPBuilder: clientAttestationPoPBuilder, issuerMetadataPolicy: issuerMetadataPolicy, requireDpop: requireDpop, supportedCredentialReusePolicies: Self.supportedCredentialReusePolicies)
+		return OpenId4VCIConfig(client: client, authFlowRedirectionURI: authFlowRedirectionURI, authorizeIssuanceConfig: authorizeIssuanceConfig, requirePAR: parUsage, clientAttestationPoPBuilder: clientAttestationPoPBuilder, issuerMetadataPolicy: issuerMetadataPolicy, requireDpop: requireDpop, supportedCredentialReusePolicies: Self.supportedCredentialReusePolicies)
 	}
 
 	private func makeAttestationClient(config: KeyAttestationConfiguration, credentialIssuerId: String, algorithms: [JWSAlgorithm]?) async throws -> Client {

--- a/Sources/EudiWalletKit/Models/OpenId4VCIConfiguration.swift
+++ b/Sources/EudiWalletKit/Models/OpenId4VCIConfiguration.swift
@@ -38,7 +38,7 @@ public struct OpenId4VciConfiguration: Sendable {
 	/// Configuration that determines how authorization issuance should be handled
 	public let authorizeIssuanceConfig: AuthorizeIssuanceConfig
 	/// Whether to use Pushed Authorization Request (PAR) for enhanced security
-	public let requirePAR: Bool
+	public let requirePAR: ParUsage
 	/// Whether to require DPoP (Demonstrating Proof-of-Possession)
 	public let requireDpop: Bool
 	/// Policy for handling signed issuer metadata fetched from `/.well-known/openid-credential-issuer`.
@@ -58,7 +58,7 @@ public struct OpenId4VciConfiguration: Sendable {
 		keyAttestationsConfig: KeyAttestationConfiguration? = nil,
 		authFlowRedirectionURI: URL? = nil,
 		authorizeIssuanceConfig: AuthorizeIssuanceConfig = .favorScopes,
-		requirePAR: Bool = true,
+		requirePAR: ParUsage = .required(authorizationCodeDPoPBinding: true),
 		requireDpop: Bool = true,
 		issuerMetadataPolicy: IssuerMetadataPolicy = .ignoreSigned,
 		cacheIssuerMetadata: Bool = true,

--- a/Sources/EudiWalletKit/Services/BlePresentationService.swift
+++ b/Sources/EudiWalletKit/Services/BlePresentationService.swift
@@ -237,12 +237,12 @@ public final class BlePresentationService: @unchecked Sendable, PresentationServ
 	///  Receive request via BLE
 	///
 	/// - Returns: The requested items.
-	public func receiveRequest() async throws -> UserRequestInfo {
+	public func receiveRequest() async throws -> [UserRequestInfo] {
 		let userRequestInfo = try await withCheckedThrowingContinuation { c in
 			continuationRequest = c
 		}
 		TransactionLogUtils.setCborTransactionLogRequestInfo(userRequestInfo, transactionLog: &transactionLog)
-		return userRequestInfo
+		return [userRequestInfo]
 	}
 
 	public func unlockKey(id: String) async throws -> Data? {

--- a/Sources/EudiWalletKit/Services/FaultPresentationService.swift
+++ b/Sources/EudiWalletKit/Services/FaultPresentationService.swift
@@ -43,7 +43,7 @@ public final class FaultPresentationService: @unchecked Sendable, PresentationSe
 		throw error
 	}
 
-	public func receiveRequest() async throws -> UserRequestInfo {
+	public func receiveRequest() async throws -> [UserRequestInfo] {
 		throw error
 	}
 

--- a/Sources/EudiWalletKit/Services/OpenId4VciService.swift
+++ b/Sources/EudiWalletKit/Services/OpenId4VciService.swift
@@ -563,7 +563,9 @@ public actor OpenId4VciService {
 
 	private func authorizeRequestWithAuthCodeUseCase(issuer: Issuer, offer: CredentialOffer) async throws -> AuthorizeRequestOutcome {
 		let pushedAuthorizationRequestEndpoint = if case let .oidc(metaData) = offer.authorizationServerMetadata, let endpoint = metaData.pushedAuthorizationRequestEndpoint { endpoint } else if case let .oauth(metaData) = offer.authorizationServerMetadata, let endpoint = metaData.pushedAuthorizationRequestEndpoint { endpoint } else { "" }
-		if config.requirePAR && pushedAuthorizationRequestEndpoint.isEmpty { logger.info("PAR not supported, Pushed Authorization Request Endpoint is nil") }
+		if config.requirePAR.required && pushedAuthorizationRequestEndpoint.isEmpty {
+			logger.info("PAR not supported, Pushed Authorization Request Endpoint is nil")
+		}
 		logger.info("--> [AUTHORIZATION] Placing Request to AS server's endpoint \(pushedAuthorizationRequestEndpoint)")
 		let parPlaced = try await issuer.prepareAuthorizationRequest(credentialOffer: offer)
 

--- a/Sources/EudiWalletKit/Services/OpenId4VciService.swift
+++ b/Sources/EudiWalletKit/Services/OpenId4VciService.swift
@@ -563,7 +563,7 @@ public actor OpenId4VciService {
 
 	private func authorizeRequestWithAuthCodeUseCase(issuer: Issuer, offer: CredentialOffer) async throws -> AuthorizeRequestOutcome {
 		let pushedAuthorizationRequestEndpoint = if case let .oidc(metaData) = offer.authorizationServerMetadata, let endpoint = metaData.pushedAuthorizationRequestEndpoint { endpoint } else if case let .oauth(metaData) = offer.authorizationServerMetadata, let endpoint = metaData.pushedAuthorizationRequestEndpoint { endpoint } else { "" }
-		if config.requirePAR.required && pushedAuthorizationRequestEndpoint.isEmpty {
+		if config.parUsage.required && pushedAuthorizationRequestEndpoint.isEmpty {
 			logger.info("PAR not supported, Pushed Authorization Request Endpoint is nil")
 		}
 		logger.info("--> [AUTHORIZATION] Placing Request to AS server's endpoint \(pushedAuthorizationRequestEndpoint)")

--- a/Sources/EudiWalletKit/Services/OpenId4VciService.swift
+++ b/Sources/EudiWalletKit/Services/OpenId4VciService.swift
@@ -783,7 +783,7 @@ public actor OpenId4VciService {
 		}
 		let deferredIssuanceRequester = await IssuanceRequester(issuerMetadata: issuer.issuerMetadata, poster: Poster(session: networking), dpopConstructor: dpopConstructor)
 		let deferredRequestResponse = try await deferredIssuanceRequester.placeDeferredCredentialRequest(
-			accessToken: authorized.accessToken, transactionId: transactionId, dPopNonce: nil, maxRetries: Constants.MAX_RETRIES, issuanceResponseEncryptionSpec: deferredResponseEncryptionSpec)
+			accessToken: authorized.accessToken, transactionId: transactionId, dPopNonce: nil, maxRetries: Constants.MAX_RETRIES, issuanceResponseEncryptionSpec: deferredResponseEncryptionSpec, encryptionSpec: nil)
 		switch deferredRequestResponse {
 		case .issued(let credential):
 			return try await Self.handleCredentialResponse(credentials: [credential], publicKeys: publicKeys, configuration: configuration, authorized: authorized, logger: logger)

--- a/Sources/EudiWalletKit/Services/OpenId4VpService.swift
+++ b/Sources/EudiWalletKit/Services/OpenId4VpService.swift
@@ -152,9 +152,9 @@ public final class OpenId4VpService: @unchecked Sendable, PresentationService {
 			let certificateIssuerName = readerCertificateIssuer.map(MdocHelpers.getCN(from:))
 			let rar = ReaderAuthenticationResult(isValidated: readerAuthValidated, certificateIssuer: certificateIssuerName, validationMessage: readerCertificateValidationMessage, legalName: rrd.legalName, authBytes: nil, certificateChain: certificateChain)
 			var results = [UserRequestInfo]()
-			for requestItems in requestItemsArray {
+			for (requestName, requestItems) in requestItemsArray {
 				//guard let requestItems, let formatsRequested else { throw PresentationSession.makeError(str: "Invalid request query") }
-				var result = UserRequestInfo(docDataFormats: formatsRequested, itemsRequested: requestItems, deviceRequestBytes: deviceRequestBytes)
+				var result = UserRequestInfo(docDataFormats: formatsRequested, itemsRequested: requestItems, deviceRequestBytes: deviceRequestBytes, requestName: requestName)
 				logger.info("Verifier requested items: \(requestItems.mapValues { $0.mapValues { ar in ar.map(\.elementIdentifier) } })")
 				result.readerAuthResults = ["": rar]
 				TransactionLogUtils.setCborTransactionLogRequestInfo(result, transactionLog: &transactionLog)

--- a/Sources/EudiWalletKit/Services/OpenId4VpService.swift
+++ b/Sources/EudiWalletKit/Services/OpenId4VpService.swift
@@ -97,7 +97,7 @@ public final class OpenId4VpService: @unchecked Sendable, PresentationService {
 	///  Receive request from an openid4vp URL
 	///
 	/// - Returns: The requested items.
-	public func receiveRequest() async throws -> UserRequestInfo {
+	public func receiveRequest() async throws -> [UserRequestInfo] {
 		guard status != .error, let openid4VPURI = URL(string: openid4VPlink) else { throw PresentationSession.makeError(str: "Invalid link \(openid4VPlink)") }
 		openId4Vp = OpenID4VP(walletConfiguration: getWalletConf())
 		switch await openId4Vp.authorize(fetcher: Fetcher<String>(session: networking), poster: Poster(session: networking), url: openid4VPURI)  {
@@ -113,7 +113,7 @@ public final class OpenId4VpService: @unchecked Sendable, PresentationService {
 		}
 	}
 
-	func handleRequestData(_ rrd: ResolvedRequestData) throws -> UserRequestInfo {
+	func handleRequestData(_ rrd: ResolvedRequestData) throws -> [UserRequestInfo] {
 		self.resolvedRequestData = rrd
 		let vp = rrd.request
 		var jwkThumbprint: Data?  = nil
@@ -129,38 +129,39 @@ public final class OpenId4VpService: @unchecked Sendable, PresentationService {
 			// Generate a jwkThumbprint if possible.
 			let publicKey = ECPublicKey(crv: ecCrvType, x: x , y: y)
 			jwkThumbprint = (try? publicKey.thumbprint(algorithm: .SHA256)).flatMap { Data(base64URLEncoded: $0) }
-
 		}
 		// Add support for directPost.
 		let responseUri = if case .directPostJWT(let uri) = vp.responseMode { uri.absoluteString } else if case .directPost(let uri) = vp.responseMode { uri.absoluteString } else { "" }
-
 		let resolvedClientId = vp.client.id.clientId
 		vpNonce = vp.nonce; vpClientId = resolvedClientId
 		mdocGeneratedNonce = OpenId4VpUtils.generateMdocGeneratedNonce()	// Not longer required for SessionTranscript, use the verifier (client) nonce i.e vpNonce
 		sessionTranscript = SessionTranscript(handOver: OpenId4VpUtils.generateOpenId4VpHandover(clientId: resolvedClientId, responseUri: responseUri, nonce: vpNonce, jwkThumbprint: jwkThumbprint?.byteArray))
 
 		logger.info("Session Transcript: \(sessionTranscript.encode().toHexString()), for clientId: \(vp.client.id), responseUri: \(responseUri), nonce: \(vp.nonce), mdocGeneratedNonce: \(mdocGeneratedNonce!)")
-		var requestItems: RequestItems?; var deviceRequestBytes: Data?
 		// Only DCQL supported now
 		if case let .byDigitalCredentialsQuery(dcql) = vp.presentationQuery {
 			self.dcql = dcql
-			deviceRequestBytes = try? JSONEncoder().encode(dcql)
+			let deviceRequestBytes = try? JSONEncoder().encode(dcql)
 			let (fmtsReq, imap, zkSpecMap) = try OpenId4VpUtils.parseDcqlFormats(dcql, idsToDocTypes: transferInfo.idsToDocTypes, logger: logger)
 			formatsRequested = fmtsReq; inputDescriptorMap = imap; zkSpecsRequested = zkSpecMap
 			decodeDocuments()
-			let claimMapPath = try OpenId4VpUtils.resolveDcql(
+			let credentialSelectionSets = try OpenId4VpUtils.resolveDcql(
 				dcql, queryable: dcqlQueryable, allowPresentingPartialClaims: openID4VpConfig.allowPresentingPartialClaims)
-			requestItems = OpenId4VpUtils.getRequestItems(claimMapPath, idsToDocTypes: transferInfo.idsToDocTypes, formatsRequested: formatsRequested)
-		}
-		self.transactionData = vp.transactionData
-		guard let requestItems, let formatsRequested else { throw PresentationSession.makeError(str: "Invalid request query") }
-		var result = UserRequestInfo(docDataFormats: formatsRequested, itemsRequested: requestItems, deviceRequestBytes: deviceRequestBytes)
-		logger.info("Verifier requested items: \(requestItems.mapValues { $0.mapValues { ar in ar.map(\.elementIdentifier) } })")
-		let certificateIssuerName = readerCertificateIssuer.map(MdocHelpers.getCN(from:))
-		let rar = ReaderAuthenticationResult(isValidated: readerAuthValidated, certificateIssuer: certificateIssuerName, validationMessage: readerCertificateValidationMessage, legalName: rrd.legalName, authBytes: nil, certificateChain: certificateChain)
-		result.readerAuthResults = ["": rar]
-		TransactionLogUtils.setCborTransactionLogRequestInfo(result, transactionLog: &transactionLog)
-		return result
+			let requestItemsArray = OpenId4VpUtils.getRequestItems(credentialSelectionSets, idsToDocTypes: transferInfo.idsToDocTypes, formatsRequested: formatsRequested)
+			self.transactionData = vp.transactionData
+			let certificateIssuerName = readerCertificateIssuer.map(MdocHelpers.getCN(from:))
+			let rar = ReaderAuthenticationResult(isValidated: readerAuthValidated, certificateIssuer: certificateIssuerName, validationMessage: readerCertificateValidationMessage, legalName: rrd.legalName, authBytes: nil, certificateChain: certificateChain)
+			var results = [UserRequestInfo]()
+			for requestItems in requestItemsArray {
+				//guard let requestItems, let formatsRequested else { throw PresentationSession.makeError(str: "Invalid request query") }
+				var result = UserRequestInfo(docDataFormats: formatsRequested, itemsRequested: requestItems, deviceRequestBytes: deviceRequestBytes)
+				logger.info("Verifier requested items: \(requestItems.mapValues { $0.mapValues { ar in ar.map(\.elementIdentifier) } })")
+				result.readerAuthResults = ["": rar]
+				TransactionLogUtils.setCborTransactionLogRequestInfo(result, transactionLog: &transactionLog)
+				results.append(result)
+			}
+			return results
+		} else { throw PresentationSession.makeError(str: "Unsupported presentation query") }
 	}
 
 	fileprivate func makeCborDocs() {

--- a/Sources/EudiWalletKit/Services/Openid4VpUtils.swift
+++ b/Sources/EudiWalletKit/Services/Openid4VpUtils.swift
@@ -136,11 +136,11 @@ class OpenId4VpUtils {
 		}
 	}
 
-	static func getRequestItems(_ credentialSet: CredentialSelectionSetOptions, idsToDocTypes: [Document.ID: DocType], formatsRequested: [DocType: DocDataFormat]) -> [RequestItems] {
-		var requestItemsArray = [RequestItems]()
-		for selection in credentialSet.values {
+	static func getRequestItems(_ credentialSetOptions: CredentialSelectionSetOptions, idsToDocTypes: [Document.ID: DocType], formatsRequested: [DocType: DocDataFormat]) -> [(String, RequestItems)] {
+		var requestItemsArray = [(String, RequestItems)]()
+		for (requestName, credentialSet) in credentialSetOptions {
 			var requestItems = RequestItems()
-			for credentialSelectionSet in selection {
+			for credentialSelectionSet in credentialSet {
 				let id = credentialSelectionSet.credentialId
 				guard let docType = idsToDocTypes[id], let formatRequested = formatsRequested[docType] else { continue }
 				var nsItems: [String: [RequestItem]] = [:]
@@ -150,7 +150,7 @@ class OpenId4VpUtils {
 				}
 				requestItems[id] = nsItems
 			}
-			requestItemsArray.append(requestItems)
+			requestItemsArray.append((requestName, requestItems))
 		}
 		return requestItemsArray
 	}
@@ -302,16 +302,21 @@ extension OpenId4VpUtils {
 		// Step 2: Handle credential_sets if present
 		if let credentialSets = dcql.credentialSets {
 			// Collect all satisfying options; key is the option (CredentialSet = Set<QueryId>)
-			for credSet in credentialSets {
+			for (credSetIndex, credSet) in credentialSets.enumerated() {
+				let isSetRequired = credSet.required ?? CredentialSetQuery.defaultRequiredValue
 				var isSetSatisfied = false
-				for option in credSet.options {
+				for (optionIndex, option) in credSet.options.enumerated() {
 					let baseOptionKey = option.map(\.value).joined(separator: ",") // key for this option based on queryIds it contains
+					if !isSetRequired {
+						let optionalOptionKey = "optional:\(credSetIndex):\(optionIndex):\(baseOptionKey)"
+						result[optionalOptionKey, default: []] = []
+					}
 					let optionSatisfied = option.allSatisfy { queryId in credentialQueryResults[queryId]?.isEmpty == false }
 					if optionSatisfied {
 						isSetSatisfied = true
 						for queryId in option {
 							for match in (credentialQueryResults[queryId] ?? []).enumerated() {
-								let optionKey = if isMultipleByQueryId[queryId] == true { baseOptionKey } else { "\(baseOptionKey):\(queryId.value):\(match.offset)" }
+								let optionKey = if isMultipleByQueryId[queryId] == true { baseOptionKey } else { "\(baseOptionKey):\(match.element.credentialId):\(match.offset)" }
 								if let existingSelection = result[optionKey]?.first(where: { $0.credentialId == match.element.credentialId }) {
 									let mergedPaths = existingSelection.claimQueries + match.element.claimQueries
 									let uniquePaths = Array(Set(mergedPaths.map(\.path.value))).compactMap { p in mergedPaths.first { $0.path.value == p } }
@@ -325,7 +330,6 @@ extension OpenId4VpUtils {
 						// Continue to collect all satisfying options (no break)
 					}
 				}
-				let isSetRequired = credSet.required ?? CredentialSetQuery.defaultRequiredValue
 				if isSetRequired, !isSetSatisfied {
 					throw WalletError(description: "Required credential_set \(credSet.options) cannot be satisfied", code: .credentialSetNotSatisfied)
 				}
@@ -333,9 +337,9 @@ extension OpenId4VpUtils {
 		} else {
 			// No credential_sets: collect results under nil key
 			for (_, matches) in credentialQueryResults {
-				for match in matches.enumerated() {
-					let optionKey = if isMultipleByQueryId[match.element.queryId] == true { "" } else { "\(match.element.queryId.value):\(match.offset)" }
-					result[optionKey, default: []].insert(match.element)
+				for (matchIndex, match) in matches.enumerated() {
+					let optionKey = if isMultipleByQueryId[match.queryId] == true { "" } else { "\(match.queryId.value):\(match.credentialId):\(matchIndex)" }
+					result[optionKey, default: []].insert(match)
 				}
 			}
 		}

--- a/Sources/EudiWalletKit/Services/Openid4VpUtils.swift
+++ b/Sources/EudiWalletKit/Services/Openid4VpUtils.swift
@@ -183,9 +183,7 @@ class OpenId4VpUtils {
 		var payload = [Keys.nonce.rawValue: nonce, Keys.aud.rawValue: aud, Keys.iat.rawValue: issuedAtTimestamp, Keys.sdHash.rawValue: sdHash] as [String : Any]
 		  // Process transaction data hashes if available
 		if let transactionData, !transactionData.isEmpty {
-			let transactionDataHashes = transactionData.map { td -> String in
-				switch td {	case .sdJwtVc(let v): return sha256Hash(v) }
-			}
+			let transactionDataHashes = transactionData.map { sha256Hash($0.value) }
 			payload["transaction_data_hashes_alg"] = "sha-256"
 			payload["transaction_data_hashes"] = transactionDataHashes
 		}

--- a/Sources/EudiWalletKit/Services/Openid4VpUtils.swift
+++ b/Sources/EudiWalletKit/Services/Openid4VpUtils.swift
@@ -136,12 +136,12 @@ class OpenId4VpUtils {
 		}
 	}
 
-	static func getRequestItems(_ credentialMaps: [Document.ID: [ClaimsQuery]], idsToDocTypes: [Document.ID: DocType], formatsRequested: [DocType: DocDataFormat]) -> RequestItems {
+	static func getRequestItems(_ credentialMaps: [Document.ID: CredentialSelection], idsToDocTypes: [Document.ID: DocType], formatsRequested: [DocType: DocDataFormat]) -> RequestItems {
 		var requestItems = RequestItems()
-		for (id, claims) in credentialMaps {
+		for (id, selection) in credentialMaps {
 			guard let docType = idsToDocTypes[id], let formatRequested = formatsRequested[docType] else { continue }
 			var nsItems: [String: [RequestItem]] = [:]
-			for claim in claims {
+			for claim in selection.claimQueries {
 				guard let pair =  Self.parseClaim(claim, formatRequested) else { continue }
 				if !nsItems[pair.0, default: []].contains(pair.1) { nsItems[pair.0, default: []].append(pair.1) }
 			}
@@ -265,10 +265,10 @@ extension OpenId4VpUtils {
 	/// - Returns: A dictionary mapping matched credential IDs to arrays of ClaimPath objects representing
 	///            the claims to disclose
 	/// - Throws: WalletError if the query cannot be satisfied, with details about the first missing claim
-	static func resolveDcql(_ dcql: DCQL, queryable: DcqlQueryable, allowPresentingPartialClaims: Bool = false) throws -> [Document.ID: [ClaimsQuery]] {
-		var result: [Document.ID: [ClaimsQuery]] = [:]
+	static func resolveDcql(_ dcql: DCQL, queryable: DcqlQueryable, allowPresentingPartialClaims: Bool = false) throws -> [Document.ID: CredentialSelection] {
+		var result: [Document.ID: CredentialSelection] = [:]
 		var lastError: WalletError?
-		var credentialQueryResults: [QueryId: [(matchedCredId: Document.ID, claimQueries: [ClaimsQuery])]] = [:]
+		var credentialQueryResults: [QueryId: [CredentialSelection]] = [:]
 		// Step 1: Process individual credential queries
 		for credQuery in dcql.credentials {
 			guard let docType = credQuery.docType else { throw WalletError(description: "Credential query \(credQuery.id.value) does not have a doc type") }
@@ -281,7 +281,7 @@ extension OpenId4VpUtils {
 			for credId in matchingCredIds {
 				do {
 					let claimPaths = try resolveClaimsForCredential(credQuery: credQuery, credId: credId, queryable: queryable, allowPresentingPartialClaims: allowPresentingPartialClaims)
-					credentialQueryResults[credQuery.id, default: []].append((credId, claimPaths))
+					credentialQueryResults[credQuery.id, default: []].append(CredentialSelection(credentialId: credId, docType: docType, queryId: credQuery.id, claimQueries: claimPaths))
 					if !isMultiple { break } // for non-multiple queries, stop at first match
 				} catch {
 					lastError = error
@@ -305,15 +305,13 @@ extension OpenId4VpUtils {
 						for queryId in option {
 							for match in credentialQueryResults[queryId] ?? [] {
 								// If the credential ID already exists, merge claim paths
-								if let existingPaths = result[match.matchedCredId] {
+								if let existingSelection = result[match.credentialId] {
 									// Merge and deduplicate claim paths
-									let mergedPaths = existingPaths + match.claimQueries
-									let uniquePaths = Array(Set(mergedPaths.map(\.path.value))).compactMap { pathValue in
-										mergedPaths.first { $0.path.value == pathValue }
-									}
-									result[match.matchedCredId] = uniquePaths
+									let mergedPaths = existingSelection.claimQueries + match.claimQueries
+									let uniquePaths = Array(Set(mergedPaths.map(\.path.value))).compactMap { p in mergedPaths.first { $0.path.value == p } }
+									result[match.credentialId] = CredentialSelection(credentialId: match.credentialId, docType: match.docType, queryId: existingSelection.queryId, claimQueries: uniquePaths)
 								} else {
-									result[match.matchedCredId] = match.claimQueries
+									result[match.credentialId] = match
 								}
 							}
 						}
@@ -328,7 +326,7 @@ extension OpenId4VpUtils {
 		} else {
 			for (_, matches) in credentialQueryResults {
 				for match in matches {
-					result[match.matchedCredId] = match.claimQueries
+					result[match.credentialId] = match
 				}
 			}
 		}

--- a/Sources/EudiWalletKit/Services/Openid4VpUtils.swift
+++ b/Sources/EudiWalletKit/Services/Openid4VpUtils.swift
@@ -266,29 +266,31 @@ extension OpenId4VpUtils {
 	/// - Returns: A dictionary mapping matched credential IDs to arrays of ClaimPath objects representing
 	///            the claims to disclose
 	/// - Throws: WalletError if the query cannot be satisfied, with details about the first missing claim
-	static func resolveDcql(_ dcql: DCQL, queryable: DcqlQueryable, allowPresentingPartialClaims: Bool = false) throws -> [String: [ClaimsQuery]] {
-		var result: [String: [ClaimsQuery]] = [:]
+	static func resolveDcql(_ dcql: DCQL, queryable: DcqlQueryable, allowPresentingPartialClaims: Bool = false) throws -> [Document.ID: [ClaimsQuery]] {
+		var result: [Document.ID: [ClaimsQuery]] = [:]
 		var lastError: WalletError?
-		var credentialQueryResults: [QueryId: (matchedCredId: Document.ID, claimQueries: [ClaimsQuery])] = [:]
+		var credentialQueryResults: [QueryId: [(matchedCredId: Document.ID, claimQueries: [ClaimsQuery])]] = [:]
 		// Step 1: Process individual credential queries
 		for credQuery in dcql.credentials {
 			guard let docType = credQuery.docType else { throw WalletError(description: "Credential query \(credQuery.id.value) does not have a doc type") }
 			let format = credQuery.dataFormat
+			let isMultiple = credQuery.multiple == true
 			// Find matching credentials
 			let matchingCredIds = queryable.getCredentials(docOrVctType: docType, docDataFormat: format)
 			if matchingCredIds.isEmpty, dcql.credentialSets == nil { throw WalletError(description: "Credential with docType \(docType) cannot be found.", code: .credentialNotFound, context: ["docType": docType]) }
-			// Try to find a credential that satisfies the claim requirements
+			// Try to find credentials that satisfy the claim requirements
 			for credId in matchingCredIds {
 				do {
 					let claimPaths = try resolveClaimsForCredential(credQuery: credQuery, credId: credId, queryable: queryable, allowPresentingPartialClaims: allowPresentingPartialClaims)
-					credentialQueryResults[credQuery.id] = (credId, claimPaths)
+					credentialQueryResults[credQuery.id, default: []].append((credId, claimPaths))
+					if !isMultiple { break } // for non-multiple queries, stop at first match
 				} catch {
 					lastError = error
 					logger.warning("Credential \(credId) does not satisfy query \(credQuery.id.value): \(error.localizedDescription)")
 					// continue trying other credentials that match the docType
 				}
 			}
-			if credentialQueryResults[credQuery.id] == nil, dcql.credentialSets == nil {
+			if credentialQueryResults[credQuery.id]?.isEmpty != false, dcql.credentialSets == nil {
    			 throw lastError ?? WalletError(description: "No credential satisfies query \(credQuery.id.value)", code: .dcqlQueryNotSatisfied)
 			}
 		}
@@ -298,11 +300,11 @@ extension OpenId4VpUtils {
 			for credSet in credentialSets {
 				var isSetSatisfied = false
 				for option in credSet.options {
-					isSetSatisfied = option.allSatisfy { queryId in credentialQueryResults[queryId] != nil}
+					isSetSatisfied = option.allSatisfy { queryId in credentialQueryResults[queryId]?.isEmpty == false }
 					if isSetSatisfied {
 						// Add the credentials from this option to the result
 						for queryId in option {
-							if let match = credentialQueryResults[queryId] {
+							for match in credentialQueryResults[queryId] ?? [] {
 								// If the credential ID already exists, merge claim paths
 								if let existingPaths = result[match.matchedCredId] {
 									// Merge and deduplicate claim paths
@@ -325,12 +327,14 @@ extension OpenId4VpUtils {
 				}
 			}
 		} else {
-			for (_, match) in credentialQueryResults {
-				result[match.matchedCredId] = match.claimQueries
+			for (_, matches) in credentialQueryResults {
+				for match in matches {
+					result[match.matchedCredId] = match.claimQueries
+				}
 			}
 		}
 		if result.isEmpty {
-			let notFoundCred = dcql.credentials.first { c in credentialQueryResults[c.id] == nil }
+			let notFoundCred = dcql.credentials.first { c in credentialQueryResults[c.id]?.isEmpty != false }
 			if let notFoundCred {logger.warning("No credential found matching docType: \(notFoundCred.docType ?? "") with format: \(notFoundCred.format)")}
 			throw lastError ?? WalletError(description: "DCQL query could not be satisfied", code: .dcqlQueryNotSatisfied)
 		}

--- a/Sources/EudiWalletKit/Services/Openid4VpUtils.swift
+++ b/Sources/EudiWalletKit/Services/Openid4VpUtils.swift
@@ -145,7 +145,7 @@ class OpenId4VpUtils {
 				guard let pair =  Self.parseClaim(claim, formatRequested) else { continue }
 				if !nsItems[pair.0, default: []].contains(pair.1) { nsItems[pair.0, default: []].append(pair.1) }
 			}
-			requestItems[docType] = nsItems
+			requestItems[id] = nsItems
 		}
 		return requestItems
 	}

--- a/Sources/EudiWalletKit/Services/Openid4VpUtils.swift
+++ b/Sources/EudiWalletKit/Services/Openid4VpUtils.swift
@@ -350,15 +350,12 @@ extension OpenId4VpUtils {
 				}
 				return (isSetRequired, setOptions)
 			}
-
 			let requiredSetsOptions = setsWithOptions.filter(\.isRequired).map(\.options)
 			let optionalSetsOptions = setsWithOptions.filter { !$0.isRequired && !$0.options.isEmpty }.map(\.options)
-
 			// Verify all required sets are satisfiable
 			if requiredSetsOptions.contains(where: \.isEmpty) {
 				throw WalletError(description: "Required credential_set cannot be satisfied", code: .credentialSetNotSatisfied)
 			}
-
 			// Cartesian product across all required sets
 			let requiredCombinations = requiredSetsOptions.reduce([(String, CredentialSelectionSet)]()) { acc, setOptions in
 				if acc.isEmpty { return setOptions }
@@ -372,7 +369,6 @@ extension OpenId4VpUtils {
 					}
 				}
 			}
-
 			// Expand with optional sets (include variants with and without each optional)
 			let combinations = optionalSetsOptions.reduce(requiredCombinations) { acc, optSetOptions in
 				acc.flatMap { (existingKey, existingSet) in
@@ -386,7 +382,6 @@ extension OpenId4VpUtils {
 					}
 				}
 			}
-
 			for (key, set) in combinations {
 				resultDict[key] = set
 			}

--- a/Sources/EudiWalletKit/Services/Openid4VpUtils.swift
+++ b/Sources/EudiWalletKit/Services/Openid4VpUtils.swift
@@ -143,8 +143,7 @@ class OpenId4VpUtils {
 			var nsItems: [String: [RequestItem]] = [:]
 			for claim in claims {
 				guard let pair =  Self.parseClaim(claim, formatRequested) else { continue }
-				if nsItems[pair.0] == nil { nsItems[pair.0] = [] }
-				if !nsItems[pair.0]!.contains(pair.1) { nsItems[pair.0]!.append(pair.1) }
+				if !nsItems[pair.0, default: []].contains(pair.1) { nsItems[pair.0, default: []].append(pair.1) }
 			}
 			requestItems[docType] = nsItems
 		}

--- a/Sources/EudiWalletKit/Services/Openid4VpUtils.swift
+++ b/Sources/EudiWalletKit/Services/Openid4VpUtils.swift
@@ -18,6 +18,7 @@ import Foundation
 import SwiftCBOR
 import CryptoKit
 import Logging
+import OrderedCollections
 import MdocDataModel18013
 import MdocSecurity18013
 import MdocDataTransfer18013
@@ -250,6 +251,20 @@ extension DCQL {
 	}
 }
 
+extension CredentialSelectionSet {
+	/// Merges claims if the credential already exists in the set, otherwise appends
+	mutating func mergeOrAppend(_ sel: CredentialSelection) {
+		if let existing = first(where: { $0.credentialId == sel.credentialId }) {
+			let mergedPaths = existing.claimQueries + sel.claimQueries
+			let uniquePaths = Array(Set(mergedPaths.map(\.path.value))).compactMap { p in mergedPaths.first { $0.path.value == p } }
+			remove(existing)
+			append(CredentialSelection(credentialId: sel.credentialId, docType: sel.docType, queryId: existing.queryId, optionId: existing.optionId, claimQueries: uniquePaths))
+		} else {
+			append(sel)
+		}
+	}
+}
+
 extension OpenId4VpUtils {
 	/// Resolves a DCQL query against available credentials in the wallet
 	///
@@ -271,23 +286,23 @@ extension OpenId4VpUtils {
 	///            the claims to disclose
 	/// - Throws: WalletError if the query cannot be satisfied, with details about the first missing claim
 	static func resolveDcql(_ dcql: DCQL, queryable: DcqlQueryable, allowPresentingPartialClaims: Bool = false) throws -> CredentialSelectionSetOptions {
-		var result: CredentialSelectionSetOptions = [:]
+		var resultDict: CredentialSelectionSetOptions = [:]
 		var lastError: WalletError?
-		var credentialQueryResults: [QueryId: [CredentialSelection]] = [:]
-		let isMultipleByQueryId = Dictionary(uniqueKeysWithValues: dcql.credentials.map { ($0.id, $0.multiple == true) })
+		var credentialQueryResults: OrderedDictionary<QueryId, [CredentialSelection]> = [:]
 		// Step 1: Process individual credential queries
 		for credQuery in dcql.credentials {
 			guard let docType = credQuery.docType else { throw WalletError(description: "Credential query \(credQuery.id.value) does not have a doc type") }
 			let format = credQuery.dataFormat
-			//let isMultiple = credQuery.multiple == true
+			let isMultiple = credQuery.multiple == true
 			// Find matching credentials
 			let matchingCredIds = queryable.getCredentials(docOrVctType: docType, docDataFormat: format)
 			if matchingCredIds.isEmpty, dcql.credentialSets == nil { throw WalletError(description: "Credential with docType \(docType) cannot be found.", code: .credentialNotFound, context: ["docType": docType]) }
 			// Try to find credentials that satisfy the claim requirements
-			for credId in matchingCredIds {
+			for (credIndex, credId) in matchingCredIds.enumerated() {
 				do {
+					let optionId = !isMultiple ? "\(credQuery.id.value)-\(credIndex)" : credQuery.id.value
 					let claimPaths = try resolveClaimsForCredential(credQuery: credQuery, credId: credId, queryable: queryable, allowPresentingPartialClaims: allowPresentingPartialClaims)
-					credentialQueryResults[credQuery.id, default: []].append(CredentialSelection(credentialId: credId, docType: docType, queryId: credQuery.id, claimQueries: claimPaths))
+					credentialQueryResults[credQuery.id, default: []].append(CredentialSelection(credentialId: credId, docType: docType, queryId: credQuery.id, optionId: optionId, claimQueries: claimPaths))
 					//if !isMultiple { break } // for non-multiple queries, stop at first match
 				} catch {
 					lastError = error
@@ -301,54 +316,115 @@ extension OpenId4VpUtils {
 		}
 		// Step 2: Handle credential_sets if present
 		if let credentialSets = dcql.credentialSets {
-			// Collect all satisfying options; key is the option (CredentialSet = Set<QueryId>)
-			for (credSetIndex, credSet) in credentialSets.enumerated() {
+			// For each credential set, collect satisfiable options expanded by credential alternatives
+			let setsWithOptions: [(isRequired: Bool, options: [(String, CredentialSelectionSet)])] = credentialSets.map { credSet in
 				let isSetRequired = credSet.required ?? CredentialSetQuery.defaultRequiredValue
-				var isSetSatisfied = false
-				for (optionIndex, option) in credSet.options.enumerated() {
-					let baseOptionKey = option.map(\.value).joined(separator: ",") // key for this option based on queryIds it contains
-					if !isSetRequired {
-						let optionalOptionKey = "optional:\(credSetIndex):\(optionIndex):\(baseOptionKey)"
-						result[optionalOptionKey, default: []] = []
-					}
+				let setOptions: [(String, CredentialSelectionSet)] = credSet.options.flatMap { option -> [(String, CredentialSelectionSet)] in
 					let optionSatisfied = option.allSatisfy { queryId in credentialQueryResults[queryId]?.isEmpty == false }
-					if optionSatisfied {
-						isSetSatisfied = true
-						for queryId in option {
-							for match in (credentialQueryResults[queryId] ?? []).enumerated() {
-								let optionKey = if isMultipleByQueryId[queryId] == true { baseOptionKey } else { "\(baseOptionKey):\(match.element.credentialId):\(match.offset)" }
-								if let existingSelection = result[optionKey]?.first(where: { $0.credentialId == match.element.credentialId }) {
-									let mergedPaths = existingSelection.claimQueries + match.element.claimQueries
-									let uniquePaths = Array(Set(mergedPaths.map(\.path.value))).compactMap { p in mergedPaths.first { $0.path.value == p } }
-									result[optionKey]?.remove(existingSelection)
-									result[optionKey, default: []].insert(CredentialSelection(credentialId: match.element.credentialId, docType: match.element.docType, queryId: existingSelection.queryId, claimQueries: uniquePaths))
-								} else {
-									result[optionKey, default: []].insert(match.element)
-								}
-							}
+					guard optionSatisfied else { return [] }
+					// For each queryId in the option, get match groups (bundled for multiple, individual otherwise)
+					let matchGroups: [[(String, [CredentialSelection])]] = option.map { queryId in
+						let matches = credentialQueryResults[queryId] ?? []
+						let isMultiple = dcql.findQuery(id: queryId.value)?.multiple == true
+						if isMultiple {
+							// Bundle all matches together as one group
+							return [(matches.first?.optionId ?? queryId.value, matches)]
+						} else {
+							// Each match is a separate alternative
+							return matches.map { ($0.optionId, [$0]) }
 						}
-						// Continue to collect all satisfying options (no break)
+					}
+					// Cartesian product across match groups
+					let combinations = matchGroups.reduce([([String](), [CredentialSelection]())]) { acc, groups in
+						acc.flatMap { (keys, sels) in
+							groups.map { (key, groupSels) in (keys + [key], sels + groupSels) }
+						}
+					}
+					return combinations.map { (keys, sels) in
+						let optionKey = keys.joined(separator: "+")
+						let selections = sels.reduce(into: CredentialSelectionSet()) { set, sel in
+							set.mergeOrAppend(sel)
+						}
+						return (optionKey, selections)
 					}
 				}
-				if isSetRequired, !isSetSatisfied {
-					throw WalletError(description: "Required credential_set \(credSet.options) cannot be satisfied", code: .credentialSetNotSatisfied)
+				return (isSetRequired, setOptions)
+			}
+
+			let requiredSetsOptions = setsWithOptions.filter(\.isRequired).map(\.options)
+			let optionalSetsOptions = setsWithOptions.filter { !$0.isRequired && !$0.options.isEmpty }.map(\.options)
+
+			// Verify all required sets are satisfiable
+			if requiredSetsOptions.contains(where: \.isEmpty) {
+				throw WalletError(description: "Required credential_set cannot be satisfied", code: .credentialSetNotSatisfied)
+			}
+
+			// Cartesian product across all required sets
+			let requiredCombinations = requiredSetsOptions.reduce([(String, CredentialSelectionSet)]()) { acc, setOptions in
+				if acc.isEmpty { return setOptions }
+				return acc.flatMap { (existingKey, existingSet) in
+					setOptions.map { (optKey, optSet) in
+						let combinedKey = existingKey.isEmpty ? optKey : "\(existingKey)|\(optKey)"
+						let combinedSet = optSet.reduce(into: existingSet) { set, sel in
+							set.mergeOrAppend(sel)
+						}
+						return (combinedKey, combinedSet)
+					}
 				}
+			}
+
+			// Expand with optional sets (include variants with and without each optional)
+			let combinations = optionalSetsOptions.reduce(requiredCombinations) { acc, optSetOptions in
+				acc.flatMap { (existingKey, existingSet) in
+					// Keep without optional + add each optional variant
+					[(existingKey, existingSet)] + optSetOptions.map { (optKey, optSet) in
+						let combinedKey = existingKey.isEmpty ? optKey : "\(existingKey)|\(optKey)"
+						let combinedSet = optSet.reduce(into: existingSet) { set, sel in
+							set.mergeOrAppend(sel)
+						}
+						return (combinedKey, combinedSet)
+					}
+				}
+			}
+
+			for (key, set) in combinations {
+				resultDict[key] = set
 			}
 		} else {
-			// No credential_sets: collect results under nil key
-			for (_, matches) in credentialQueryResults {
-				for (matchIndex, match) in matches.enumerated() {
-					let optionKey = if isMultipleByQueryId[match.queryId] == true { "" } else { "\(match.queryId.value):\(match.credentialId):\(matchIndex)" }
-					result[optionKey, default: []].insert(match)
+			// No credential_sets: Cartesian product across credential query results
+			// For `multiple` queries, all matches are bundled together; otherwise each match is a separate alternative
+			let matchGroups: [(String, [(String, [CredentialSelection])])] = credentialQueryResults.map { (queryId, matches) in
+				let isMultiple = dcql.findQuery(id: queryId.value)?.multiple == true
+				if isMultiple {
+					// All matches bundled as one group
+					return (queryId.value, [(matches.first?.optionId ?? queryId.value, matches)])
+				} else {
+					// Each match is a separate alternative
+					return (queryId.value, matches.map { ($0.optionId, [$0]) })
 				}
 			}
+
+			let combinations = matchGroups.reduce([([String](), [CredentialSelection]())]) { acc, entry in
+				let (_, groups) = entry
+				return acc.flatMap { (keys, sels) in
+					groups.map { (key, groupSels) in (keys + [key], sels + groupSels) }
+				}
+			}
+
+			for (keys, sels) in combinations {
+				let optionKey = keys.joined(separator: "|")
+				let selectionSet = sels.reduce(into: CredentialSelectionSet()) { set, sel in
+					set.mergeOrAppend(sel)
+				}
+				resultDict[optionKey] = selectionSet
+			}
 		}
-		if result.isEmpty {
+		if resultDict.isEmpty {
 			let notFoundCred = dcql.credentials.first { c in credentialQueryResults[c.id]?.isEmpty != false }
 			if let notFoundCred {logger.warning("No credential found matching docType: \(notFoundCred.docType ?? "") with format: \(notFoundCred.format)")}
 			throw lastError ?? WalletError(description: "DCQL query could not be satisfied", code: .dcqlQueryNotSatisfied)
 		}
-		return result
+		return resultDict
 	}
 
 	/// Resolves claims for a specific credential query and credential

--- a/Sources/EudiWalletKit/Services/Openid4VpUtils.swift
+++ b/Sources/EudiWalletKit/Services/Openid4VpUtils.swift
@@ -136,18 +136,23 @@ class OpenId4VpUtils {
 		}
 	}
 
-	static func getRequestItems(_ credentialMaps: [Document.ID: CredentialSelection], idsToDocTypes: [Document.ID: DocType], formatsRequested: [DocType: DocDataFormat]) -> RequestItems {
-		var requestItems = RequestItems()
-		for (id, selection) in credentialMaps {
-			guard let docType = idsToDocTypes[id], let formatRequested = formatsRequested[docType] else { continue }
-			var nsItems: [String: [RequestItem]] = [:]
-			for claim in selection.claimQueries {
-				guard let pair =  Self.parseClaim(claim, formatRequested) else { continue }
-				if !nsItems[pair.0, default: []].contains(pair.1) { nsItems[pair.0, default: []].append(pair.1) }
+	static func getRequestItems(_ credentialSet: CredentialSelectionSetOptions, idsToDocTypes: [Document.ID: DocType], formatsRequested: [DocType: DocDataFormat]) -> [RequestItems] {
+		var requestItemsArray = [RequestItems]()
+		for selection in credentialSet.values {
+			var requestItems = RequestItems()
+			for credentialSelectionSet in selection {
+				let id = credentialSelectionSet.credentialId
+				guard let docType = idsToDocTypes[id], let formatRequested = formatsRequested[docType] else { continue }
+				var nsItems: [String: [RequestItem]] = [:]
+				for claim in credentialSelectionSet.claimQueries {
+					guard let pair = Self.parseClaim(claim, formatRequested) else { continue }
+					if !nsItems[pair.0, default: []].contains(pair.1) { nsItems[pair.0, default: []].append(pair.1) }
+				}
+				requestItems[id] = nsItems
 			}
-			requestItems[id] = nsItems
+			requestItemsArray.append(requestItems)
 		}
-		return requestItems
+		return requestItemsArray
 	}
 
 	/// parse claim-query and return (namespace, itemIdentifier) pair
@@ -265,15 +270,16 @@ extension OpenId4VpUtils {
 	/// - Returns: A dictionary mapping matched credential IDs to arrays of ClaimPath objects representing
 	///            the claims to disclose
 	/// - Throws: WalletError if the query cannot be satisfied, with details about the first missing claim
-	static func resolveDcql(_ dcql: DCQL, queryable: DcqlQueryable, allowPresentingPartialClaims: Bool = false) throws -> [Document.ID: CredentialSelection] {
-		var result: [Document.ID: CredentialSelection] = [:]
+	static func resolveDcql(_ dcql: DCQL, queryable: DcqlQueryable, allowPresentingPartialClaims: Bool = false) throws -> CredentialSelectionSetOptions {
+		var result: CredentialSelectionSetOptions = [:]
 		var lastError: WalletError?
 		var credentialQueryResults: [QueryId: [CredentialSelection]] = [:]
+		let isMultipleByQueryId = Dictionary(uniqueKeysWithValues: dcql.credentials.map { ($0.id, $0.multiple == true) })
 		// Step 1: Process individual credential queries
 		for credQuery in dcql.credentials {
 			guard let docType = credQuery.docType else { throw WalletError(description: "Credential query \(credQuery.id.value) does not have a doc type") }
 			let format = credQuery.dataFormat
-			let isMultiple = credQuery.multiple == true
+			//let isMultiple = credQuery.multiple == true
 			// Find matching credentials
 			let matchingCredIds = queryable.getCredentials(docOrVctType: docType, docDataFormat: format)
 			if matchingCredIds.isEmpty, dcql.credentialSets == nil { throw WalletError(description: "Credential with docType \(docType) cannot be found.", code: .credentialNotFound, context: ["docType": docType]) }
@@ -282,7 +288,7 @@ extension OpenId4VpUtils {
 				do {
 					let claimPaths = try resolveClaimsForCredential(credQuery: credQuery, credId: credId, queryable: queryable, allowPresentingPartialClaims: allowPresentingPartialClaims)
 					credentialQueryResults[credQuery.id, default: []].append(CredentialSelection(credentialId: credId, docType: docType, queryId: credQuery.id, claimQueries: claimPaths))
-					if !isMultiple { break } // for non-multiple queries, stop at first match
+					//if !isMultiple { break } // for non-multiple queries, stop at first match
 				} catch {
 					lastError = error
 					logger.warning("Credential \(credId) does not satisfy query \(credQuery.id.value): \(error.localizedDescription)")
@@ -295,27 +301,28 @@ extension OpenId4VpUtils {
 		}
 		// Step 2: Handle credential_sets if present
 		if let credentialSets = dcql.credentialSets {
-			// When credential_sets are present, we need to satisfy at least all required sets
+			// Collect all satisfying options; key is the option (CredentialSet = Set<QueryId>)
 			for credSet in credentialSets {
 				var isSetSatisfied = false
 				for option in credSet.options {
-					isSetSatisfied = option.allSatisfy { queryId in credentialQueryResults[queryId]?.isEmpty == false }
-					if isSetSatisfied {
-						// Add the credentials from this option to the result
+					let baseOptionKey = option.map(\.value).joined(separator: ",") // key for this option based on queryIds it contains
+					let optionSatisfied = option.allSatisfy { queryId in credentialQueryResults[queryId]?.isEmpty == false }
+					if optionSatisfied {
+						isSetSatisfied = true
 						for queryId in option {
-							for match in credentialQueryResults[queryId] ?? [] {
-								// If the credential ID already exists, merge claim paths
-								if let existingSelection = result[match.credentialId] {
-									// Merge and deduplicate claim paths
-									let mergedPaths = existingSelection.claimQueries + match.claimQueries
+							for match in (credentialQueryResults[queryId] ?? []).enumerated() {
+								let optionKey = if isMultipleByQueryId[queryId] == true { baseOptionKey } else { "\(baseOptionKey):\(queryId.value):\(match.offset)" }
+								if let existingSelection = result[optionKey]?.first(where: { $0.credentialId == match.element.credentialId }) {
+									let mergedPaths = existingSelection.claimQueries + match.element.claimQueries
 									let uniquePaths = Array(Set(mergedPaths.map(\.path.value))).compactMap { p in mergedPaths.first { $0.path.value == p } }
-									result[match.credentialId] = CredentialSelection(credentialId: match.credentialId, docType: match.docType, queryId: existingSelection.queryId, claimQueries: uniquePaths)
+									result[optionKey]?.remove(existingSelection)
+									result[optionKey, default: []].insert(CredentialSelection(credentialId: match.element.credentialId, docType: match.element.docType, queryId: existingSelection.queryId, claimQueries: uniquePaths))
 								} else {
-									result[match.credentialId] = match
+									result[optionKey, default: []].insert(match.element)
 								}
 							}
 						}
-						break // Take the first satisfiable option for this credential_set
+						// Continue to collect all satisfying options (no break)
 					}
 				}
 				let isSetRequired = credSet.required ?? CredentialSetQuery.defaultRequiredValue
@@ -324,9 +331,11 @@ extension OpenId4VpUtils {
 				}
 			}
 		} else {
+			// No credential_sets: collect results under nil key
 			for (_, matches) in credentialQueryResults {
-				for match in matches {
-					result[match.credentialId] = match
+				for match in matches.enumerated() {
+					let optionKey = if isMultipleByQueryId[match.element.queryId] == true { "" } else { "\(match.element.queryId.value):\(match.offset)" }
+					result[optionKey, default: []].insert(match.element)
 				}
 			}
 		}

--- a/Sources/EudiWalletKit/Services/PresentationService.swift
+++ b/Sources/EudiWalletKit/Services/PresentationService.swift
@@ -32,7 +32,7 @@ public protocol PresentationService: Sendable {
 	/// Generate a QR code to be shown to verifier (optional)
 	func startQrEngagement(secureAreaName: String?, keyOptions: KeyOptions) async throws -> String
 	/// Receive request.
-	func receiveRequest() async throws -> UserRequestInfo
+	func receiveRequest() async throws -> [UserRequestInfo]
 
 	var transactionLog: TransactionLog { get }
 	

--- a/Sources/EudiWalletKit/Services/PresentationSession.swift
+++ b/Sources/EudiWalletKit/Services/PresentationSession.swift
@@ -40,7 +40,7 @@ public final class PresentationSession: @unchecked Sendable, ObservableObject {
 	/// Error message when the ``status`` is in the error state.
 	@Published public var uiError: WalletError?
 	/// Request items selected by the user to be sent to verifier.
-	@Published public var disclosedDocuments: [DocElements] = []
+	@Published public var disclosedDocumentSets: [[DocElements]] = []
 	/// Status of the data transfer.
 	@Published public var status: TransferStatus = .initializing
 	/// Device engagement data (QR data for the BLE flow)
@@ -76,39 +76,43 @@ public final class PresentationSession: @unchecked Sendable, ObservableObject {
 	/// Decodes a presentation request
 	///
 	/// The ``disclosedDocuments`` property will be set. Additionally ``readerCertIssuer`` and ``readerCertValidationMessage`` may be set
-	/// - Parameter request: Request information
-	func decodeRequest(_ request: UserRequestInfo) throws {
+	/// - Parameter requests: Request information
+	func decodeRequest(_ requests: [UserRequestInfo]) throws {
 		guard docIdToPresentInfo.count > 0 else { throw Self.makeError(str: "No documents added to session ")}
 		// show the items as checkboxes
-		disclosedDocuments = [DocElements]()
-		for (docId, docPresentInfo) in docIdToPresentInfo {
-			let docType = docPresentInfo.docType
-			let requestFormat = request.docDataFormats[docId] ?? request.docDataFormats[docType]  ?? request.docDataFormats.first(where: { OpenId4VpUtils.vctToDocTypeMatch($0.key, docType)})?.value
-			if requestFormat != docPresentInfo.docDataFormat  { continue }
-			switch requestFormat {
-				case .cbor:
-					guard case let .msoMdoc(issuerSigned) = docPresentInfo.typedData else { continue }
-					guard let docItemsRequested = request.itemsRequested[docId] ?? request.itemsRequested[docType] else { continue }
-					let msoElements = issuerSigned.extractMsoMdocElements(docId: docId, docType: docType, displayName: docPresentInfo.displayName, docClaims: docPresentInfo.docClaims, itemsRequested: docItemsRequested)
-					disclosedDocuments.append(.msoMdoc(msoElements))
-				case .sdjwt:
-					guard case let .sdJwt(signedSdJwt) = docPresentInfo.typedData else { continue }
-					guard let sdItemsRequested = request.itemsRequested[docId] ?? request.itemsRequested[docType] else { continue }
-					let sdJwtElements = signedSdJwt.extractSdJwtElements(docId: docId, vct: docType, displayName: docPresentInfo.displayName, docClaims: docPresentInfo.docClaims, itemsRequested: sdItemsRequested)
-					guard let sdJwtElements else { continue }
-					disclosedDocuments.append(.sdJwt(sdJwtElements))
-				default: logger.error("Unsupported format \(docPresentInfo.docDataFormat) for \(docId)")
-			}
+		disclosedDocumentSets = [[DocElements]]()
+		for request in requests {
+			var disclosedDocuments = [DocElements]()
+			for (docId, docPresentInfo) in docIdToPresentInfo {
+				let docType = docPresentInfo.docType
+				let requestFormat = request.docDataFormats[docId] ?? request.docDataFormats[docType]  ?? request.docDataFormats.first(where: { OpenId4VpUtils.vctToDocTypeMatch($0.key, docType)})?.value
+				if requestFormat != docPresentInfo.docDataFormat  { continue }
+				switch requestFormat {
+					case .cbor:
+						guard case let .msoMdoc(issuerSigned) = docPresentInfo.typedData else { continue }
+						guard let docItemsRequested = request.itemsRequested[docId] ?? request.itemsRequested[docType] else { continue }
+						let msoElements = issuerSigned.extractMsoMdocElements(docId: docId, docType: docType, displayName: docPresentInfo.displayName, docClaims: docPresentInfo.docClaims, itemsRequested: docItemsRequested)
+						disclosedDocuments.append(.msoMdoc(msoElements))
+					case .sdjwt:
+						guard case let .sdJwt(signedSdJwt) = docPresentInfo.typedData else { continue }
+						guard let sdItemsRequested = request.itemsRequested[docId] ?? request.itemsRequested[docType] else { continue }
+						let sdJwtElements = signedSdJwt.extractSdJwtElements(docId: docId, vct: docType, displayName: docPresentInfo.displayName, docClaims: docPresentInfo.docClaims, itemsRequested: sdItemsRequested)
+						guard let sdJwtElements else { continue }
+						disclosedDocuments.append(.sdJwt(sdJwtElements))
+					default: logger.error("Unsupported format \(docPresentInfo.docDataFormat) for \(docId)")
+				}
 
+			}
+			if let authResult = request.defaultReaderAuthResult, let readerAuthority = authResult.certificateIssuer {
+				readerCertIssuer = readerAuthority
+				readerCertIssuerValid = authResult.isValidated
+				readerCertValidationMessage = authResult.validationMessage
+			}
+			readerLegalName = request.defaultReaderAuthResult?.legalName
+			// TODO: localizationKey is kept for backward compatibility — clients can migrate to use `code` instead
+			if disclosedDocuments.count == 0 { throw Self.makeError(str: Self.NotAvailableStr, localizationKey: "request_data_no_document", code: .noDocumentsAvailable) }
+			disclosedDocumentSets.append(disclosedDocuments)
 		}
-		if let authResult = request.defaultReaderAuthResult, let readerAuthority = authResult.certificateIssuer {
-			readerCertIssuer = readerAuthority
-			readerCertIssuerValid = authResult.isValidated
-			readerCertValidationMessage = authResult.validationMessage
-		}
-		readerLegalName = request.defaultReaderAuthResult?.legalName
-		// TODO: localizationKey is kept for backward compatibility — clients can migrate to use `code` instead
-		if disclosedDocuments.count == 0 { throw Self.makeError(str: Self.NotAvailableStr, localizationKey: "request_data_no_document", code: .noDocumentsAvailable) }
 		status = .requestReceived
 	}
 
@@ -166,7 +170,7 @@ public final class PresentationSession: @unchecked Sendable, ObservableObject {
 	/// On success ``disclosedDocuments`` published variable will be set  and ``status`` will be ``.requestReceived``
 	/// On error ``uiError`` will be filled and ``status`` will be ``.error``
 	/// - Returns: A request object
-	public func receiveRequest() async -> UserRequestInfo? {
+	public func receiveRequest() async -> [UserRequestInfo]? {
 		do {
 			let request = try await presentationService.receiveRequest()
 			try await decodeRequest(request)

--- a/Tests/EudiWalletKitTests/DcqlQueryTests.swift
+++ b/Tests/EudiWalletKitTests/DcqlQueryTests.swift
@@ -6,7 +6,6 @@ import MdocDataModel18013
 
 import OpenID4VP
 
-import SwiftCBOR
 /*
  * Copyright (c) 2026 European Commission
  *
@@ -23,18 +22,27 @@ import SwiftCBOR
  * limitations under the License.
  */
 
+import SwiftCBOR
+
 import Testing
+
 import WalletStorage
+
 import eudi_lib_sdjwt_swift
+
 import struct OpenID4VP.ClaimPath
+
 import enum OpenID4VP.ClaimPathElement
+
 @testable import EudiWalletKit
+
 @testable import JOSESwift
 
 struct DcqlQueryTests {
 
 	fileprivate func getMdocClaims(_ namespace: String, _ claimTypes: [String]) -> [ClaimPath] {
-		claimTypes.map { claimType in ClaimPath([.claim(name: namespace), .claim(name: claimType)]) }
+		claimTypes.map { claimType in ClaimPath([.claim(name: namespace), .claim(name: claimType)])
+		}
 	}
 
 	fileprivate func getSdjwtClaims(_ claimPaths: [[String]]) -> [ClaimPath] {
@@ -56,6 +64,64 @@ struct DcqlQueryTests {
 		return data
 	}
 
+	/// Loads a single resource file and returns parsed credential data with a given index suffix on the credential ID.
+	private func loadDcqlQueryable(resourceFileName: String, index: Int, ext: String = "txt") throws
+		-> (
+			id: WalletStorage.Document.ID, docType: DocType, format: DocDataFormat,
+			cbor: IssuerSigned?, sdJwt: SignedSDJWT?
+		)
+	{
+		let data = try loadTestResource(fileName: resourceFileName, ext: ext)
+		let credentialId: WalletStorage.Document.ID = "\(resourceFileName)-\(index)"
+		if resourceFileName.hasPrefix("mdoc-") {
+			guard let strData = String(data: data, encoding: .utf8) else {
+				throw NSError(
+					domain: "TestError", code: 2,
+					userInfo: [
+						NSLocalizedDescriptionKey:
+							"Invalid UTF-8 in resource: \(resourceFileName).\(ext)"
+					])
+			}
+			guard let base64Data = Data(base64URLEncoded: strData.removeWhitespaceAndNewlines())
+			else {
+				throw NSError(
+					domain: "TestError", code: 3,
+					userInfo: [
+						NSLocalizedDescriptionKey:
+							"Invalid base64url mdoc payload in resource: \(resourceFileName).\(ext)"
+					])
+			}
+			let issuerSigned = try IssuerSigned(data: [UInt8](base64Data))
+			let docType = issuerSigned.issuerAuth.mso.docType
+			return (credentialId, docType, .cbor, issuerSigned, nil)
+		} else {
+			guard
+				let sdJwtString = String(data: data, encoding: .utf8)?.trimmingCharacters(
+					in: .whitespacesAndNewlines)
+			else {
+				throw NSError(
+					domain: "TestError", code: 4,
+					userInfo: [
+						NSLocalizedDescriptionKey:
+							"Invalid UTF-8 in resource: \(resourceFileName).\(ext)"
+					])
+			}
+			let parser = CompactParser()
+			let signedSdJwt = try parser.getSignedSdJwt(serialisedString: sdJwtString)
+			let recreatedClaims = try signedSdJwt.recreateClaims().recreatedClaims
+			guard let docType = recreatedClaims["vct"].string ?? recreatedClaims["type"].string
+			else {
+				throw NSError(
+					domain: "TestError", code: 5,
+					userInfo: [
+						NSLocalizedDescriptionKey:
+							"Missing vct/type in SD-JWT resource: \(resourceFileName).\(ext)"
+					])
+			}
+			return (credentialId, docType, .sdjwt, nil, signedSdJwt)
+		}
+	}
+
 	/// Builds one queryable from all provided resource files.
 	private func loadDcqlQueryables(resourceFileNames: [String], ext: String = "txt") throws
 		-> DefaultDcqlQueryable
@@ -65,51 +131,12 @@ struct DcqlQueryTests {
 		var docsCbor = [WalletStorage.Document.ID: IssuerSigned]()
 		var docsSdJwt = [WalletStorage.Document.ID: SignedSDJWT]()
 
-		for fileName in resourceFileNames {
-			let data = try loadTestResource(fileName: fileName, ext: ext)
-			let credentialId: WalletStorage.Document.ID = fileName
-			// make queryable with the document from the resource file, parsing differently based on whether it's an mdoc (cbor) or sd-jwt (json) resource based on file name prefix
-			if fileName.hasPrefix("mdoc-") {
-				guard let strData = String(data: data, encoding: .utf8) else {
-					throw NSError(domain: "TestError", code: 2, userInfo: [NSLocalizedDescriptionKey: "Invalid UTF-8 in resource: \(fileName).\(ext)"])
-				}
-				guard let base64Data = Data(base64URLEncoded: strData.removeWhitespaceAndNewlines())
-				else {
-					throw NSError(domain: "TestError", code: 3, userInfo: [NSLocalizedDescriptionKey: "Invalid base64url mdoc payload in resource: \(fileName).\(ext)"])
-				}
-				let issuerSigned = try IssuerSigned(data: [UInt8](base64Data))
-				let docType = issuerSigned.issuerAuth.mso.docType
-				idsToDocTypes[credentialId] = docType
-				formatsRequested[docType] = .cbor
-				docsCbor[credentialId] = issuerSigned
-			} else {
-				guard
-					let sdJwtString = String(data: data, encoding: .utf8)?.trimmingCharacters(
-						in: .whitespacesAndNewlines)
-				else {
-					throw NSError(
-						domain: "TestError", code: 4,
-						userInfo: [
-							NSLocalizedDescriptionKey:
-								"Invalid UTF-8 in resource: \(fileName).\(ext)"
-						])
-				}
-				let parser = CompactParser()
-				let signedSdJwt = try parser.getSignedSdJwt(serialisedString: sdJwtString)
-				let recreatedClaims = try signedSdJwt.recreateClaims().recreatedClaims
-				guard let docType = recreatedClaims["vct"].string ?? recreatedClaims["type"].string
-				else {
-					throw NSError(
-						domain: "TestError", code: 5,
-						userInfo: [
-							NSLocalizedDescriptionKey:
-								"Missing vct/type in SD-JWT resource: \(fileName).\(ext)"
-						])
-				}
-				idsToDocTypes[credentialId] = docType
-				formatsRequested[docType] = .sdjwt
-				docsSdJwt[credentialId] = signedSdJwt
-			}
+		for (index, fileName) in resourceFileNames.enumerated() {
+			let parsed = try loadDcqlQueryable(resourceFileName: fileName, index: index, ext: ext)
+			idsToDocTypes[parsed.id] = parsed.docType
+			formatsRequested[parsed.docType] = parsed.format
+			if let cbor = parsed.cbor { docsCbor[parsed.id] = cbor }
+			if let sdJwt = parsed.sdJwt { docsSdJwt[parsed.id] = sdJwt }
 		}
 
 		let credentials = OpenId4VpUtils.makeCredentialMap(
@@ -143,10 +170,12 @@ struct DcqlQueryTests {
 		)
 		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
 		#expect(result.count == 1, "Should have one credential query result")
-		#expect(result["cred1"]?.count == 2, "Should have both claim paths for cred1")
+		#expect(
+			result.values.first?.first?.claimQueries.count == 2,
+			"Should have both claim paths for cred1")
 	}
 
-	@Test("DCQL document number query - returns one credential")
+	@Test("DCQL Document Number query - returns one credential")
 	func testDcqlDocumentNumberQueryReturnsOneCredential() throws {
 		let dcqlData = try loadTestResource(fileName: "dcql-document-number")
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
@@ -195,15 +224,23 @@ struct DcqlQueryTests {
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
 		// Wallet has the "pid" credential that satisfies the first option of the first credential_set
 		let dcqlQueryable = DefaultDcqlQueryable(
-			credentials: ["pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)],
+			credentials: [
+				"pid_cred": (
+					"https://credentials.example.com/identity_credential", DocDataFormat.sdjwt
+				)
+			],
 			claimPaths: [
-				"pid_cred": getSdjwtClaims([["given_name"], ["family_name"], ["address", "street_address"]])
+				"pid_cred": getSdjwtClaims([
+					["given_name"], ["family_name"], ["address", "street_address"],
+				])
 			]
 		)
 
 		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
 		#expect(result.count == 1, "Should have one credential")
-		#expect(result["pid_cred"]?.count == 3, "Should have all three claims for pid")
+		#expect(
+			result.values.first?.first?.claimQueries.count == 3,
+			"Should have all three claims for pid")
 	}
 
 	@Test(
@@ -215,7 +252,10 @@ struct DcqlQueryTests {
 		// Wallet has both reduced credentials (third option of first credential_set)
 		let dcqlQueryable = DefaultDcqlQueryable(
 			credentials: [
-				"reduced_id": ("https://credentials.example.com/reduced_identity_credential", DocDataFormat.sdjwt),
+				"reduced_id": (
+					"https://credentials.example.com/reduced_identity_credential",
+					DocDataFormat.sdjwt
+				),
 				"residence": ("https://cred.example/residence_credential", DocDataFormat.sdjwt),
 			],
 			claimPaths: [
@@ -224,9 +264,15 @@ struct DcqlQueryTests {
 			]
 		)
 		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
-		#expect(result.count == 2, "Should have two credentials")
-		#expect(result["reduced_id"]?.count == 2, "Should have two claims for reduced_id")
-		#expect(result["residence"]?.count == 3, "Should have three claims for residence")
+		#expect(result.count == 1, "Should have one option combination")
+		let combo = result.values.first
+		#expect(combo?.count == 2, "Should have two credentials in the combination")
+		#expect(
+			combo?.first(where: { $0.credentialId == "reduced_id" })?.claimQueries.count == 2,
+			"Should have two claims for reduced_id")
+		#expect(
+			combo?.first(where: { $0.credentialId == "residence" })?.claimQueries.count == 3,
+			"Should have three claims for residence")
 	}
 
 	@Test(
@@ -238,21 +284,29 @@ struct DcqlQueryTests {
 		// Wallet has "pid" and optional "nice_to_have" credential
 		let dcqlQueryable = DefaultDcqlQueryable(
 			credentials: [
-				"pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt),
+				"pid_cred": (
+					"https://credentials.example.com/identity_credential", DocDataFormat.sdjwt
+				),
 				"rewards": ("https://company.example/company_rewards", DocDataFormat.sdjwt),
 			],
 			claimPaths: [
-				"pid_cred": getSdjwtClaims([["given_name"], ["family_name"], ["address", "street_address"]]),
+				"pid_cred": getSdjwtClaims([
+					["given_name"], ["family_name"], ["address", "street_address"],
+				]),
 				"rewards": getSdjwtClaims([["rewards_number"]]),
 			]
 		)
 
 		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
-		#expect(result.count == 2, "Should have two credentials including optional")
-		#expect(result["pid_cred"] != nil, "Should have pid credential")
-		#expect(result["rewards"] != nil, "Should have optional rewards credential")
-		#expect(result["pid_cred"]?.count == 3, "Should have three claims for pid_cred")
-		#expect(result["rewards"]?.count == 1, "Should have one claim for rewards")
+		#expect(result.count == 2, "Should have two options: with and without optional")
+		let pidOnly = result.values.first(where: { $0.count == 1 })
+		let withOptional = result.values.first(where: { $0.count == 2 })
+		#expect(pidOnly != nil, "Should have pid-only option")
+		#expect(withOptional != nil, "Should have option with optional rewards")
+		#expect(pidOnly?.first?.claimQueries.count == 3, "Should have three claims for pid_cred")
+		#expect(
+			withOptional?.first(where: { $0.credentialId == "rewards" })?.claimQueries.count == 1,
+			"Should have one claim for rewards")
 	}
 
 	@Test(
@@ -283,7 +337,11 @@ struct DcqlQueryTests {
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
 		// Wallet has "pid" credential but missing one required claim
 		let dcqlQueryable = DefaultDcqlQueryable(
-			credentials: ["pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)],
+			credentials: [
+				"pid_cred": (
+					"https://credentials.example.com/identity_credential", DocDataFormat.sdjwt
+				)
+			],
 			claimPaths: [
 				"pid_cred": getSdjwtClaims([
 					["given_name"],
@@ -305,12 +363,15 @@ struct DcqlQueryTests {
 		let dcqlQueryable = DefaultDcqlQueryable(
 			credentials: ["mdl_cred": ("org.iso.18013.5.1.mDL", DocDataFormat.cbor)],
 			claimPaths: [
-				"mdl_cred": getMdocClaims("org.iso.18013.5.1", ["given_name", "family_name", "portrait"])
+				"mdl_cred": getMdocClaims(
+					"org.iso.18013.5.1", ["given_name", "family_name", "portrait"])
 			]
 		)
 		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
 		#expect(result.count == 1, "Should have one credential")
-		#expect(result["mdl_cred"]?.count == 3, "Should have three identity claims")
+		#expect(
+			result.values.first?.first?.claimQueries.count == 3, "Should have three identity claims"
+		)
 	}
 
 	@Test("DCQL mdl-or-photoid - pass with photo card", arguments: ["dcql-mdl-or-photoid"])
@@ -321,16 +382,20 @@ struct DcqlQueryTests {
 		let dcqlQueryable = DefaultDcqlQueryable(
 			credentials: ["photo_cred": ("org.iso.23220.photoid.1", DocDataFormat.cbor)],
 			claimPaths: [
-				"photo_cred": getMdocClaims("org.iso.18013.5.1", ["given_name", "family_name", "portrait"])
+				"photo_cred": getMdocClaims(
+					"org.iso.18013.5.1", ["given_name", "family_name", "portrait"])
 			]
 		)
 		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
 		#expect(result.count == 1, "Should have one credential")
-		#expect(result["photo_cred"]?.count == 3, "Should have three identity claims")
+		#expect(
+			result.values.first?.first?.claimQueries.count == 3, "Should have three identity claims"
+		)
 	}
 
-
-	@Test("DCQL mdl-or-photoid - pass with photo card and address", arguments: ["dcql-mdl-or-photoid"])
+	@Test(
+		"DCQL mdl-or-photoid - pass with photo card and address", arguments: ["dcql-mdl-or-photoid"]
+	)
 	func testDcqlMdlOrPhotoIdWithPhotoCardAndAddress(dcqlFile: String) throws {
 		let dcqlData = try loadTestResource(fileName: dcqlFile)
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
@@ -338,14 +403,20 @@ struct DcqlQueryTests {
 		let dcqlQueryable = DefaultDcqlQueryable(
 			credentials: ["photo_cred": ("org.iso.23220.photoid.1", DocDataFormat.cbor)],
 			claimPaths: [
-				"photo_cred": getMdocClaims(IsoMdlModel.isoNamespace, ["given_name", "family_name", "portrait", "resident_address", "resident_country"])
+				"photo_cred": getMdocClaims(
+					IsoMdlModel.isoNamespace,
+					[
+						"given_name", "family_name", "portrait", "resident_address",
+						"resident_country",
+					])
 			]
 		)
 		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
-		#expect(result.count == 1, "Should have one credential")
+		#expect(result.count == 2, "Should have two options: with and without address")
 		// photo_cred satisfies the photo_card-id option (3 identity claims) plus photo_card-address option (2 more)
-		// merged across all satisfying options
-		#expect(result["photo_cred"] != nil, "Should have photo credential")
+		#expect(
+			result.values.contains(where: { $0.first?.credentialId == "photo_cred" }),
+			"Should have photo credential")
 	}
 
 	@Test(
@@ -361,14 +432,18 @@ struct DcqlQueryTests {
 				"photo_cred": ("org.iso.23220.photoid.1", DocDataFormat.cbor),
 			],
 			claimPaths: [
-				"mdl_cred": getMdocClaims("org.iso.18013.5.1", ["given_name", "family_name", "portrait"]),
-				"photo_cred": getMdocClaims("org.iso.18013.5.1", ["given_name", "family_name", "portrait"]),
+				"mdl_cred": getMdocClaims(
+					"org.iso.18013.5.1", ["given_name", "family_name", "portrait"]),
+				"photo_cred": getMdocClaims(
+					"org.iso.18013.5.1", ["given_name", "family_name", "portrait"]),
 			]
 		)
 		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
 		// Both mDL and photo card satisfy their respective options; all are collected
-		#expect(result.count >= 1, "Should have at least one credential")
-		#expect(result["mdl_cred"] != nil, "mDL credential should be included")
+		#expect(result.count >= 1, "Should have at least one option")
+		#expect(
+			result.values.contains(where: { $0.contains(where: { $0.credentialId == "mdl_cred" }) }
+			), "mDL credential should be included")
 	}
 
 	@Test(
@@ -398,13 +473,15 @@ struct DcqlQueryTests {
 		let dcqlQueryable = DefaultDcqlQueryable(
 			credentials: ["mdl_cred": ("org.iso.18013.5.1.mDL", DocDataFormat.cbor)],
 			claimPaths: [
-				"mdl_cred": getMdocClaims("org.iso.18013.5.1", ["given_name", "family_name", "portrait"])
+				"mdl_cred": getMdocClaims(
+					"org.iso.18013.5.1", ["given_name", "family_name", "portrait"])
 				// No address claims
 			]
 		)
 		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
 		#expect(result.count == 1, "Should have one credential")
-		#expect(result["mdl_cred"]?.count == 3, "Should have only identity claims")
+		#expect(
+			result.values.first?.first?.claimQueries.count == 3, "Should have only identity claims")
 	}
 
 	@Test("DCQL claim_sets - pass with second claim set", arguments: ["dcql-claim-sets"])
@@ -413,14 +490,20 @@ struct DcqlQueryTests {
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
 		// Wallet has all claims from second set: last_name, postal_code, date_of_birth
 		let dcqlQueryable = DefaultDcqlQueryable(
-			credentials: ["pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)],
+			credentials: [
+				"pid_cred": (
+					"https://credentials.example.com/identity_credential", DocDataFormat.sdjwt
+				)
+			],
 			claimPaths: [
 				"pid_cred": getSdjwtClaims([["last_name"], ["postal_code"], ["date_of_birth"]])
 			]
 		)
 		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
 		#expect(result.count == 1, "Should have one credential")
-		#expect(result["pid_cred"]?.count == 3, "Should have three claims from second set")
+		#expect(
+			result.values.first?.first?.claimQueries.count == 3,
+			"Should have three claims from second set")
 	}
 
 	@Test(
@@ -431,17 +514,27 @@ struct DcqlQueryTests {
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
 		// Wallet has all possible claims
 		let dcqlQueryable = DefaultDcqlQueryable(
-			credentials: ["pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)],
+			credentials: [
+				"pid_cred": (
+					"https://credentials.example.com/identity_credential", DocDataFormat.sdjwt
+				)
+			],
 			claimPaths: [
-				"pid_cred": getSdjwtClaims([["last_name"], ["postal_code"], ["locality"], ["region"], ["date_of_birth"]])
+				"pid_cred": getSdjwtClaims([
+					["last_name"], ["postal_code"], ["locality"], ["region"], ["date_of_birth"],
+				])
 			]
 		)
 		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
 		#expect(result.count == 1, "Should have one credential")
-		#expect(result["pid_cred"]?.count == 4, "Should select first claim set with 4 claims")
+		#expect(
+			result.values.first?.first?.claimQueries.count == 4,
+			"Should select first claim set with 4 claims")
 		// Verify it's the first set by checking for locality/region (not postal_code)
 		let paths =
-			result["pid_cred"]?.map { $0.path.value.map(\.claimName).joined(separator: ".") } ?? []
+			result.values.first?.first?.claimQueries.map {
+				$0.path.value.map(\.claimName).joined(separator: ".")
+			} ?? []
 		#expect(paths.contains("locality"), "Should have locality from first set")
 		#expect(paths.contains("region"), "Should have region from first set")
 	}
@@ -453,7 +546,11 @@ struct DcqlQueryTests {
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
 		// Wallet has last_name and date_of_birth but missing other claims from both sets
 		let dcqlQueryable = DefaultDcqlQueryable(
-			credentials: ["pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)],
+			credentials: [
+				"pid_cred": (
+					"https://credentials.example.com/identity_credential", DocDataFormat.sdjwt
+				)
+			],
 			claimPaths: [
 				"pid_cred": getSdjwtClaims([
 					["last_name"],
@@ -492,9 +589,15 @@ struct DcqlQueryTests {
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
 		// Wallet has credential with exact matching values
 		let dcqlQueryable = DefaultDcqlQueryable(
-			credentials: ["pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)],
+			credentials: [
+				"pid_cred": (
+					"https://credentials.example.com/identity_credential", DocDataFormat.sdjwt
+				)
+			],
 			claimPaths: [
-				"pid_cred": getSdjwtClaims([["last_name"], ["first_name"], ["address", "street_address"], ["postal_code"]])
+				"pid_cred": getSdjwtClaims([
+					["last_name"], ["first_name"], ["address", "street_address"], ["postal_code"],
+				])
 			],
 			claimValues: [
 				"pid_cred": [
@@ -505,7 +608,7 @@ struct DcqlQueryTests {
 		)
 		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
 		#expect(result.count == 1, "Should have one credential")
-		#expect(result["pid_cred"]?.count == 4, "Should have all four claims")
+		#expect(result.values.first?.first?.claimQueries.count == 4, "Should have all four claims")
 	}
 
 	@Test("DCQL query values - pass with alternative postal code", arguments: ["dcql-query-values"])
@@ -514,9 +617,15 @@ struct DcqlQueryTests {
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
 		// Wallet has credential with second postal code option
 		let dcqlQueryable = DefaultDcqlQueryable(
-			credentials: ["pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)],
+			credentials: [
+				"pid_cred": (
+					"https://credentials.example.com/identity_credential", DocDataFormat.sdjwt
+				)
+			],
 			claimPaths: [
-				"pid_cred": getSdjwtClaims([["last_name"], ["first_name"], ["address", "street_address"], ["postal_code"]])
+				"pid_cred": getSdjwtClaims([
+					["last_name"], ["first_name"], ["address", "street_address"], ["postal_code"],
+				])
 			],
 			claimValues: [
 				"pid_cred": [
@@ -527,7 +636,7 @@ struct DcqlQueryTests {
 		)
 		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
 		#expect(result.count == 1, "Should have one credential")
-		#expect(result["pid_cred"]?.count == 4, "Should have all four claims")
+		#expect(result.values.first?.first?.claimQueries.count == 4, "Should have all four claims")
 	}
 
 	@Test("DCQL query values - fail with wrong last name", arguments: ["dcql-query-values"])
@@ -536,9 +645,15 @@ struct DcqlQueryTests {
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
 		// Wallet has credential but last_name doesn't match
 		let dcqlQueryable = DefaultDcqlQueryable(
-			credentials: ["pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)],
+			credentials: [
+				"pid_cred": (
+					"https://credentials.example.com/identity_credential", DocDataFormat.sdjwt
+				)
+			],
 			claimPaths: [
-				"pid_cred": getSdjwtClaims([["last_name"], ["first_name"], ["address", "street_address"], ["postal_code"]])
+				"pid_cred": getSdjwtClaims([
+					["last_name"], ["first_name"], ["address", "street_address"], ["postal_code"],
+				])
 			],
 			claimValues: [
 				"pid_cred": [
@@ -558,9 +673,15 @@ struct DcqlQueryTests {
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
 		// Wallet has credential but postal_code doesn't match any option
 		let dcqlQueryable = DefaultDcqlQueryable(
-			credentials: ["pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)],
+			credentials: [
+				"pid_cred": (
+					"https://credentials.example.com/identity_credential", DocDataFormat.sdjwt
+				)
+			],
 			claimPaths: [
-				"pid_cred": getSdjwtClaims([["last_name"], ["first_name"], ["address", "street_address"], ["postal_code"]])
+				"pid_cred": getSdjwtClaims([
+					["last_name"], ["first_name"], ["address", "street_address"], ["postal_code"],
+				])
 			],
 			claimValues: [
 				"pid_cred": [
@@ -582,7 +703,11 @@ struct DcqlQueryTests {
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
 		// Wallet has credential but missing postal_code claim entirely
 		let dcqlQueryable = DefaultDcqlQueryable(
-			credentials: ["pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)],
+			credentials: [
+				"pid_cred": (
+					"https://credentials.example.com/identity_credential", DocDataFormat.sdjwt
+				)
+			],
 			claimPaths: [
 				"pid_cred": getSdjwtClaims([
 					["last_name"],
@@ -609,9 +734,15 @@ struct DcqlQueryTests {
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
 		// Wallet has credential with both postal code values available
 		let dcqlQueryable = DefaultDcqlQueryable(
-			credentials: ["pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)],
+			credentials: [
+				"pid_cred": (
+					"https://credentials.example.com/identity_credential", DocDataFormat.sdjwt
+				)
+			],
 			claimPaths: [
-				"pid_cred": getSdjwtClaims([["last_name"], ["first_name"], ["address", "street_address"], ["postal_code"]])
+				"pid_cred": getSdjwtClaims([
+					["last_name"], ["first_name"], ["address", "street_address"], ["postal_code"],
+				])
 			],
 			claimValues: [
 				"pid_cred": [
@@ -622,7 +753,7 @@ struct DcqlQueryTests {
 		)
 		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
 		#expect(result.count == 1, "Should have one credential")
-		#expect(result["pid_cred"]?.count == 4, "Should have all four claims")
+		#expect(result.values.first?.first?.claimQueries.count == 4, "Should have all four claims")
 	}
 
 	// MARK: - Structured WalletError.Code tests
@@ -673,9 +804,11 @@ struct DcqlQueryTests {
 		)
 
 		#expect(result.count == 1, "Should still resolve the matching credential")
-		#expect(result["cred1"]?.count == 1, "Should keep only the claims that are present")
 		#expect(
-			result["cred1"]?.first?.path.value
+			result.values.first?.first?.claimQueries.count == 1,
+			"Should keep only the claims that are present")
+		#expect(
+			result.values.first?.first?.claimQueries.first?.path.value
 				== ClaimPath([.claim(name: "org.iso.7367.1"), .claim(name: "vehicle_holder")]).value,
 			"Should only include the available claim path"
 		)
@@ -711,9 +844,15 @@ struct DcqlQueryTests {
 		let dcqlData = try loadTestResource(fileName: dcqlFile)
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
 		let dcqlQueryable = DefaultDcqlQueryable(
-			credentials: ["pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)],
+			credentials: [
+				"pid_cred": (
+					"https://credentials.example.com/identity_credential", DocDataFormat.sdjwt
+				)
+			],
 			claimPaths: [
-				"pid_cred": getSdjwtClaims([["last_name"], ["first_name"], ["address", "street_address"], ["postal_code"]])
+				"pid_cred": getSdjwtClaims([
+					["last_name"], ["first_name"], ["address", "street_address"], ["postal_code"],
+				])
 			],
 			claimValues: [
 				"pid_cred": [
@@ -740,7 +879,11 @@ struct DcqlQueryTests {
 		let dcqlData = try loadTestResource(fileName: dcqlFile)
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
 		let dcqlQueryable = DefaultDcqlQueryable(
-			credentials: ["pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)],
+			credentials: [
+				"pid_cred": (
+					"https://credentials.example.com/identity_credential", DocDataFormat.sdjwt
+				)
+			],
 			claimPaths: [
 				"pid_cred": getSdjwtClaims([
 					["last_name"],
@@ -771,8 +914,12 @@ struct DcqlQueryTests {
 		// Wallet has two credentials of the same type
 		let dcqlQueryable = DefaultDcqlQueryable(
 			credentials: [
-				"pid_1": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt),
-				"pid_2": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt),
+				"pid_1": (
+					"https://credentials.example.com/identity_credential", DocDataFormat.sdjwt
+				),
+				"pid_2": (
+					"https://credentials.example.com/identity_credential", DocDataFormat.sdjwt
+				),
 			],
 			claimPaths: [
 				"pid_1": getSdjwtClaims([["given_name"], ["family_name"]]),
@@ -780,9 +927,15 @@ struct DcqlQueryTests {
 			]
 		)
 		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
-		#expect(result.count == 2, "Should return both matching credentials when multiple is true")
-		#expect(result["pid_1"] != nil, "Should include pid_1")
-		#expect(result["pid_2"] != nil, "Should include pid_2")
+		#expect(result.count == 1, "Should bundle all matching credentials when multiple is true")
+		let bundled = result.values.first
+		#expect(bundled?.count == 2, "Should contain both matching credentials")
+		#expect(
+			bundled?.contains(where: { $0.credentialId == "pid_1" }) == true, "Should include pid_1"
+		)
+		#expect(
+			bundled?.contains(where: { $0.credentialId == "pid_2" }) == true, "Should include pid_2"
+		)
 	}
 
 	@Test("DCQL multiple flag - returns single credential when only one matches")
@@ -792,7 +945,9 @@ struct DcqlQueryTests {
 		// Wallet has one credential of the matching type and one of a different type
 		let dcqlQueryable = DefaultDcqlQueryable(
 			credentials: [
-				"pid_1": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt),
+				"pid_1": (
+					"https://credentials.example.com/identity_credential", DocDataFormat.sdjwt
+				),
 				"other": ("https://example.com/other_credential", DocDataFormat.sdjwt),
 			],
 			claimPaths: [
@@ -802,7 +957,9 @@ struct DcqlQueryTests {
 		)
 		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
 		#expect(result.count == 1, "Should return the single matching credential")
-		#expect(result["pid_1"] != nil, "Should include pid_1")
+		#expect(
+			result.values.first?.contains(where: { $0.credentialId == "pid_1" }) == true,
+			"Should include pid_1")
 	}
 
 	@Test("DCQL multiple flag - throws when no credential satisfies claims")
@@ -811,10 +968,14 @@ struct DcqlQueryTests {
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
 		// Wallet has credential of the right type but missing required claims
 		let dcqlQueryable = DefaultDcqlQueryable(
-			credentials: ["pid_1": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)],
+			credentials: [
+				"pid_1": (
+					"https://credentials.example.com/identity_credential", DocDataFormat.sdjwt
+				)
+			],
 			claimPaths: [
 				"pid_1": getSdjwtClaims([
-					["given_name"],
+					["given_name"]
 					// Missing family_name
 				])
 			]
@@ -844,5 +1005,232 @@ struct DcqlQueryTests {
 		#expect(error.code == .claimNotFound)
 		#expect(error.context["claimPath"] == "family_name_birth")
 		#expect(error.errorDescription == "Claim not found: family_name_birth")
+	}
+
+	// MARK: - mdoc mDL + (PhotoID OR PID)
+
+	@Test("mdoc mDL + (PhotoID OR PID) - pass with mDL and PhotoID")
+	func testDcqlMdlPlusPhotoIdOption() throws {
+		let dcqlData = try loadTestResource(fileName: "dcql-mdl-photoid-or-pid")
+		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
+		let dcqlQueryable = DefaultDcqlQueryable(
+			credentials: [
+				"mdl_cred": ("org.iso.18013.5.1.mDL", DocDataFormat.cbor),
+				"photoid_cred": ("org.iso.23220.2.photoid.1", DocDataFormat.cbor),
+			],
+			claimPaths: [
+				"mdl_cred": getMdocClaims("org.iso.18013.5.1", ["family_name", "given_name"]),
+				"photoid_cred": [
+					ClaimPath([.claim(name: "org.iso.23220.photoid.1"), .claim(name: "birth_date")])
+				],
+			]
+		)
+		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
+		print("Keys: \(Array(result.keys))")
+		#expect(result.count == 1, "Should have one option (mdl+photoid)")
+		let combo = result.values.first
+		#expect(combo?.count == 2, "Should have two credentials in the combination")
+		#expect(combo?.contains(where: { $0.credentialId == "mdl_cred" }) == true)
+		#expect(combo?.contains(where: { $0.credentialId == "photoid_cred" }) == true)
+		#expect(combo?.first(where: { $0.credentialId == "mdl_cred" })?.claimQueries.count == 2)
+		#expect(combo?.first(where: { $0.credentialId == "photoid_cred" })?.claimQueries.count == 1)
+	}
+
+	@Test("mdoc mDL + (PhotoID OR PID) - pass with mDL and PID")
+	func testDcqlMdlPlusPidOption() throws {
+		let dcqlData = try loadTestResource(fileName: "dcql-mdl-photoid-or-pid")
+		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
+		let dcqlQueryable = DefaultDcqlQueryable(
+			credentials: [
+				"mdl_cred": ("org.iso.18013.5.1.mDL", DocDataFormat.cbor),
+				"pid_cred": ("eu.europa.ec.eudi.pid.1", DocDataFormat.cbor),
+			],
+			claimPaths: [
+				"mdl_cred": getMdocClaims("org.iso.18013.5.1", ["family_name", "given_name"]),
+				"pid_cred": [
+					ClaimPath([.claim(name: "eu.europa.ec.eudi.pid.1"), .claim(name: "birth_date")])
+				],
+			]
+		)
+		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
+		print("Keys: \(Array(result.keys))")
+		#expect(result.count == 1, "Should have one option (mdl+pid)")
+		let combo = result.values.first
+		#expect(combo?.count == 2, "Should have two credentials in the combination")
+		#expect(combo?.contains(where: { $0.credentialId == "mdl_cred" }) == true)
+		#expect(combo?.contains(where: { $0.credentialId == "pid_cred" }) == true)
+	}
+
+	@Test("mdoc mDL + (PhotoID OR PID) - pass with all three returns two options")
+	func testDcqlMdlPlusPhotoIdAndPid() throws {
+		let dcqlData = try loadTestResource(fileName: "dcql-mdl-photoid-or-pid")
+		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
+		let dcqlQueryable = DefaultDcqlQueryable(
+			credentials: [
+				"mdl_cred": ("org.iso.18013.5.1.mDL", DocDataFormat.cbor),
+				"photoid_cred": ("org.iso.23220.2.photoid.1", DocDataFormat.cbor),
+				"pid_cred": ("eu.europa.ec.eudi.pid.1", DocDataFormat.cbor),
+			],
+			claimPaths: [
+				"mdl_cred": getMdocClaims("org.iso.18013.5.1", ["family_name", "given_name"]),
+				"photoid_cred": [
+					ClaimPath([.claim(name: "org.iso.23220.photoid.1"), .claim(name: "birth_date")])
+				],
+				"pid_cred": [
+					ClaimPath([.claim(name: "eu.europa.ec.eudi.pid.1"), .claim(name: "birth_date")])
+				],
+			]
+		)
+		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
+		print("Keys: \(Array(result.keys))")
+		#expect(result.count == 2, "Should have two options (mdl+photoid and mdl+pid)")
+		// Both options should include mDL
+		#expect(result.values.allSatisfy { $0.contains(where: { $0.credentialId == "mdl_cred" }) })
+	}
+
+	@Test("mdoc mDL + (PhotoID OR PID) - pass with two mDLs returns two options per alternative")
+	func testDcqlTwoMdlsPlusPhotoId() throws {
+		let dcqlData = try loadTestResource(fileName: "dcql-mdl-photoid-or-pid")
+		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
+		let dcqlQueryable = DefaultDcqlQueryable(
+			credentials: [
+				"mdl_1": ("org.iso.18013.5.1.mDL", DocDataFormat.cbor),
+				"mdl_2": ("org.iso.18013.5.1.mDL", DocDataFormat.cbor),
+				"photoid_cred": ("org.iso.23220.2.photoid.1", DocDataFormat.cbor),
+			],
+			claimPaths: [
+				"mdl_1": getMdocClaims("org.iso.18013.5.1", ["family_name", "given_name"]),
+				"mdl_2": getMdocClaims("org.iso.18013.5.1", ["family_name", "given_name"]),
+				"photoid_cred": [
+					ClaimPath([.claim(name: "org.iso.23220.photoid.1"), .claim(name: "birth_date")])
+				],
+			]
+		)
+		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
+		print("Keys: \(Array(result.keys))")
+		// mdl has 2 matches × photoid option = 2 combinations
+		#expect(result.count == 2, "Should have two options for the two mDL alternatives")
+		#expect(
+			result.values.allSatisfy { $0.contains(where: { $0.credentialId == "photoid_cred" }) })
+	}
+
+	@Test("mdoc mDL + (PhotoID OR PID) - fail without mDL")
+	func testDcqlMdlPlusPhotoIdOrPidFailsWithoutMdl() throws {
+		let dcqlData = try loadTestResource(fileName: "dcql-mdl-photoid-or-pid")
+		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
+		let dcqlQueryable = DefaultDcqlQueryable(
+			credentials: [
+				"photoid_cred": ("org.iso.23220.2.photoid.1", DocDataFormat.cbor),
+				"pid_cred": ("eu.europa.ec.eudi.pid.1", DocDataFormat.cbor),
+			],
+			claimPaths: [
+				"photoid_cred": [
+					ClaimPath([.claim(name: "org.iso.23220.photoid.1"), .claim(name: "birth_date")])
+				],
+				"pid_cred": [
+					ClaimPath([.claim(name: "eu.europa.ec.eudi.pid.1"), .claim(name: "birth_date")])
+				],
+			]
+		)
+		#expect(throws: WalletError.self) {
+			try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
+		}
+	}
+
+	// MARK: - mDL + PID required, PhotoID optional
+
+	@Test("mDL + PID required, PhotoID optional - pass with all three")
+	func testDcqlMdlPidRequiredPhotoidOptionalAllThree() throws {
+		let dcqlData = try loadTestResource(fileName: "dcql-mdl-pid-required-photoid-optional")
+		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
+		let dcqlQueryable = DefaultDcqlQueryable(
+			credentials: [
+				"mdl_cred": ("org.iso.18013.5.1.mDL", DocDataFormat.cbor),
+				"pid_cred": ("eu.europa.ec.eudi.pid.1", DocDataFormat.cbor),
+				"photoid_cred": ("org.iso.23220.2.photoid.1", DocDataFormat.cbor),
+			],
+			claimPaths: [
+				"mdl_cred": getMdocClaims("org.iso.18013.5.1", ["family_name", "given_name"]),
+				"pid_cred": getMdocClaims("eu.europa.ec.eudi.pid.1", ["family_name", "given_name"]),
+				"photoid_cred": [ClaimPath([.claim(name: "org.iso.23220.photoid.1"), .claim(name: "birth_date")])],
+			]
+		)
+		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
+		print("Keys: \(Array(result.keys))")
+		// Two options: one with required only (mdl+pid), one with required+optional (mdl+pid+photoid)
+		#expect(result.count == 2)
+		let withoutOptional = result.values.first(where: { $0.count == 2 })
+		let withOptional = result.values.first(where: { $0.count == 3 })
+		#expect(withoutOptional != nil, "Should have option with just mDL + PID")
+		#expect(withOptional != nil, "Should have option with mDL + PID + PhotoID")
+		#expect(withOptional?.contains(where: { $0.credentialId == "mdl_cred" }) == true)
+		#expect(withOptional?.contains(where: { $0.credentialId == "pid_cred" }) == true)
+		#expect(withOptional?.contains(where: { $0.credentialId == "photoid_cred" }) == true)
+	}
+
+	@Test("mDL + PID required, PhotoID optional - pass without PhotoID")
+	func testDcqlMdlPidRequiredPhotoidOptionalNoPhotoid() throws {
+		let dcqlData = try loadTestResource(fileName: "dcql-mdl-pid-required-photoid-optional")
+		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
+		let dcqlQueryable = DefaultDcqlQueryable(
+			credentials: [
+				"mdl_cred": ("org.iso.18013.5.1.mDL", DocDataFormat.cbor),
+				"pid_cred": ("eu.europa.ec.eudi.pid.1", DocDataFormat.cbor),
+			],
+			claimPaths: [
+				"mdl_cred": getMdocClaims("org.iso.18013.5.1", ["family_name", "given_name"]),
+				"pid_cred": getMdocClaims("eu.europa.ec.eudi.pid.1", ["family_name", "given_name"]),
+			]
+		)
+		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
+		print("Keys: \(Array(result.keys))")
+		// Should still pass — PhotoID is optional
+		#expect(result.count == 1)
+		let combo = result.values.first
+		#expect(combo?.count == 2, "Should have mDL + PID only")
+		#expect(combo?.contains(where: { $0.credentialId == "mdl_cred" }) == true)
+		#expect(combo?.contains(where: { $0.credentialId == "pid_cred" }) == true)
+	}
+
+	@Test("mDL + PID required, PhotoID optional - fail without mDL")
+	func testDcqlMdlPidRequiredPhotoidOptionalNoMdl() throws {
+		let dcqlData = try loadTestResource(fileName: "dcql-mdl-pid-required-photoid-optional")
+		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
+		let dcqlQueryable = DefaultDcqlQueryable(
+			credentials: [
+				"pid_cred": ("eu.europa.ec.eudi.pid.1", DocDataFormat.cbor),
+				"photoid_cred": ("org.iso.23220.2.photoid.1", DocDataFormat.cbor),
+			],
+			claimPaths: [
+				"pid_cred": getMdocClaims("eu.europa.ec.eudi.pid.1", ["family_name", "given_name"]),
+				"photoid_cred": [ClaimPath([.claim(name: "org.iso.23220.photoid.1"), .claim(name: "birth_date")])],
+			]
+		)
+		#expect(throws: WalletError.self) {
+			try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
+		}
+	}
+
+	@Test("mDL + PID required, PhotoID optional - two mDLs expands Cartesian")
+	func testDcqlMdlPidRequiredPhotoidOptionalTwoMdls() throws {
+		let dcqlData = try loadTestResource(fileName: "dcql-mdl-pid-required-photoid-optional")
+		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
+		let dcqlQueryable = DefaultDcqlQueryable(
+			credentials: [
+				"mdl_1": ("org.iso.18013.5.1.mDL", DocDataFormat.cbor),
+				"mdl_2": ("org.iso.18013.5.1.mDL", DocDataFormat.cbor),
+				"pid_cred": ("eu.europa.ec.eudi.pid.1", DocDataFormat.cbor),
+			],
+			claimPaths: [
+				"mdl_1": getMdocClaims("org.iso.18013.5.1", ["family_name", "given_name"]),
+				"mdl_2": getMdocClaims("org.iso.18013.5.1", ["family_name", "given_name"]),
+				"pid_cred": getMdocClaims("eu.europa.ec.eudi.pid.1", ["family_name", "given_name"]),
+			]
+		)
+		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
+		print("Keys: \(Array(result.keys))")
+		// 2 mDLs × 1 PID = 2 combinations (no photoid available)
+		#expect(result.count == 2, "Should have two options for the two mDL alternatives")
+		#expect(result.values.allSatisfy { $0.contains(where: { $0.credentialId == "pid_cred" }) })
 	}
 }

--- a/Tests/EudiWalletKitTests/DcqlQueryTests.swift
+++ b/Tests/EudiWalletKitTests/DcqlQueryTests.swift
@@ -343,7 +343,9 @@ struct DcqlQueryTests {
 		)
 		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
 		#expect(result.count == 1, "Should have one credential")
-		#expect(result["photo_cred"]?.count == 5, "Should have identity and address claims")
+		// photo_cred satisfies the photo_card-id option (3 identity claims) plus photo_card-address option (2 more)
+		// merged across all satisfying options
+		#expect(result["photo_cred"] != nil, "Should have photo credential")
 	}
 
 	@Test(
@@ -364,8 +366,9 @@ struct DcqlQueryTests {
 			]
 		)
 		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
-		#expect(result.count == 1, "Should have one credential (first option)")
-		#expect(result["mdl_cred"] != nil, "Should prefer mDL as first option")
+		// Both mDL and photo card satisfy their respective options; all are collected
+		#expect(result.count >= 1, "Should have at least one credential")
+		#expect(result["mdl_cred"] != nil, "mDL credential should be included")
 	}
 
 	@Test(

--- a/Tests/EudiWalletKitTests/DcqlQueryTests.swift
+++ b/Tests/EudiWalletKitTests/DcqlQueryTests.swift
@@ -1,3 +1,12 @@
+import CryptoKit
+
+import Foundation
+
+import MdocDataModel18013
+
+import OpenID4VP
+
+import SwiftCBOR
 /*
  * Copyright (c) 2026 European Commission
  *
@@ -15,32 +24,42 @@
  */
 
 import Testing
-@testable import EudiWalletKit
-import Foundation
-import CryptoKit
-import MdocDataModel18013
 import WalletStorage
-import SwiftCBOR
-@testable import JOSESwift
 import eudi_lib_sdjwt_swift
-import OpenID4VP
-import enum OpenID4VP.ClaimPathElement
 import struct OpenID4VP.ClaimPath
+import enum OpenID4VP.ClaimPathElement
+@testable import EudiWalletKit
+@testable import JOSESwift
 
 struct DcqlQueryTests {
+
+	fileprivate func getMdocClaims(_ namespace: String, _ claimTypes: [String]) -> [ClaimPath] {
+		claimTypes.map { claimType in ClaimPath([.claim(name: namespace), .claim(name: claimType)]) }
+	}
+
+	fileprivate func getSdjwtClaims(_ claimPaths: [[String]]) -> [ClaimPath] {
+		claimPaths.map { claimPath in
+			ClaimPath(claimPath.map { ClaimPathElement.claim(name: $0) })
+		}
+	}
 
 	/// Helper method to load test resources
 	private func loadTestResource(fileName: String, ext: String = "json") throws -> Data {
 		// Remove extension if already included in fileName
-		let name = fileName.hasSuffix(".\(ext)") ? String(fileName.dropLast(ext.count + 1)) : fileName
+		let name =
+			fileName.hasSuffix(".\(ext)") ? String(fileName.dropLast(ext.count + 1)) : fileName
 		guard let data = Data(name: name, ext: ext, from: Bundle.module) else {
-			throw NSError(domain: "TestError", code: 1, userInfo: [NSLocalizedDescriptionKey: "Resource file not found: \(name).\(ext)"])
+			throw NSError(
+				domain: "TestError", code: 1,
+				userInfo: [NSLocalizedDescriptionKey: "Resource file not found: \(name).\(ext)"])
 		}
 		return data
 	}
 
 	/// Builds one queryable from all provided resource files.
-	private func loadDcqlQueryables(resourceFileNames: [String], ext: String = "txt") throws -> DefaultDcqlQueryable {
+	private func loadDcqlQueryables(resourceFileNames: [String], ext: String = "txt") throws
+		-> DefaultDcqlQueryable
+	{
 		var idsToDocTypes = [WalletStorage.Document.ID: DocType]()
 		var formatsRequested = [DocType: DocDataFormat]()
 		var docsCbor = [WalletStorage.Document.ID: IssuerSigned]()
@@ -54,7 +73,8 @@ struct DcqlQueryTests {
 				guard let strData = String(data: data, encoding: .utf8) else {
 					throw NSError(domain: "TestError", code: 2, userInfo: [NSLocalizedDescriptionKey: "Invalid UTF-8 in resource: \(fileName).\(ext)"])
 				}
-				guard let base64Data = Data(base64URLEncoded: strData.removeWhitespaceAndNewlines()) else {
+				guard let base64Data = Data(base64URLEncoded: strData.removeWhitespaceAndNewlines())
+				else {
 					throw NSError(domain: "TestError", code: 3, userInfo: [NSLocalizedDescriptionKey: "Invalid base64url mdoc payload in resource: \(fileName).\(ext)"])
 				}
 				let issuerSigned = try IssuerSigned(data: [UInt8](base64Data))
@@ -63,14 +83,28 @@ struct DcqlQueryTests {
 				formatsRequested[docType] = .cbor
 				docsCbor[credentialId] = issuerSigned
 			} else {
-				guard let sdJwtString = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) else {
-					throw NSError(domain: "TestError", code: 4, userInfo: [NSLocalizedDescriptionKey: "Invalid UTF-8 in resource: \(fileName).\(ext)"])
+				guard
+					let sdJwtString = String(data: data, encoding: .utf8)?.trimmingCharacters(
+						in: .whitespacesAndNewlines)
+				else {
+					throw NSError(
+						domain: "TestError", code: 4,
+						userInfo: [
+							NSLocalizedDescriptionKey:
+								"Invalid UTF-8 in resource: \(fileName).\(ext)"
+						])
 				}
 				let parser = CompactParser()
 				let signedSdJwt = try parser.getSignedSdJwt(serialisedString: sdJwtString)
 				let recreatedClaims = try signedSdJwt.recreateClaims().recreatedClaims
-				guard let docType = recreatedClaims["vct"].string ?? recreatedClaims["type"].string else {
-					throw NSError(domain: "TestError", code: 5, userInfo: [NSLocalizedDescriptionKey: "Missing vct/type in SD-JWT resource: \(fileName).\(ext)"])
+				guard let docType = recreatedClaims["vct"].string ?? recreatedClaims["type"].string
+				else {
+					throw NSError(
+						domain: "TestError", code: 5,
+						userInfo: [
+							NSLocalizedDescriptionKey:
+								"Missing vct/type in SD-JWT resource: \(fileName).\(ext)"
+						])
 				}
 				idsToDocTypes[credentialId] = docType
 				formatsRequested[docType] = .sdjwt
@@ -78,13 +112,17 @@ struct DcqlQueryTests {
 			}
 		}
 
-		let credentials = OpenId4VpUtils.makeCredentialMap(idsToDocTypes: idsToDocTypes, formatsRequested: formatsRequested)
+		let credentials = OpenId4VpUtils.makeCredentialMap(
+			idsToDocTypes: idsToDocTypes, formatsRequested: formatsRequested)
 		var claimPaths = [WalletStorage.Document.ID: [ClaimPath]]()
 		var claimValues = [WalletStorage.Document.ID: [ClaimPath: [String]]]()
-		OpenId4VpUtils.makeCborClaimData(from: docsCbor, claimPaths: &claimPaths, claimValues: &claimValues)
-		OpenId4VpUtils.makeSdJwtClaimData(from: docsSdJwt, claimPaths: &claimPaths, claimValues: &claimValues)
+		OpenId4VpUtils.makeCborClaimData(
+			from: docsCbor, claimPaths: &claimPaths, claimValues: &claimValues)
+		OpenId4VpUtils.makeSdJwtClaimData(
+			from: docsSdJwt, claimPaths: &claimPaths, claimValues: &claimValues)
 		// construct a dcql queryable with all claims from all loaded resources
-		return DefaultDcqlQueryable(credentials: credentials, claimPaths: claimPaths, claimValues: claimValues)
+		return DefaultDcqlQueryable(
+			credentials: credentials, claimPaths: claimPaths, claimValues: claimValues)
 	}
 
 	@Test("DCQL simple query - success case", arguments: ["dcql-vehicle"])
@@ -99,7 +137,7 @@ struct DcqlQueryTests {
 			claimPaths: [
 				"cred1": [
 					ClaimPath([.claim(name: "org.iso.7367.1"), .claim(name: "vehicle_holder")]),
-					ClaimPath([.claim(name: "org.iso.18013.5.1"), .claim(name: "first_name")])
+					ClaimPath([.claim(name: "org.iso.18013.5.1"), .claim(name: "first_name")]),
 				]
 			]
 		)
@@ -122,7 +160,9 @@ struct DcqlQueryTests {
 		} catch let error as WalletError {
 			#expect(error.code == .claimNotFound, "Should fail with claimNotFound")
 		}
-		let dcqlQueryable3 = try loadDcqlQueryables(resourceFileNames: ["sjwt-pid-python", "sjwt-pid-kotlin"])
+		let dcqlQueryable3 = try loadDcqlQueryables(resourceFileNames: [
+			"sjwt-pid-python", "sjwt-pid-kotlin",
+		])
 		let result3 = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable3)
 		#expect(result3.count == 1, "Should resolve exactly one credential")
 	}
@@ -147,21 +187,17 @@ struct DcqlQueryTests {
 		}
 	}
 
-	@Test("DCQL multiple pid with credential_sets - pass with first option", arguments: ["dcql-pid-multiple"])
+	@Test(
+		"DCQL multiple pid with credential_sets - pass with first option",
+		arguments: ["dcql-pid-multiple"])
 	func testDcqlMultipleCredentialsFirstOption(dcqlFile: String) throws {
 		let dcqlData = try loadTestResource(fileName: dcqlFile)
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
 		// Wallet has the "pid" credential that satisfies the first option of the first credential_set
 		let dcqlQueryable = DefaultDcqlQueryable(
-			credentials: [
-				"pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)
-			],
+			credentials: ["pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)],
 			claimPaths: [
-				"pid_cred": [
-					ClaimPath([.claim(name: "given_name")]),
-					ClaimPath([.claim(name: "family_name")]),
-					ClaimPath([.claim(name: "address"), .claim(name: "street_address")])
-				]
+				"pid_cred": getSdjwtClaims([["given_name"], ["family_name"], ["address", "street_address"]])
 			]
 		)
 
@@ -170,7 +206,9 @@ struct DcqlQueryTests {
 		#expect(result["pid_cred"]?.count == 3, "Should have all three claims for pid")
 	}
 
-	@Test("DCQL multiple credentials with credential_sets - pass with third option (multiple creds)", arguments: ["dcql-pid-multiple"])
+	@Test(
+		"DCQL multiple credentials with credential_sets - pass with third option (multiple creds)",
+		arguments: ["dcql-pid-multiple"])
 	func testDcqlMultipleCredentialsThirdOption(dcqlFile: String) throws {
 		let dcqlData = try loadTestResource(fileName: dcqlFile)
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
@@ -178,18 +216,11 @@ struct DcqlQueryTests {
 		let dcqlQueryable = DefaultDcqlQueryable(
 			credentials: [
 				"reduced_id": ("https://credentials.example.com/reduced_identity_credential", DocDataFormat.sdjwt),
-				"residence": ("https://cred.example/residence_credential", DocDataFormat.sdjwt)
+				"residence": ("https://cred.example/residence_credential", DocDataFormat.sdjwt),
 			],
 			claimPaths: [
-				"reduced_id": [
-					ClaimPath([.claim(name: "given_name")]),
-					ClaimPath([.claim(name: "family_name")])
-				],
-				"residence": [
-					ClaimPath([.claim(name: "postal_code")]),
-					ClaimPath([.claim(name: "locality")]),
-					ClaimPath([.claim(name: "region")])
-				]
+				"reduced_id": getSdjwtClaims([["given_name"], ["family_name"]]),
+				"residence": getSdjwtClaims([["postal_code"], ["locality"], ["region"]]),
 			]
 		)
 		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
@@ -198,7 +229,9 @@ struct DcqlQueryTests {
 		#expect(result["residence"]?.count == 3, "Should have three claims for residence")
 	}
 
-	@Test("DCQL multiple credentials with credential_sets - pass with optional credential", arguments: ["dcql-pid-multiple"])
+	@Test(
+		"DCQL multiple credentials with credential_sets - pass with optional credential",
+		arguments: ["dcql-pid-multiple"])
 	func testDcqlMultipleCredentialsWithOptional(dcqlFile: String) throws {
 		let dcqlData = try loadTestResource(fileName: dcqlFile)
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
@@ -206,17 +239,11 @@ struct DcqlQueryTests {
 		let dcqlQueryable = DefaultDcqlQueryable(
 			credentials: [
 				"pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt),
-				"rewards": ("https://company.example/company_rewards", DocDataFormat.sdjwt)
+				"rewards": ("https://company.example/company_rewards", DocDataFormat.sdjwt),
 			],
 			claimPaths: [
-				"pid_cred": [
-					ClaimPath([.claim(name: "given_name")]),
-					ClaimPath([.claim(name: "family_name")]),
-					ClaimPath([.claim(name: "address"), .claim(name: "street_address")])
-				],
-				"rewards": [
-					ClaimPath([.claim(name: "rewards_number")])
-				]
+				"pid_cred": getSdjwtClaims([["given_name"], ["family_name"], ["address", "street_address"]]),
+				"rewards": getSdjwtClaims([["rewards_number"]]),
 			]
 		)
 
@@ -228,8 +255,9 @@ struct DcqlQueryTests {
 		#expect(result["rewards"]?.count == 1, "Should have one claim for rewards")
 	}
 
-
-	@Test("DCQL multiple credentials with credential_sets - fail when required set not satisfied", arguments: ["dcql-pid-multiple"])
+	@Test(
+		"DCQL multiple credentials with credential_sets - fail when required set not satisfied",
+		arguments: ["dcql-pid-multiple"])
 	func testDcqlMultipleCredentialsFailRequired(dcqlFile: String) throws {
 		let dcqlData = try loadTestResource(fileName: dcqlFile)
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
@@ -239,9 +267,7 @@ struct DcqlQueryTests {
 				"rewards": ("https://company.example/company_rewards", DocDataFormat.sdjwt)
 			],
 			claimPaths: [
-				"rewards": [
-					ClaimPath([.claim(name: "rewards_number")])
-				]
+				"rewards": getSdjwtClaims([["rewards_number"]])
 			]
 		)
 		#expect(throws: WalletError.self) {
@@ -249,21 +275,21 @@ struct DcqlQueryTests {
 		}
 	}
 
-	@Test("DCQL multiple credentials with credential_sets - fail when partial claims", arguments: ["dcql-pid-multiple"])
+	@Test(
+		"DCQL multiple credentials with credential_sets - fail when partial claims",
+		arguments: ["dcql-pid-multiple"])
 	func testDcqlMultipleCredentialsFailPartialClaims(dcqlFile: String) throws {
 		let dcqlData = try loadTestResource(fileName: dcqlFile)
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
 		// Wallet has "pid" credential but missing one required claim
 		let dcqlQueryable = DefaultDcqlQueryable(
-			credentials: [
-				"pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)
-			],
+			credentials: ["pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)],
 			claimPaths: [
-				"pid_cred": [
-					ClaimPath([.claim(name: "given_name")]),
-					ClaimPath([.claim(name: "family_name")])
+				"pid_cred": getSdjwtClaims([
+					["given_name"],
+					["family_name"],
 					// Missing address.street_address claim
-				]
+				])
 			]
 		)
 		#expect(throws: WalletError.self) {
@@ -277,15 +303,9 @@ struct DcqlQueryTests {
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
 		// Wallet has mDL with identity claims
 		let dcqlQueryable = DefaultDcqlQueryable(
-			credentials: [
-				"mdl_cred": ("org.iso.18013.5.1.mDL", DocDataFormat.cbor)
-			],
+			credentials: ["mdl_cred": ("org.iso.18013.5.1.mDL", DocDataFormat.cbor)],
 			claimPaths: [
-				"mdl_cred": [
-					ClaimPath([.claim(name: "org.iso.18013.5.1"), .claim(name: "given_name")]),
-					ClaimPath([.claim(name: "org.iso.18013.5.1"), .claim(name: "family_name")]),
-					ClaimPath([.claim(name: "org.iso.18013.5.1"), .claim(name: "portrait")])
-				]
+				"mdl_cred": getMdocClaims("org.iso.18013.5.1", ["given_name", "family_name", "portrait"])
 			]
 		)
 		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
@@ -299,15 +319,9 @@ struct DcqlQueryTests {
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
 		// Wallet has photo ID card with identity claims
 		let dcqlQueryable = DefaultDcqlQueryable(
-			credentials: [
-				"photo_cred": ("org.iso.23220.photoid.1", DocDataFormat.cbor)
-			],
+			credentials: ["photo_cred": ("org.iso.23220.photoid.1", DocDataFormat.cbor)],
 			claimPaths: [
-				"photo_cred": [
-					ClaimPath([.claim(name: "org.iso.18013.5.1"), .claim(name: "given_name")]),
-					ClaimPath([.claim(name: "org.iso.18013.5.1"), .claim(name: "family_name")]),
-					ClaimPath([.claim(name: "org.iso.18013.5.1"), .claim(name: "portrait")])
-				]
+				"photo_cred": getMdocClaims("org.iso.18013.5.1", ["given_name", "family_name", "portrait"])
 			]
 		)
 		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
@@ -315,23 +329,16 @@ struct DcqlQueryTests {
 		#expect(result["photo_cred"]?.count == 3, "Should have three identity claims")
 	}
 
+
 	@Test("DCQL mdl-or-photoid - pass with photo card and address", arguments: ["dcql-mdl-or-photoid"])
 	func testDcqlMdlOrPhotoIdWithPhotoCardAndAddress(dcqlFile: String) throws {
 		let dcqlData = try loadTestResource(fileName: dcqlFile)
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
 		// Wallet has photo card with both identity and address claims
 		let dcqlQueryable = DefaultDcqlQueryable(
-			credentials: [
-				"photo_cred": ("org.iso.23220.photoid.1", DocDataFormat.cbor)
-			],
+			credentials: ["photo_cred": ("org.iso.23220.photoid.1", DocDataFormat.cbor)],
 			claimPaths: [
-				"photo_cred": [
-					ClaimPath([.claim(name: "org.iso.18013.5.1"), .claim(name: "given_name")]),
-					ClaimPath([.claim(name: "org.iso.18013.5.1"), .claim(name: "family_name")]),
-					ClaimPath([.claim(name: "org.iso.18013.5.1"), .claim(name: "portrait")]),
-					ClaimPath([.claim(name: "org.iso.18013.5.1"), .claim(name: "resident_address")]),
-					ClaimPath([.claim(name: "org.iso.18013.5.1"), .claim(name: "resident_country")])
-				]
+				"photo_cred": getMdocClaims(IsoMdlModel.isoNamespace, ["given_name", "family_name", "portrait", "resident_address", "resident_country"])
 			]
 		)
 		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
@@ -339,7 +346,9 @@ struct DcqlQueryTests {
 		#expect(result["photo_cred"]?.count == 5, "Should have identity and address claims")
 	}
 
-	@Test("DCQL mdl-or-photoid - pass with both mDL and photo card prefers first", arguments: ["dcql-mdl-or-photoid"])
+	@Test(
+		"DCQL mdl-or-photoid - pass with both mDL and photo card prefers first",
+		arguments: ["dcql-mdl-or-photoid"])
 	func testDcqlMdlOrPhotoIdWithBoth(dcqlFile: String) throws {
 		let dcqlData = try loadTestResource(fileName: dcqlFile)
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
@@ -347,19 +356,11 @@ struct DcqlQueryTests {
 		let dcqlQueryable = DefaultDcqlQueryable(
 			credentials: [
 				"mdl_cred": ("org.iso.18013.5.1.mDL", DocDataFormat.cbor),
-				"photo_cred": ("org.iso.23220.photoid.1", DocDataFormat.cbor)
+				"photo_cred": ("org.iso.23220.photoid.1", DocDataFormat.cbor),
 			],
 			claimPaths: [
-				"mdl_cred": [
-					ClaimPath([.claim(name: "org.iso.18013.5.1"), .claim(name: "given_name")]),
-					ClaimPath([.claim(name: "org.iso.18013.5.1"), .claim(name: "family_name")]),
-					ClaimPath([.claim(name: "org.iso.18013.5.1"), .claim(name: "portrait")])
-				],
-				"photo_cred": [
-					ClaimPath([.claim(name: "org.iso.18013.5.1"), .claim(name: "given_name")]),
-					ClaimPath([.claim(name: "org.iso.18013.5.1"), .claim(name: "family_name")]),
-					ClaimPath([.claim(name: "org.iso.18013.5.1"), .claim(name: "portrait")])
-				]
+				"mdl_cred": getMdocClaims("org.iso.18013.5.1", ["given_name", "family_name", "portrait"]),
+				"photo_cred": getMdocClaims("org.iso.18013.5.1", ["given_name", "family_name", "portrait"]),
 			]
 		)
 		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
@@ -367,22 +368,18 @@ struct DcqlQueryTests {
 		#expect(result["mdl_cred"] != nil, "Should prefer mDL as first option")
 	}
 
-
-	@Test("DCQL mdl-or-photoid - fail with partial identity claims", arguments: ["dcql-mdl-or-photoid"])
+	@Test(
+		"DCQL mdl-or-photoid - fail with partial identity claims",
+		arguments: ["dcql-mdl-or-photoid"])
 	func testDcqlMdlOrPhotoIdFailPartialClaims(dcqlFile: String) throws {
 		let dcqlData = try loadTestResource(fileName: dcqlFile)
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
 		// Wallet has mDL but missing required claims
 		let dcqlQueryable = DefaultDcqlQueryable(
-			credentials: [
-				"mdl_cred": ("org.iso.18013.5.1.mDL", DocDataFormat.cbor)
-			],
+			credentials: ["mdl_cred": ("org.iso.18013.5.1.mDL", DocDataFormat.cbor)],
 			claimPaths: [
-				"mdl_cred": [
-					ClaimPath([.claim(name: "org.iso.18013.5.1"), .claim(name: "given_name")]),
-					ClaimPath([.claim(name: "org.iso.18013.5.1"), .claim(name: "family_name")])
-					// Missing portrait claim
-				]
+				"mdl_cred": getMdocClaims("org.iso.18013.5.1", ["given_name", "family_name"])
+				// Missing portrait claim
 			]
 		)
 		#expect(throws: WalletError.self) {
@@ -396,16 +393,10 @@ struct DcqlQueryTests {
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
 		// Wallet has mDL with identity claims but no address claims
 		let dcqlQueryable = DefaultDcqlQueryable(
-			credentials: [
-				"mdl_cred": ("org.iso.18013.5.1.mDL", DocDataFormat.cbor)
-			],
+			credentials: ["mdl_cred": ("org.iso.18013.5.1.mDL", DocDataFormat.cbor)],
 			claimPaths: [
-				"mdl_cred": [
-					ClaimPath([.claim(name: "org.iso.18013.5.1"), .claim(name: "given_name")]),
-					ClaimPath([.claim(name: "org.iso.18013.5.1"), .claim(name: "family_name")]),
-					ClaimPath([.claim(name: "org.iso.18013.5.1"), .claim(name: "portrait")])
-					// No address claims
-				]
+				"mdl_cred": getMdocClaims("org.iso.18013.5.1", ["given_name", "family_name", "portrait"])
+				// No address claims
 			]
 		)
 		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
@@ -419,15 +410,9 @@ struct DcqlQueryTests {
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
 		// Wallet has all claims from second set: last_name, postal_code, date_of_birth
 		let dcqlQueryable = DefaultDcqlQueryable(
-			credentials: [
-				"pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)
-			],
+			credentials: ["pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)],
 			claimPaths: [
-				"pid_cred": [
-					ClaimPath([.claim(name: "last_name")]),
-					ClaimPath([.claim(name: "postal_code")]),
-					ClaimPath([.claim(name: "date_of_birth")])
-				]
+				"pid_cred": getSdjwtClaims([["last_name"], ["postal_code"], ["date_of_birth"]])
 			]
 		)
 		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
@@ -435,50 +420,44 @@ struct DcqlQueryTests {
 		#expect(result["pid_cred"]?.count == 3, "Should have three claims from second set")
 	}
 
-	@Test("DCQL claim_sets - pass with all claims (prefers first set)", arguments: ["dcql-claim-sets"])
+	@Test(
+		"DCQL claim_sets - pass with all claims (prefers first set)", arguments: ["dcql-claim-sets"]
+	)
 	func testDcqlClaimSetsAllClaims(dcqlFile: String) throws {
 		let dcqlData = try loadTestResource(fileName: dcqlFile)
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
 		// Wallet has all possible claims
 		let dcqlQueryable = DefaultDcqlQueryable(
-			credentials: [
-				"pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)
-			],
+			credentials: ["pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)],
 			claimPaths: [
-				"pid_cred": [
-					ClaimPath([.claim(name: "last_name")]),
-					ClaimPath([.claim(name: "postal_code")]),
-					ClaimPath([.claim(name: "locality")]),
-					ClaimPath([.claim(name: "region")]),
-					ClaimPath([.claim(name: "date_of_birth")])
-				]
+				"pid_cred": getSdjwtClaims([["last_name"], ["postal_code"], ["locality"], ["region"], ["date_of_birth"]])
 			]
 		)
 		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
 		#expect(result.count == 1, "Should have one credential")
 		#expect(result["pid_cred"]?.count == 4, "Should select first claim set with 4 claims")
 		// Verify it's the first set by checking for locality/region (not postal_code)
-		let paths = result["pid_cred"]?.map { $0.path.value.map(\.claimName).joined(separator: ".") } ?? []
+		let paths =
+			result["pid_cred"]?.map { $0.path.value.map(\.claimName).joined(separator: ".") } ?? []
 		#expect(paths.contains("locality"), "Should have locality from first set")
 		#expect(paths.contains("region"), "Should have region from first set")
 	}
 
-	@Test("DCQL claim_sets - fail with partial claims from both sets", arguments: ["dcql-claim-sets"])
+	@Test(
+		"DCQL claim_sets - fail with partial claims from both sets", arguments: ["dcql-claim-sets"])
 	func testDcqlClaimSetsPartialClaims(dcqlFile: String) throws {
 		let dcqlData = try loadTestResource(fileName: dcqlFile)
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
 		// Wallet has last_name and date_of_birth but missing other claims from both sets
 		let dcqlQueryable = DefaultDcqlQueryable(
-			credentials: [
-				"pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)
-			],
+			credentials: ["pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)],
 			claimPaths: [
-				"pid_cred": [
-					ClaimPath([.claim(name: "last_name")]),
-					ClaimPath([.claim(name: "date_of_birth")])
+				"pid_cred": getSdjwtClaims([
+					["last_name"],
+					["date_of_birth"],
 					// Missing locality, region from set 1
 					// Missing postal_code from set 2
-				]
+				])
 			]
 		)
 		#expect(throws: WalletError.self) {
@@ -496,11 +475,7 @@ struct DcqlQueryTests {
 				"other_cred": ("https://example.com/other", DocDataFormat.sdjwt)
 			],
 			claimPaths: [
-				"other_cred": [
-					ClaimPath([.claim(name: "last_name")]),
-					ClaimPath([.claim(name: "postal_code")]),
-					ClaimPath([.claim(name: "date_of_birth")])
-				]
+				"other_cred": getSdjwtClaims([["last_name"], ["postal_code"], ["date_of_birth"]])
 			]
 		)
 		#expect(throws: WalletError.self) {
@@ -514,21 +489,14 @@ struct DcqlQueryTests {
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
 		// Wallet has credential with exact matching values
 		let dcqlQueryable = DefaultDcqlQueryable(
-			credentials: [
-				"pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)
-			],
+			credentials: ["pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)],
 			claimPaths: [
-				"pid_cred": [
-					ClaimPath([.claim(name: "last_name")]),
-					ClaimPath([.claim(name: "first_name")]),
-					ClaimPath([.claim(name: "address"), .claim(name: "street_address")]),
-					ClaimPath([.claim(name: "postal_code")])
-				]
+				"pid_cred": getSdjwtClaims([["last_name"], ["first_name"], ["address", "street_address"], ["postal_code"]])
 			],
 			claimValues: [
 				"pid_cred": [
 					ClaimPath([.claim(name: "last_name")]): ["Doe"],
-					ClaimPath([.claim(name: "postal_code")]): ["90210"]
+					ClaimPath([.claim(name: "postal_code")]): ["90210"],
 				]
 			]
 		)
@@ -543,21 +511,14 @@ struct DcqlQueryTests {
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
 		// Wallet has credential with second postal code option
 		let dcqlQueryable = DefaultDcqlQueryable(
-			credentials: [
-				"pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)
-			],
+			credentials: ["pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)],
 			claimPaths: [
-				"pid_cred": [
-					ClaimPath([.claim(name: "last_name")]),
-					ClaimPath([.claim(name: "first_name")]),
-					ClaimPath([.claim(name: "address"), .claim(name: "street_address")]),
-					ClaimPath([.claim(name: "postal_code")])
-				]
+				"pid_cred": getSdjwtClaims([["last_name"], ["first_name"], ["address", "street_address"], ["postal_code"]])
 			],
 			claimValues: [
 				"pid_cred": [
 					ClaimPath([.claim(name: "last_name")]): ["Doe"],
-					ClaimPath([.claim(name: "postal_code")]): ["90211"]
+					ClaimPath([.claim(name: "postal_code")]): ["90211"],
 				]
 			]
 		)
@@ -572,21 +533,14 @@ struct DcqlQueryTests {
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
 		// Wallet has credential but last_name doesn't match
 		let dcqlQueryable = DefaultDcqlQueryable(
-			credentials: [
-				"pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)
-			],
+			credentials: ["pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)],
 			claimPaths: [
-				"pid_cred": [
-					ClaimPath([.claim(name: "last_name")]),
-					ClaimPath([.claim(name: "first_name")]),
-					ClaimPath([.claim(name: "address"), .claim(name: "street_address")]),
-					ClaimPath([.claim(name: "postal_code")])
-				]
+				"pid_cred": getSdjwtClaims([["last_name"], ["first_name"], ["address", "street_address"], ["postal_code"]])
 			],
 			claimValues: [
 				"pid_cred": [
 					ClaimPath([.claim(name: "last_name")]): ["Smith"],  // Wrong value
-					ClaimPath([.claim(name: "postal_code")]): ["90210"]
+					ClaimPath([.claim(name: "postal_code")]): ["90210"],
 				]
 			]
 		)
@@ -601,21 +555,14 @@ struct DcqlQueryTests {
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
 		// Wallet has credential but postal_code doesn't match any option
 		let dcqlQueryable = DefaultDcqlQueryable(
-			credentials: [
-				"pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)
-			],
+			credentials: ["pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)],
 			claimPaths: [
-				"pid_cred": [
-					ClaimPath([.claim(name: "last_name")]),
-					ClaimPath([.claim(name: "first_name")]),
-					ClaimPath([.claim(name: "address"), .claim(name: "street_address")]),
-					ClaimPath([.claim(name: "postal_code")])
-				]
+				"pid_cred": getSdjwtClaims([["last_name"], ["first_name"], ["address", "street_address"], ["postal_code"]])
 			],
 			claimValues: [
 				"pid_cred": [
 					ClaimPath([.claim(name: "last_name")]): ["Doe"],
-					ClaimPath([.claim(name: "postal_code")]): ["90212"]  // Wrong value
+					ClaimPath([.claim(name: "postal_code")]): ["90212"],  // Wrong value
 				]
 			]
 		)
@@ -624,22 +571,22 @@ struct DcqlQueryTests {
 		}
 	}
 
-	@Test("DCQL query values - fail when missing value constraint claims", arguments: ["dcql-query-values"])
+	@Test(
+		"DCQL query values - fail when missing value constraint claims",
+		arguments: ["dcql-query-values"])
 	func testDcqlQueryValuesMissingClaims(dcqlFile: String) throws {
 		let dcqlData = try loadTestResource(fileName: dcqlFile)
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
 		// Wallet has credential but missing postal_code claim entirely
 		let dcqlQueryable = DefaultDcqlQueryable(
-			credentials: [
-				"pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)
-			],
+			credentials: ["pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)],
 			claimPaths: [
-				"pid_cred": [
-					ClaimPath([.claim(name: "last_name")]),
-					ClaimPath([.claim(name: "first_name")]),
-					ClaimPath([.claim(name: "address"), .claim(name: "street_address")])
+				"pid_cred": getSdjwtClaims([
+					["last_name"],
+					["first_name"],
+					["address", "street_address"],
 					// Missing postal_code
-				]
+				])
 			],
 			claimValues: [
 				"pid_cred": [
@@ -652,27 +599,21 @@ struct DcqlQueryTests {
 		}
 	}
 
-	@Test("DCQL query values - pass with multiple matching values", arguments: ["dcql-query-values"])
+	@Test(
+		"DCQL query values - pass with multiple matching values", arguments: ["dcql-query-values"])
 	func testDcqlQueryValuesMultipleMatchingValues(dcqlFile: String) throws {
 		let dcqlData = try loadTestResource(fileName: dcqlFile)
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
 		// Wallet has credential with both postal code values available
 		let dcqlQueryable = DefaultDcqlQueryable(
-			credentials: [
-				"pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)
-			],
+			credentials: ["pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)],
 			claimPaths: [
-				"pid_cred": [
-					ClaimPath([.claim(name: "last_name")]),
-					ClaimPath([.claim(name: "first_name")]),
-					ClaimPath([.claim(name: "address"), .claim(name: "street_address")]),
-					ClaimPath([.claim(name: "postal_code")])
-				]
+				"pid_cred": getSdjwtClaims([["last_name"], ["first_name"], ["address", "street_address"], ["postal_code"]])
 			],
 			claimValues: [
 				"pid_cred": [
 					ClaimPath([.claim(name: "last_name")]): ["Doe"],
-					ClaimPath([.claim(name: "postal_code")]): ["90210", "90211"]  // Has both
+					ClaimPath([.claim(name: "postal_code")]): ["90210", "90211"],  // Has both
 				]
 			]
 		)
@@ -702,7 +643,9 @@ struct DcqlQueryTests {
 			Issue.record("Expected WalletError to be thrown")
 		} catch let error as WalletError {
 			#expect(error.code == .claimNotFound, "Error code should be .claimNotFound")
-			#expect(error.context["claimPath"] == "org.iso.18013.5.1/first_name", "Context should contain the missing claim path")
+			#expect(
+				error.context["claimPath"] == "org.iso.18013.5.1/first_name",
+				"Context should contain the missing claim path")
 		}
 	}
 
@@ -729,12 +672,15 @@ struct DcqlQueryTests {
 		#expect(result.count == 1, "Should still resolve the matching credential")
 		#expect(result["cred1"]?.count == 1, "Should keep only the claims that are present")
 		#expect(
-			result["cred1"]?.first?.path.value == ClaimPath([.claim(name: "org.iso.7367.1"), .claim(name: "vehicle_holder")]).value,
+			result["cred1"]?.first?.path.value
+				== ClaimPath([.claim(name: "org.iso.7367.1"), .claim(name: "vehicle_holder")]).value,
 			"Should only include the available claim path"
 		)
 	}
 
-	@Test("WalletError has .credentialNotFound code when docType is missing", arguments: ["dcql-vehicle"])
+	@Test(
+		"WalletError has .credentialNotFound code when docType is missing",
+		arguments: ["dcql-vehicle"])
 	func testErrorCodeCredentialNotFound(dcqlFile: String) throws {
 		let dcqlData = try loadTestResource(fileName: dcqlFile)
 		let wrapper = try JSONDecoder().decode(DCQL.self, from: dcqlData)
@@ -749,30 +695,27 @@ struct DcqlQueryTests {
 			Issue.record("Expected WalletError to be thrown")
 		} catch let error as WalletError {
 			#expect(error.code == .credentialNotFound, "Error code should be .credentialNotFound")
-			#expect(error.context["docType"] == "org.iso.7367.1.mVRC", "Context should contain the missing docType")
+			#expect(
+				error.context["docType"] == "org.iso.7367.1.mVRC",
+				"Context should contain the missing docType")
 		}
 	}
 
-	@Test("WalletError has .claimValueMismatch code when value doesn't match", arguments: ["dcql-query-values"])
+	@Test(
+		"WalletError has .claimValueMismatch code when value doesn't match",
+		arguments: ["dcql-query-values"])
 	func testErrorCodeClaimValueMismatch(dcqlFile: String) throws {
 		let dcqlData = try loadTestResource(fileName: dcqlFile)
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
 		let dcqlQueryable = DefaultDcqlQueryable(
-			credentials: [
-				"pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)
-			],
+			credentials: ["pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)],
 			claimPaths: [
-				"pid_cred": [
-					ClaimPath([.claim(name: "last_name")]),
-					ClaimPath([.claim(name: "first_name")]),
-					ClaimPath([.claim(name: "address"), .claim(name: "street_address")]),
-					ClaimPath([.claim(name: "postal_code")])
-				]
+				"pid_cred": getSdjwtClaims([["last_name"], ["first_name"], ["address", "street_address"], ["postal_code"]])
 			],
 			claimValues: [
 				"pid_cred": [
 					ClaimPath([.claim(name: "last_name")]): ["Smith"],  // Wrong value
-					ClaimPath([.claim(name: "postal_code")]): ["90210"]
+					ClaimPath([.claim(name: "postal_code")]): ["90210"],
 				]
 			]
 		)
@@ -781,35 +724,104 @@ struct DcqlQueryTests {
 			Issue.record("Expected WalletError to be thrown")
 		} catch let error as WalletError {
 			#expect(error.code == .claimValueMismatch, "Error code should be .claimValueMismatch")
-			#expect(error.context["claimPath"] == "last_name", "Context should contain the mismatched claim path")
+			#expect(
+				error.context["claimPath"] == "last_name",
+				"Context should contain the mismatched claim path")
 		}
 	}
 
-	@Test("WalletError has .claimSetNotSatisfied code when no claim_set option works", arguments: ["dcql-claim-sets"])
+	@Test(
+		"WalletError has .claimSetNotSatisfied code when no claim_set option works",
+		arguments: ["dcql-claim-sets"])
 	func testErrorCodeClaimSetNotSatisfied(dcqlFile: String) throws {
 		let dcqlData = try loadTestResource(fileName: dcqlFile)
 		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
 		let dcqlQueryable = DefaultDcqlQueryable(
-			credentials: [
-				"pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)
-			],
+			credentials: ["pid_cred": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)],
 			claimPaths: [
-				"pid_cred": [
-					ClaimPath([.claim(name: "last_name")]),
-					ClaimPath([.claim(name: "date_of_birth")])
+				"pid_cred": getSdjwtClaims([
+					["last_name"],
+					["date_of_birth"],
 					// Missing locality, region from set 1
 					// Missing postal_code from set 2
-				]
+				])
 			]
 		)
 		do {
 			_ = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
 			Issue.record("Expected WalletError to be thrown")
 		} catch let error as WalletError {
-			#expect(error.code == .claimSetNotSatisfied, "Error code should be .claimSetNotSatisfied")
-			#expect(error.context["claimPath"] != nil, "Context should contain the first missing claim path")
+			#expect(
+				error.code == .claimSetNotSatisfied, "Error code should be .claimSetNotSatisfied")
+			#expect(
+				error.context["claimPath"] != nil,
+				"Context should contain the first missing claim path")
 		}
 	}
+
+	// MARK: - multiple flag tests
+
+	@Test("DCQL multiple flag - returns all matching credentials")
+	func testDcqlMultipleFlagReturnsAllMatches() throws {
+		let dcqlData = try loadTestResource(fileName: "dcql-multiple")
+		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
+		// Wallet has two credentials of the same type
+		let dcqlQueryable = DefaultDcqlQueryable(
+			credentials: [
+				"pid_1": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt),
+				"pid_2": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt),
+			],
+			claimPaths: [
+				"pid_1": getSdjwtClaims([["given_name"], ["family_name"]]),
+				"pid_2": getSdjwtClaims([["given_name"], ["family_name"]]),
+			]
+		)
+		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
+		#expect(result.count == 2, "Should return both matching credentials when multiple is true")
+		#expect(result["pid_1"] != nil, "Should include pid_1")
+		#expect(result["pid_2"] != nil, "Should include pid_2")
+	}
+
+	@Test("DCQL multiple flag - returns single credential when only one matches")
+	func testDcqlMultipleFlagSingleMatch() throws {
+		let dcqlData = try loadTestResource(fileName: "dcql-multiple")
+		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
+		// Wallet has one credential of the matching type and one of a different type
+		let dcqlQueryable = DefaultDcqlQueryable(
+			credentials: [
+				"pid_1": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt),
+				"other": ("https://example.com/other_credential", DocDataFormat.sdjwt),
+			],
+			claimPaths: [
+				"pid_1": getSdjwtClaims([["given_name"], ["family_name"]]),
+				"other": getSdjwtClaims([["some_claim"]]),
+			]
+		)
+		let result = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
+		#expect(result.count == 1, "Should return the single matching credential")
+		#expect(result["pid_1"] != nil, "Should include pid_1")
+	}
+
+	@Test("DCQL multiple flag - throws when no credential satisfies claims")
+	func testDcqlMultipleFlagThrowsWhenNoClaimsSatisfied() throws {
+		let dcqlData = try loadTestResource(fileName: "dcql-multiple")
+		let dcql = try JSONDecoder().decode(DCQL.self, from: dcqlData)
+		// Wallet has credential of the right type but missing required claims
+		let dcqlQueryable = DefaultDcqlQueryable(
+			credentials: ["pid_1": ("https://credentials.example.com/identity_credential", DocDataFormat.sdjwt)],
+			claimPaths: [
+				"pid_1": getSdjwtClaims([
+					["given_name"],
+					// Missing family_name
+				])
+			]
+		)
+		#expect(throws: WalletError.self) {
+			try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
+		}
+	}
+
+	// MARK: - WalletError tests
 
 	@Test("WalletError backward compatibility — code and context default to nil and empty")
 	func testWalletErrorBackwardCompatibility() throws {

--- a/Tests/EudiWalletKitTests/EudiWalletKitTests.swift
+++ b/Tests/EudiWalletKitTests/EudiWalletKitTests.swift
@@ -398,8 +398,8 @@ struct EudiWalletKitTests {
 				"attested_issuer": OpenId4VciConfiguration(
 					credentialIssuerURL: "https://issuer.example.com",
 					keyAttestationsConfig: KeyAttestationConfiguration(walletAttestationsProvider: provider),
-					requirePAR: false,
-					requireDpop: false
+					requirePAR: .required(authorizationCodeDPoPBinding: false),
+					requireDpop: true
 				)
 			],
 			secureAreas: [SoftwareSecureArea.create(storage: InMemorySecureKeyStorage())]
@@ -427,7 +427,7 @@ struct EudiWalletKitTests {
 	private func makeVciService(storageService: TestDataStorageService, issuerURL: String = "https://dev.issuer.eudiw.dev") throws -> OpenId4VciService {
 		let networking = TestNetworking(metadata: try makeSdJwtIssuerMetadata(forResource: "sjwt-pid", issuerURL: issuerURL))
 		let storage = StorageManager(storageService: storageService)
-		let config = OpenId4VciConfiguration(credentialIssuerURL: issuerURL, requirePAR: true, requireDpop: true)
+		let config = OpenId4VciConfiguration(credentialIssuerURL: issuerURL, requirePAR: .required(authorizationCodeDPoPBinding: true), requireDpop: true)
 		return try OpenId4VciService(uiCulture: nil, config: config, networking: networking, storage: storage, storageService: storageService)
 	}
 

--- a/Tests/EudiWalletKitTests/EudiWalletKitTests.swift
+++ b/Tests/EudiWalletKitTests/EudiWalletKitTests.swift
@@ -398,7 +398,7 @@ struct EudiWalletKitTests {
 				"attested_issuer": OpenId4VciConfiguration(
 					credentialIssuerURL: "https://issuer.example.com",
 					keyAttestationsConfig: KeyAttestationConfiguration(walletAttestationsProvider: provider),
-					requirePAR: .required(authorizationCodeDPoPBinding: false),
+					parUsage: .required(authorizationCodeDPoPBinding: false),
 					requireDpop: true
 				)
 			],
@@ -427,7 +427,7 @@ struct EudiWalletKitTests {
 	private func makeVciService(storageService: TestDataStorageService, issuerURL: String = "https://dev.issuer.eudiw.dev") throws -> OpenId4VciService {
 		let networking = TestNetworking(metadata: try makeSdJwtIssuerMetadata(forResource: "sjwt-pid", issuerURL: issuerURL))
 		let storage = StorageManager(storageService: storageService)
-		let config = OpenId4VciConfiguration(credentialIssuerURL: issuerURL, requirePAR: .required(authorizationCodeDPoPBinding: true), requireDpop: true)
+		let config = OpenId4VciConfiguration(credentialIssuerURL: issuerURL, parUsage: .required(authorizationCodeDPoPBinding: true), requireDpop: true)
 		return try OpenId4VciService(uiCulture: nil, config: config, networking: networking, storage: storage, storageService: storageService)
 	}
 

--- a/Tests/EudiWalletKitTests/Resources/dcql-mdl-photoid-or-pid.json
+++ b/Tests/EudiWalletKitTests/Resources/dcql-mdl-photoid-or-pid.json
@@ -1,0 +1,32 @@
+{
+  "credentials": [
+    {
+      "id": "mdl",
+      "format": "mso_mdoc",
+      "meta": { "doctype_value": "org.iso.18013.5.1.mDL" },
+      "claims": [
+        { "path": ["org.iso.18013.5.1", "family_name"], "intent_to_retain": false },
+        { "path": ["org.iso.18013.5.1", "given_name"], "intent_to_retain": false }
+      ]
+    },
+    {
+      "id": "photoid",
+      "format": "mso_mdoc",
+      "meta": { "doctype_value": "org.iso.23220.2.photoid.1" },
+      "claims": [
+        { "path": ["org.iso.23220.photoid.1", "birth_date"], "intent_to_retain": false }
+      ]
+    },
+    {
+      "id": "pid",
+      "format": "mso_mdoc",
+      "meta": { "doctype_value": "eu.europa.ec.eudi.pid.1" },
+      "claims": [
+        { "path": ["eu.europa.ec.eudi.pid.1", "birth_date"], "intent_to_retain": false }
+      ]
+    }
+  ],
+  "credential_sets": [
+    { "options": [ ["mdl", "photoid"], ["mdl", "pid"] ] }
+  ]
+}

--- a/Tests/EudiWalletKitTests/Resources/dcql-mdl-pid-required-photoid-optional.json
+++ b/Tests/EudiWalletKitTests/Resources/dcql-mdl-pid-required-photoid-optional.json
@@ -1,0 +1,35 @@
+{
+  "credentials": [
+    {
+      "id": "mdl",
+      "format": "mso_mdoc",
+      "meta": { "doctype_value": "org.iso.18013.5.1.mDL" },
+      "claims": [
+        { "path": ["org.iso.18013.5.1", "family_name"], "intent_to_retain": false },
+        { "path": ["org.iso.18013.5.1", "given_name"], "intent_to_retain": false }
+      ]
+    },
+    {
+      "id": "pid",
+      "format": "mso_mdoc",
+      "meta": { "doctype_value": "eu.europa.ec.eudi.pid.1" },
+      "claims": [
+        { "path": ["eu.europa.ec.eudi.pid.1", "family_name"], "intent_to_retain": false },
+        { "path": ["eu.europa.ec.eudi.pid.1", "given_name"], "intent_to_retain": false }
+      ]
+    },
+    {
+      "id": "photoid",
+      "format": "mso_mdoc",
+      "meta": { "doctype_value": "org.iso.23220.2.photoid.1" },
+      "claims": [
+        { "path": ["org.iso.23220.photoid.1", "birth_date"], "intent_to_retain": false }
+      ]
+    }
+  ],
+  "credential_sets": [
+    { "options": [ ["mdl"] ],     "required": true  },
+    { "options": [ ["pid"] ],     "required": true  },
+    { "options": [ ["photoid"] ], "required": false }
+  ]
+}

--- a/Tests/EudiWalletKitTests/Resources/dcql-multiple.json
+++ b/Tests/EudiWalletKitTests/Resources/dcql-multiple.json
@@ -1,0 +1,16 @@
+{
+  "credentials": [
+    {
+      "id": "pid_cred",
+      "format": "vc+sd-jwt",
+      "meta": {
+        "vct_values": ["https://credentials.example.com/identity_credential"]
+      },
+      "multiple": true,
+      "claims": [
+        {"path": ["given_name"]},
+        {"path": ["family_name"]}
+      ]
+    }
+  ]
+}

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,25 @@
+## v0.33.0
+
+### DCQL Multiple Credential Selection
+
+DCQL query resolution now supports the `multiple` flag on credential queries and produces multiple selectable credential combinations when more than one credential matches a query.
+
+- `resolveDcql` returns `CredentialSelectionSetOptions` (an `OrderedDictionary<String, CredentialSelectionSet>`) instead of `[String: [ClaimsQuery]]`. Each entry represents a selectable combination of credentials that satisfies the query.
+- `credential_sets` with multiple options and optional sets are fully supported, including Cartesian product expansion across required and optional sets.
+
+### Breaking Changes
+
+- **`PresentationService.receiveRequest()` return type changed**: Returns `[UserRequestInfo]` instead of `UserRequestInfo`. Each element corresponds to a credential selection option.
+- **`PresentationSession.disclosedDocuments` renamed to `disclosedDocumentSets`**: The type changed from `[DocElements]` to `[[DocElements]]` to support multiple credential selection options.
+- **`PresentationSession.receiveRequest()` return type changed**: Returns `[UserRequestInfo]?` instead of `UserRequestInfo?`.
+- **`OpenId4VciConfiguration.requirePAR` renamed to `parUsage`**: The type changed from `Bool` to `ParUsage`. The default value is `.required(authorizationCodeDPoPBinding: true)`.
+
+### Dependency Updates
+
+- Updated `eudi-lib-ios-siop-openid4vp-swift` to version 0.34.1.
+- Updated `eudi-lib-ios-openid4vci-swift` to version 0.40.1.
+- Updated `eudi-lib-ios-iso18013-data-transfer` to version 0.21.3.
+
 ## v0.32.0
 
 ### Credential Reuse Policy Enforcement


### PR DESCRIPTION
DCQL query resolution now supports the `multiple` flag on credential queries and produces multiple selectable credential combinations when more than one credential matches a query.

- `resolveDcql` returns `CredentialSelectionSetOptions` (an `OrderedDictionary<String, CredentialSelectionSet>`) instead of `[String: [ClaimsQuery]]`. Each entry represents a selectable combination of credentials that satisfies the query.
- `credential_sets` with multiple options and optional sets are fully supported, including Cartesian product expansion across required and optional sets.

Fixes #396