### PR TITLE
Bump dependencies and update package versions

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c2bb834ac5edb5166276fb63ee17ed13bf370a81bc5a1dac780235c203d12cc6",
+  "originHash" : "160189457e522e80785f53180e340cb91f26f91fe46d63bdc36deca28ff173b8",
   "pins" : [
     {
       "identity" : "cryptoswift",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git",
       "state" : {
-        "revision" : "27cca2318546c99e8d29a1b25e2cd5cbd0369a6a",
-        "version" : "0.40.2"
+        "revision" : "fdc9c9de49c631049af8e8b6b5734f8c5923f6c4",
+        "version" : "0.41.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "160189457e522e80785f53180e340cb91f26f91fe46d63bdc36deca28ff173b8",
+  "originHash" : "ee2e52c5828df9129573366d62d87fdbb44a3ae33630360f50323e71c94303af",
   "pins" : [
     {
       "identity" : "cryptoswift",
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-statium-swift.git",
       "state" : {
-        "revision" : "bcb54c2c2730a8cb83f34e64ba41ed6f8323670a",
-        "version" : "0.4.0"
+        "revision" : "d3cb29f978b7c5f839351e56bc9b433c105a5737",
+        "version" : "0.5.0"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
-        "version" : "1.3.0"
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git", exact: "0.22.0"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git", exact: "0.22.0"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift.git", exact: "0.14.6"),
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git", exact: "0.40.2"),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git", exact: "0.41.0"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vp-swift.git", exact: "0.35.0"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-statium-swift.git", exact: "0.4.0"),
     	.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.5.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift.git", exact: "0.14.6"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git", exact: "0.41.0"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vp-swift.git", exact: "0.35.0"),
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-statium-swift.git", exact: "0.4.0"),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-statium-swift.git", exact: "0.5.0"),
     	.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.5.0"),
 	],
 	targets: [

--- a/Sources/EudiWalletKit/Services/DocumentStatusService.swift
+++ b/Sources/EudiWalletKit/Services/DocumentStatusService.swift
@@ -43,7 +43,7 @@ public actor DocumentStatusService {
 }
 
 struct VerifyStatusListTokenSignatureIgnore: VerifyStatusListTokenSignature {
-	func verify(statusListToken: Data, format: StatusListTokenFormat, at: Date) {
+	func verify(statusListToken: Data, format: StatusListTokenFormat, at: Date) async throws {
 		// No verification logic, ignore the signature
 	}
 }

--- a/Sources/EudiWalletKit/Services/TrustedChainValidator.swift
+++ b/Sources/EudiWalletKit/Services/TrustedChainValidator.swift
@@ -29,7 +29,7 @@ public struct TrustedChainValidator: CertificateChainTrust {
 		self.crlRevocationPolicy = crlRevocationPolicy
     }
 
-	public func isValid(chain: [String]) -> Bool {
+	public func isValid(chain: [String]) async -> Bool {
         var isValid: Bool = false
         let b64certs = chain
         let certsData = b64certs.compactMap { Data(base64Encoded: $0) }


### PR DESCRIPTION
Update the Swift package dependencies to the latest versions, including OpenID4VCI Swift to 0.41.0 and Statium Swift to 0.5.0, ensuring compatibility with recent changes and fixes. Additionally, merge updates from the main branch.