### PR TITLE
fix: populate `documentId`, `docType` and `displayName` in `TransactionLog` for OpenID4VP and BLE flows

### DIFF
--- a/Sources/EudiWalletKit/Services/BlePresentationService.swift
+++ b/Sources/EudiWalletKit/Services/BlePresentationService.swift
@@ -274,7 +274,12 @@ public final class BlePresentationService: @unchecked Sendable, PresentationServ
 	public func sendResponse(userAccepted: Bool, itemsToSend: RequestItems, deviceNameSpacesToSend: RequestDeviceNameSpaces? = nil, onSuccess: (@Sendable (URL?) -> Void)?) async throws  {
 		await handleSelected?(userAccepted, itemsToSend, deviceNameSpacesToSend)
 		handleSelected = nil
-		TransactionLogUtils.setCborTransactionLogResponseInfo(self, transactionLog: &transactionLog)
+		// documentIds is populated by userSelected after a successful response build.
+		// docType and displayName are not available on this service; they are populated by the
+		// PresentationSession caller which has access to docIdToPresentInfo.
+let firstDocId = documentIds.first
+let firstDocType = firstDocId.flatMap { docs[$0]?.issuerAuth.mso.docType }
+TransactionLogUtils.setCborTransactionLogResponseInfo(self, documentId: firstDocId, docType: firstDocType, displayName: nil, transactionLog: &transactionLog)
 	}
 	
 	public func waitForDisconnect() async throws {

--- a/Sources/EudiWalletKit/Services/OpenId4VpService.swift
+++ b/Sources/EudiWalletKit/Services/OpenId4VpService.swift
@@ -335,9 +335,16 @@ public final class OpenId4VpService: @unchecked Sendable, PresentationService {
 				}
 			}
 			let responsePayload = VpResponsePayload(verifiable_presentations: vpTokenValues, data_formats: data_formats, transaction_data: transactionData)
-			TransactionLogUtils.setTransactionLogResponseInfo(deviceResponseBytes: try? JSONEncoder().encode(responsePayload), dataFormat: .json, sessionTranscript: Data(sessionTranscript.taggedEncoded.encode(options: CBOROptions())), responseMetadata: responseMetadata, transactionLog: &transactionLog)
+			// Resolve document identity from the first presented document.
+			// vpTokens is non-optional here (unwrapped by the enclosing if let).
+			// docType comes from transferInfo.idsToDocTypes; displayName is not held on this service.
+let firstDocId = vpTokens.compactMap { $0.1 }.sorted().first
+let firstDocType = firstDocId.flatMap { transferInfo.idsToDocTypes[$0] }
+			TransactionLogUtils.setTransactionLogResponseInfo(deviceResponseBytes: try? JSONEncoder().encode(responsePayload), dataFormat: .json, sessionTranscript: Data(sessionTranscript.taggedEncoded.encode(options: CBOROptions())), responseMetadata: responseMetadata, documentId: firstDocId, docType: firstDocType, displayName: nil, transactionLog: &transactionLog)
 		} else if case let .negative(message) = consent {
-			transactionLog = transactionLog.copy(status: .failed, errorMessage: message)
+			let firstDocId = vpTokens?.first(where: { $0.1 != nil })?.1
+			let firstDocType = firstDocId.flatMap { transferInfo.idsToDocTypes[$0] }
+			transactionLog = transactionLog.copy(status: .failed, errorMessage: message, documentId: firstDocId, docType: firstDocType, displayName: nil)
 		}
 	}
 

--- a/Sources/EudiWalletKit/Services/TransactionLogUtils.swift
+++ b/Sources/EudiWalletKit/Services/TransactionLogUtils.swift
@@ -19,15 +19,15 @@ class TransactionLogUtils {
 		transactionLog = transactionLog.copy(timestamp: getTimestamp(), rawRequest: requestInfo.deviceRequestBytes, relyingParty: TransactionLogUtils.getRelyingParty(requestInfo), dataFormat: .cbor)
 	}
 
-	static func setCborTransactionLogResponseInfo(_ bleService: BlePresentationService, transactionLog: inout TransactionLog) {
+	static func setCborTransactionLogResponseInfo(_ bleService: BlePresentationService, documentId: String?, docType: String?, displayName: String?, transactionLog: inout TransactionLog) {
 		let sessionTranscript: Data? = if let stb = bleService.sessionEncryption?.sessionTranscriptBytes { Data(stb) } else { nil }
 		let rawResponse = bleService.deviceResponseBytes
 		let responseMetadata = bleService.responseMetadata
-		transactionLog = transactionLog.copy(timestamp: getTimestamp(), status: .completed, rawResponse: rawResponse, dataFormat: .cbor, sessionTranscript: sessionTranscript, docMetadata: responseMetadata)
+		transactionLog = transactionLog.copy(timestamp: getTimestamp(), status: .completed, rawResponse: rawResponse, dataFormat: .cbor, sessionTranscript: sessionTranscript, docMetadata: responseMetadata, documentId: documentId, docType: docType, displayName: displayName)
 	}
 
-	static func setTransactionLogResponseInfo(deviceResponseBytes: Data?, dataFormat: TransactionLog.DataFormat, sessionTranscript: Data?, responseMetadata: [Data?]?, transactionLog: inout TransactionLog) {
-		transactionLog = transactionLog.copy(timestamp: getTimestamp(), status: .completed, rawResponse: deviceResponseBytes, dataFormat: dataFormat, sessionTranscript: sessionTranscript, docMetadata: responseMetadata)
+	static func setTransactionLogResponseInfo(deviceResponseBytes: Data?, dataFormat: TransactionLog.DataFormat, sessionTranscript: Data?, responseMetadata: [Data?]?, documentId: String?, docType: String?, displayName: String?, transactionLog: inout TransactionLog) {
+		transactionLog = transactionLog.copy(timestamp: getTimestamp(), status: .completed, rawResponse: deviceResponseBytes, dataFormat: dataFormat, sessionTranscript: sessionTranscript, docMetadata: responseMetadata, documentId: documentId, docType: docType, displayName: displayName)
 	}
 
 	static func setErrorTransactionLog(type: TransactionLog.LogType, error: Error, transactionLog: inout TransactionLog) {


### PR DESCRIPTION
The SDK's `OpenId4VpService` and `BlePresentationService` never populated `documentId`, `docType` and `displayName` on the `TransactionLog` passed to the registered `TransactionLogger`. All three fields were always `nil` after a presentation completed.

Changes:
- TransactionLogUtils: added documentId, docType, displayName parameters to setCborTransactionLogResponseInfo and setTransactionLogResponseInfo; forwarded into TransactionLog.copy() on each call.
- OpenId4VpService.SendVpTokens: resolves the first presented document ID from vpTokens and its docType from transferInfo.idsToDocTypes; passed to setTransactionLogResponseInfo on both the accepted and rejected paths.
- BlePresentationService.sendResponse: passes documentIds.first as documentId to setCborTransactionLogResponseInfo. docType and displayName are not available on this service layer (they live on PresentationSession via docIdToPresentInfo) so are passed as nil.

Note: displayName cannot be set from either service without access to DocPresentInfo. A follow-up could enrich it in PresentationSession.sendResponse which has docIdToPresentInfo available.

---------

Authored-by: Craig Pearson <craigaps@au1.ibm.com>