### PR TITLE
Refactor SDJWT elements extraction

### DIFF
--- a/Sources/EudiWalletKit/EudiWallet.swift
+++ b/Sources/EudiWalletKit/EudiWallet.swift
@@ -626,12 +626,17 @@ public final class EudiWallet: ObservableObject, @unchecked Sendable {
 				let bleSvc = try await BlePresentationService(parameters: parameters)
 				return PresentationSession(presentationService: bleSvc, storageManager: storage, storageService: storageService, docIdToPresentInfo: docIdToPresentInfo, documentKeyIndexes: parameters.documentKeyIndexes, userAuthenticationRequired: eudiWalletConfig.userAuthenticationRequired, transactionLogger: mergedTransactionLogger)
 			case .openid4vp(let qrCode):
+				let docTypeDisplayNames: [String: String] = Dictionary(documents.compactMap { doc in
+					guard let displayName = docIdToPresentInfo[doc.id]?.displayName else { return nil }
+					return (doc.docType, displayName)
+				}, uniquingKeysWith: { first, _ in first })
 				let openIdSvc = try await OpenId4VpService(
 					parameters: parameters,
 					qrCode: qrCode,
 					openID4VpConfig: self.openID4VpConfig,
 					networking: networkingVp,
-					crlRevocationPolicy: eudiWalletConfig.crlRevocationPolicy
+					crlRevocationPolicy: eudiWalletConfig.crlRevocationPolicy,
+					docTypeDisplayNames: docTypeDisplayNames
 				)
 				return PresentationSession(presentationService: openIdSvc, storageManager: storage, storageService: storageService, docIdToPresentInfo: docIdToPresentInfo, documentKeyIndexes: parameters.documentKeyIndexes, userAuthenticationRequired: eudiWalletConfig.userAuthenticationRequired, transactionLogger: mergedTransactionLogger)
 			default:

--- a/Sources/EudiWalletKit/Models/DocElements.swift
+++ b/Sources/EudiWalletKit/Models/DocElements.swift
@@ -150,16 +150,43 @@ extension SignedSDJWT {
 		let allPaths = OrderedSet(allPathsDict.keys).union(docClaims.flatMap(\.claimPaths))
 		let isMandatory: (RequestItem) -> Bool = { if let o = $0.isOptional { !o } else { false } }
 		let itemsReq = itemsRequested[""] ?? allPaths.map { RequestItem(elementPath: $0.value.map(\.claimName)) }
-		var sdJwtArray = [SdJwtElement]()
-		let tmp = itemsReq.map { reqItem in reqItem.extractSdJwtElement(allPaths: allPaths, docClaims: docClaims, isMandatory: isMandatory(reqItem), bRootOnly: true) }
-		for d in tmp { if !sdJwtArray.contains(d) { sdJwtArray.append(d) } }
-		for nestedReqItem in itemsReq.filter({ $0.elementPath.count > 1 }) {
-			let parentSd = sdJwtArray.first(where: { $0.elementPath == [nestedReqItem.rootIdentifier] })!
-			let nestedSd = nestedReqItem.extractSdJwtElement(allPaths: allPaths, docClaims: docClaims, isMandatory: isMandatory(nestedReqItem), bRootOnly: false)
-			if parentSd.nestedElements == nil { parentSd.nestedElements = [] }
-			parentSd.nestedElements!.append(nestedSd)
-		}
+		let sdJwtArray = Self.buildSdJwtElementTree(itemsReq: itemsReq, allPaths: allPaths, docClaims: docClaims, isMandatory: isMandatory, parentPath: [])
 		return SdJwtElements(docId: docId, vct: vct, displayName: displayName, sdJwtElements: sdJwtArray)
+	}
+
+	static func buildSdJwtElementTree(itemsReq: [RequestItem], allPaths: OrderedSet<ClaimPath>, docClaims: [DocClaim], isMandatory: (RequestItem) -> Bool, parentPath: [String]) -> [SdJwtElement] {
+		let depth = parentPath.count + 1
+		// Group request items by the element at current depth
+		var groupedByCurrentLevel = OrderedDictionary<String, [RequestItem]>()
+		for reqItem in itemsReq {
+			guard reqItem.elementPath.count >= depth else { continue }
+			let key = reqItem.elementPath[depth - 1]
+			if groupedByCurrentLevel[key] == nil { groupedByCurrentLevel[key] = [] }
+			groupedByCurrentLevel[key]!.append(reqItem)
+		}
+		var sdJwtArray = [SdJwtElement]()
+		for (key, groupItems) in groupedByCurrentLevel {
+			let currentPath = parentPath + [key]
+			// Find the request item that matches exactly this level (for element metadata)
+			let exactItem = groupItems.first { $0.elementPath.count == depth } ?? groupItems.first!
+			// Recursively build nested elements from deeper request items
+			let deeperItems = groupItems.filter { $0.elementPath.count > depth }
+			let docClaim = exactItem.findDocClaimByPath(docClaims: docClaims, requestPath: currentPath)
+			var nestedElements: [SdJwtElement]?
+			var filteredDocClaim = docClaim
+			if !deeperItems.isEmpty {
+				let nestedDocClaims = docClaim?.children ?? docClaims
+				nestedElements = Self.buildSdJwtElementTree(itemsReq: deeperItems, allPaths: allPaths, docClaims: nestedDocClaims, isMandatory: isMandatory, parentPath: currentPath)
+				// Filter docClaim children to only include those matching nested elements
+				if let children = docClaim?.children, let nested = nestedElements {
+					let nestedNames = Set(nested.map { $0.elementPath.last! })
+					filteredDocClaim?.children = children.filter { nestedNames.contains($0.name) }
+				}
+			}
+			let element = exactItem.extractSdJwtElement(allPaths: allPaths, docClaim: filteredDocClaim, isMandatory: isMandatory(exactItem), overridePath: currentPath, nestedElements: nestedElements)
+			if !sdJwtArray.contains(element) { sdJwtArray.append(element) }
+		}
+		return sdJwtArray
 	}
 }
 
@@ -183,14 +210,18 @@ extension RequestItem {
 	}
 
 	public func extractSdJwtElement(allPaths: OrderedSet<ClaimPath>, docClaims: [DocClaim], isMandatory: Bool, bRootOnly: Bool) -> SdJwtElement {
+		let requestPath = bRootOnly ? [rootIdentifier] : elementPath
+		let docClaim: DocClaim? = findDocClaimByPath(docClaims: docClaims, requestPath: requestPath)
+		return extractSdJwtElement(allPaths: allPaths, docClaim: docClaim, isMandatory: isMandatory, overridePath: requestPath, nestedElements: nil)
+	}
+
+	public func extractSdJwtElement(allPaths: OrderedSet<ClaimPath>, docClaim: DocClaim?, isMandatory: Bool, overridePath: [String], nestedElements: [SdJwtElement]?) -> SdJwtElement {
 		// find path that the request item contains it
 		let requestClaimPath = claimPath
 		let query = allPaths.first { path in path == requestClaimPath } ?? allPaths.first { path in requestClaimPath.contains2(path) }
 		let isValid = query != nil
-		let requestPath = bRootOnly ? [rootIdentifier] : elementPath
-		let docClaim: DocClaim? = findDocClaimByPath(docClaims: docClaims, requestPath: requestPath)
 		let stringValue: String? = docClaim?.stringValue
-		return SdJwtElement(elementPath: requestPath, isOptional: !isMandatory, intentToRetain: intentToRetain ?? false, stringValue: stringValue, docClaim: docClaim, isValid: isValid, nestedElements: nil)
+		return SdJwtElement(elementPath: overridePath, isOptional: !isMandatory, intentToRetain: intentToRetain ?? false, stringValue: stringValue, docClaim: docClaim, isValid: isValid, nestedElements: nestedElements)
 	}
 
 	public func findDocClaimByPath(docClaims: [DocClaim], requestPath: [String]) -> DocClaim? {

--- a/Sources/EudiWalletKit/Services/OpenId4VpService.swift
+++ b/Sources/EudiWalletKit/Services/OpenId4VpService.swift
@@ -68,6 +68,7 @@ public final class OpenId4VpService: @unchecked Sendable, PresentationService {
 	var networking: Networking
 	var unlockData: [String: Data]!
 	var verifierInfo: [VerifierInfo]?
+	var docTypeDisplayNames: [DocType: String]
 	public var transactionLog: TransactionLog
 	public var zkpDocumentIds: [WalletStorage.Document.ID]?
 	public var flow: FlowType
@@ -78,7 +79,8 @@ public final class OpenId4VpService: @unchecked Sendable, PresentationService {
 		qrCode: Data,
 		openID4VpConfig: OpenId4VpConfiguration,
 		networking: Networking,
-		crlRevocationPolicy: RevocationPolicy
+		crlRevocationPolicy: RevocationPolicy,
+		docTypeDisplayNames: [DocType: String] = [:]
 	) async throws {
 		self.flow = .openid4vp(qrCode: qrCode)
 		let objs = try await parameters.toInitializeTransferInfo()
@@ -90,6 +92,7 @@ public final class OpenId4VpService: @unchecked Sendable, PresentationService {
 		self.openID4VpConfig = openID4VpConfig
 		self.networking = networking
 		self.crlRevocationPolicy = crlRevocationPolicy
+		self.docTypeDisplayNames = docTypeDisplayNames
 		transactionLog = TransactionLogUtils.initializeTransactionLog(type: .presentation, dataFormat: .json)
 	}
 
@@ -158,7 +161,7 @@ public final class OpenId4VpService: @unchecked Sendable, PresentationService {
 			formatsRequested = fmtsReq; inputDescriptorMap = imap; zkSpecsRequested = zkSpecMap
 			decodeDocuments()
 			let credentialSelectionSets = try OpenId4VpUtils.resolveDcql(
-				dcql, queryable: dcqlQueryable, allowPresentingPartialClaims: openID4VpConfig.allowPresentingPartialClaims)
+				dcql, queryable: dcqlQueryable, allowPresentingPartialClaims: openID4VpConfig.allowPresentingPartialClaims, docTypeDisplayNames: docTypeDisplayNames)
 			let requestItemsArray = OpenId4VpUtils.getRequestItems(credentialSelectionSets, idsToDocTypes: transferInfo.idsToDocTypes, formatsRequested: formatsRequested)
 			let transactionDataRequestedArray = transactionData != nil
 				? try OpenId4VpUtils.getTransactionDataRequested(

--- a/Sources/EudiWalletKit/Services/Openid4VpUtils.swift
+++ b/Sources/EudiWalletKit/Services/Openid4VpUtils.swift
@@ -340,7 +340,7 @@ extension OpenId4VpUtils {
 	/// - Returns: A dictionary mapping matched credential IDs to arrays of ClaimPath objects representing
 	///            the claims to disclose
 	/// - Throws: WalletError if the query cannot be satisfied, with details about the first missing claim
-	static func resolveDcql(_ dcql: DCQL, queryable: DcqlQueryable, allowPresentingPartialClaims: Bool = false) throws -> CredentialSelectionSetOptions {
+	static func resolveDcql(_ dcql: DCQL, queryable: DcqlQueryable, allowPresentingPartialClaims: Bool = false, docTypeDisplayNames: [DocType: String] = [:]) throws -> CredentialSelectionSetOptions {
 		var resultDict: CredentialSelectionSetOptions = [:]
 		var lastError: WalletError?
 		var credentialQueryResults: OrderedDictionary<QueryId, [CredentialSelection]> = [:]
@@ -351,7 +351,8 @@ extension OpenId4VpUtils {
 			let isMultiple = credQuery.multiple == true
 			// Find matching credentials
 			let matchingCredIds = queryable.getCredentials(docOrVctType: docType, docDataFormat: format)
-			if matchingCredIds.isEmpty, dcql.credentialSets == nil { throw WalletError(description: "Credential with docType \(docType) cannot be found.", code: .credentialNotFound, context: ["docType": docType]) }
+			let docTypeDisplayName = docTypeDisplayNames[docType] ?? docType
+			if matchingCredIds.isEmpty, dcql.credentialSets == nil { throw WalletError(description: "Credential of type \(docTypeDisplayName) cannot be found.", code: .credentialNotFound, context: ["docType": docType]) }
 			// Try to find credentials that satisfy the claim requirements
 			for (credIndex, credId) in matchingCredIds.enumerated() {
 				do {


### PR DESCRIPTION
Refactor the extraction and tree-building logic for SDJWT elements to improve filtering of document claims. Introduce a new parameter for `resolveDcql` to include display names for document types, enhancing error messages for missing credentials.