### PR TITLE
Fixes for ETSI trust

### DIFF
--- a/Sources/EudiWalletKit/EudiWallet.swift
+++ b/Sources/EudiWalletKit/EudiWallet.swift
@@ -346,7 +346,7 @@ public final class EudiWallet: ObservableObject, @unchecked Sendable {
 	// Get fallback service or create new config
 	func autoRegisterVciConfiguration(_ urlString: String, _ authFlowRedirectionURI: URL?) async throws -> OpenId4VciService {
 		// Todo: validate tot pre-registered isser by a trusted list
-        logger.warning("Issuer for url \(urlString) not registered.")
+		logger.warning("Issuer for url \(urlString) not registered.")
 		let fallbackService = OpenId4VCIServiceRegistry.shared.getAllServices().first
 		var config: OpenId4VciConfiguration
 		if let fallbackService {
@@ -368,7 +368,7 @@ public final class EudiWallet: ObservableObject, @unchecked Sendable {
 	/// - Returns: Offered issue information model
 	public func resolveOfferUrlDocTypes(offerUri: String, authFlowRedirectionURI: URL?) async throws -> OfferedIssuanceModel {
 		let vciServiceFromOfferUri = await resolveVCIServiceFromOfferUri(offerUri)
-		let policy: IssuerMetadataPolicy = if let vciServiceFromOfferUri { await vciServiceFromOfferUri.config.issuerMetadataPolicy } else { .ignoreSigned }
+		let policy: IssuerMetadataPolicy = if let vciServiceFromOfferUri { await vciServiceFromOfferUri.config.issuerMetadataPolicy } else { trustConfig.issuerMetadataPolicy }
 		let fetcher = Fetcher<CredentialOfferRequestObject>(session: networkingVci)
 		let metadataResolver = OpenId4VciService.makeMetadataResolver(networkingVci)
 		let oidcFetcher = Fetcher<OIDCProviderMetadata>(session: networkingVci)
@@ -399,7 +399,7 @@ public final class EudiWallet: ObservableObject, @unchecked Sendable {
 	///  - configuration: Optional OpenId4VciConfiguration to override the default one for this issuance
 	/// - Returns: Array of issued and stored documents
 	public func issueDocumentsByOfferUrl(offerUri: String, docTypes: [OfferedDocModel], txCodeValue: String? = nil, promptMessage: String? = nil, configuration: OpenId4VciConfiguration? = nil) async throws -> [WalletStorage.Document] {
-		let issuerMetadataPolicy = configuration?.issuerMetadataPolicy ?? .ignoreSigned
+		let issuerMetadataPolicy = configuration?.issuerMetadataPolicy ?? trustConfig.issuerMetadataPolicy
 		let fetcher = Fetcher<CredentialOfferRequestObject>(session: networkingVci)
 		let metadataResolver = OpenId4VciService.makeMetadataResolver(networkingVci)
 		let oidcFetcher = Fetcher<OIDCProviderMetadata>(session: networkingVci)

--- a/Sources/EudiWalletKit/Models/IssuerMetadataChainTrust.swift
+++ b/Sources/EudiWalletKit/Models/IssuerMetadataChainTrust.swift
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,12 +19,16 @@ import MdocSecurity18013
 import OpenID4VCI
 
 /// `CertificateChainTrust` protocol required by OpenID4VCI's `IssuerMetadataPolicy`.
-struct IssuerMetadataChainTrust: CertificateChainTrust {
-    let trustManager: EtsiTrustManager
+public struct IssuerMetadataChainTrust: CertificateChainTrust {
+	public let trustManager: EtsiTrustManager
 
-    func isValid(chain: [String]) async -> Bool {
-        let chainData = chain.compactMap { Data(base64Encoded: $0) }
-        guard !chainData.isEmpty, chainData.count == chain.count else { return false }
+	public init(trustManager: EtsiTrustManager) {
+		self.trustManager = trustManager
+	}
+
+	public func isValid(chain: [String]) async -> Bool {
+		let chainData = chain.compactMap { Data(base64Encoded: $0) }
+		guard !chainData.isEmpty, chainData.count == chain.count else { return false }
 		return await trustManager.validateCertTrustPath(chain: chainData).0
-    }
+	}
 }

--- a/Sources/EudiWalletKit/Models/TrustConfiguration.swift
+++ b/Sources/EudiWalletKit/Models/TrustConfiguration.swift
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,59 +20,62 @@ import OpenID4VCI
 
 /// Configuration that describes where trust anchors come from and how trust failures are handled.
 public struct TrustConfiguration: Sendable {
-    /// The policy applied to doc types without a specific entry in `docTypePolicies`.
-    public let defaultPolicy: TrustPolicy
-    /// Per doc-type overrides of `defaultPolicy`, keyed by doc type.
-    public let docTypePolicies: [String: TrustPolicy]
+	/// The policy applied to doc types without a specific entry in `docTypePolicies`.
+	public let defaultPolicy: TrustPolicy
+	/// Per doc-type overrides of `defaultPolicy`, keyed by doc type.
+	public let docTypePolicies: [String: TrustPolicy]
 	/// Require signed metadata
 	public let requireSignedMetadata: Bool
+	/// The trust policy applied to document status token validation.
+	/// Defaults to `.enforce`. Set to `.warning` to allow status checks to succeed even when the status token trust chain cannot be validated.
+	public let statusTrustPolicy: TrustPolicy
 	/// Clock skew for the status token verifier
 	public let clockSkew: TimeInterval
-	
-    /// Trust manager for issuer (document-signer) certificates. Falls back to the `default`
-    /// doc-type mappings only when the trust source does not already define its own.
-    /// When a `fallbackTrustSource` is supplied it is consulted for doc types this manager
-    /// has no validation context for.
-    public var issuerTrustManager: EtsiTrustManager
+	/// Trust manager for issuer (document-signer) certificates. Falls back to the `default`
+	/// doc-type mappings only when the trust source does not already define its own.
+	/// When a `fallbackTrustSource` is supplied it is consulted for doc types this manager
+	/// has no validation context for.
+	var issuerTrustManager: EtsiTrustManager
+	/// Trust manager for reader/relying-party access certificates. Uses the WRPAC verification context.
+	let accessTrustManager: EtsiTrustManager
 
-    /// Trust manager for reader/relying-party access certificates. Uses the WRPAC verification context.
-    public let accessTrustManager: EtsiTrustManager
-
-    public init(
-        trustSource: TrustSource,
+	public init(
+		trustSource: TrustSource,
 		fallbackTrustSource: TrustSource? = nil,
-        defaultPolicy: TrustPolicy = .enforce,
-        docTypePolicies: [String: TrustPolicy] = [:],
+		defaultPolicy: TrustPolicy = .enforce,
+		docTypePolicies: [String: TrustPolicy] = [:],
 		requireSignedMetadata: Bool = true,
+		statusTrustPolicy: TrustPolicy = .enforce,
 		clockSkew: TimeInterval = 60
-    ) {
-        self.defaultPolicy = defaultPolicy
-        self.docTypePolicies = docTypePolicies
+	) {
+		self.defaultPolicy = defaultPolicy
+		self.docTypePolicies = docTypePolicies
 		self.requireSignedMetadata = requireSignedMetadata
+		self.statusTrustPolicy = statusTrustPolicy
 		self.clockSkew = clockSkew
-        let issuerSource = trustSource.contextTypeMappings == nil ? trustSource.withContextTypeMappings(.default) : trustSource
-        let fallbackTrustManager: EtsiTrustManager?
+		let issuerSource = trustSource.contextTypeMappings == nil ? trustSource.withContextTypeMappings(.default) : trustSource
+		let fallbackTrustManager: EtsiTrustManager?
 		if let fts = fallbackTrustSource {
 			let fallbackTrustSource1 = fts.contextTypeMappings == nil ? fts.withContextTypeMappings(.default) : fts
 			fallbackTrustManager = EtsiTrustManager(source: fallbackTrustSource1)
 		} else { fallbackTrustManager = nil }
-        issuerTrustManager = EtsiTrustManager(source: issuerSource, fallback: fallbackTrustManager)
-        accessTrustManager = EtsiTrustManager(source: trustSource.withContextTypeMappings(nil))
-    }
+		issuerTrustManager = EtsiTrustManager(source: issuerSource, fallback: fallbackTrustManager)
+		accessTrustManager = EtsiTrustManager(source: trustSource.withContextTypeMappings(nil))
+	}
 
-    /// The trust policy effective for the given doc type, falling back to `defaultPolicy`.
-    public func policy(for docType: String) -> TrustPolicy {
-        docTypePolicies[docType] ?? defaultPolicy
-    }
+	/// The trust policy effective for the given doc type, falling back to `defaultPolicy`.
+	public func policy(for docType: String) -> TrustPolicy {
+		docTypePolicies[docType] ?? defaultPolicy
+	}
 
-    /// The OpenID4VCI issuer-metadata signature policy derived from this configuration.
-    ///
-    /// When `requireSignedMetadata` is set the issuer metadata must be signed and its signing
-    /// certificate chain is validated against the issuer trust anchors; otherwise signing is ignored.
-    public var issuerMetadataPolicy: IssuerMetadataPolicy {
-        guard requireSignedMetadata else { return .ignoreSigned }
-        let chainTrust = IssuerMetadataChainTrust(trustManager: accessTrustManager)
-        return .requireSigned(issuerTrust: .byCertificateChain(certificateChainTrust: chainTrust))
-    }
+	/// The OpenID4VCI issuer-metadata signature policy derived from this configuration.
+	///
+	/// When `requireSignedMetadata` is set the issuer metadata must be signed and its signing
+	/// certificate chain is validated against the issuer trust anchors; otherwise signing is ignored.
+	public var issuerMetadataPolicy: IssuerMetadataPolicy {
+		guard requireSignedMetadata else { return .ignoreSigned }
+		let chainTrust = IssuerMetadataChainTrust(trustManager: accessTrustManager)
+		return .requireSigned(issuerTrust: .byCertificateChain(certificateChainTrust: chainTrust))
+	}
 }
 

--- a/Sources/EudiWalletKit/Services/DocumentStatusService.swift
+++ b/Sources/EudiWalletKit/Services/DocumentStatusService.swift
@@ -21,12 +21,14 @@ import EudiEtsi1196x2
 import StatiumSwift
 import JSONWebSignature
 import SwiftCBOR
+import Logging
 
 public actor DocumentStatusService {
 	let statusIdentifier: StatusIdentifier
 	/// Trust configuration used to validate the reader/relying-party access certificate chain.
 	public let trustConfig: TrustConfiguration
 	let date: Date?
+	private static let logger = Logger(label: "DocumentStatusService")
 
 	public init(statusIdentifier: StatusIdentifier, date: Date = .now, trustConfig: TrustConfiguration) {
 		self.statusIdentifier = statusIdentifier
@@ -49,6 +51,8 @@ public actor DocumentStatusService {
 
 struct VerifyStatusListTokenSignatureWithTrustManager: VerifyStatusListTokenSignature {
 	public let trustConfig: TrustConfiguration
+	private static let logger = Logger(label: "VerifyStatusListTokenSignatureWithTrustManager")
+
 	func verify(statusListToken: Data, format: StatusListTokenFormat, at: Date) async throws {
 		let certsData: [Data]
 		switch format {
@@ -65,7 +69,16 @@ struct VerifyStatusListTokenSignatureWithTrustManager: VerifyStatusListTokenSign
 		}
 		guard certsData.count > 0 else { throw JWS.JWSError.somethingWentWrong }
 		let (isValid, reason) = await trustConfig.accessTrustManager.validateCertTrustPath(chain: certsData)
-		guard isValid else { throw WalletError(description: "\(format) status token trust error: \(reason ?? "")", code: .trustError) }
+		guard isValid else {
+			let message = "\(format) status token trust error: \(reason ?? "")"
+			switch trustConfig.statusTrustPolicy {
+			case .warning:
+				Self.logger.warning("\(message)")
+				return
+			case .enforce:
+				throw WalletError(description: message, code: .trustError)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
- VCI configurations fall back to trustConfig.issuerMetadataPolicy when no per-issuer policy is set
- TrustConfiguration.swift: Added statusTrustPolicy: TrustPolicy property (defaults to .enforce).