### PR TITLE
Update BLE transport factory support and dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2417ec54dec94fd33b75bc46ac14218b408afa1720a9b9ba4e1bbb4b9d51c9e5",
+  "originHash" : "3ff963924773c58b584858b9b90ef7ba9cc233dcd6e3ddee3987d01ea8ceeb5f",
   "pins" : [
     {
       "identity" : "cryptoswift",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git",
       "state" : {
-        "revision" : "2c7fbe4ae08dcc8de06312b2fc9cf9bf461e60fe",
-        "version" : "0.23.2"
+        "revision" : "aa10d0364de3874bd24104539cf95d10dc1f552e",
+        "version" : "0.23.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
 			targets: ["EudiWalletKit"])
 	],
 	dependencies: [
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git", exact: "0.23.2"),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git", exact: "0.23.3"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git", exact: "0.23.0"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift.git", exact: "0.14.6"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git", exact: "0.50.0"),

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ let trustConfig = TrustConfiguration(
     defaultPolicy: .enforce,             // .enforce (reject on failure) or .warning (log only)
     docTypePolicies: [:],                // optional per-doc-type overrides of defaultPolicy
     requireSignedMetadata: true,         // require signed OpenID4VCI issuer metadata
+    statusTrustPolicy: .warning,         // trust policy for status token signature validation
     clockSkew: 60                        // allowed clock skew (seconds) for status token verification
 )
 ```
@@ -170,6 +171,8 @@ let trustConfig = TrustConfiguration(
 The `fallbackTrustSource` is optional (pass `nil` to disable it). When the primary trust source cannot evaluate a chain — for example, it has no verification context configured for the requested doc type — validation is delegated to the fallback source.
 
 Use `defaultPolicy` to control the behaviour on a trust failure: `.enforce` rejects the certificate chain, while `.warning` logs the failure but allows the operation to continue. Provide `docTypePolicies` to override the policy for specific doc types.
+
+The `statusTrustPolicy` parameter controls how the wallet handles trust failures when validating status list token signatures (used for document revocation/suspension checks). It defaults to `.enforce`, which rejects tokens whose signing certificate chain cannot be validated. Set it to `.warning` to log the trust failure but still allow the status check to succeed — useful during development or when status token issuers use certificates outside the configured trust anchors.
 
 ### OpenID4VCI Configuration
 

--- a/Sources/EudiWalletKit/EudiWallet.swift
+++ b/Sources/EudiWalletKit/EudiWallet.swift
@@ -57,6 +57,8 @@ public final class EudiWallet: ObservableObject, @unchecked Sendable {
 	public private(set) var modelFactory: (any DocClaimsDecodableFactory)?
 	/// Ble transfer mode
 	public var bleTransferMode: BleTransferMode = .server
+	/// Factory for creating BLE transport instances. When nil, default GATT transports are used.
+	public var bleTransportFactory: (any BleTransportFactory)?
 	/// Repository for zk system parameters, used in mdoc presentation when zk proofs are required.
 	public var zkSystemRepository: ZkSystemRepository?
 
@@ -104,6 +106,7 @@ public final class EudiWallet: ObservableObject, @unchecked Sendable {
 		self.modelFactory = modelFactory
 		self.zkSystemRepository = zkSystemRepository
 		self.bleTransferMode = eudiWalletConfig.bleTransferMode
+		self.bleTransportFactory = eudiWalletConfig.bleTransportFactory
 		storage = StorageManager(storageService: storageServiceObj, modelFactory: modelFactory)
 		if let secureAreas, !secureAreas.isEmpty {
 			for asa in secureAreas { SecureAreaRegistry.shared.register(secureArea: asa) }
@@ -628,7 +631,7 @@ public final class EudiWallet: ObservableObject, @unchecked Sendable {
 			let storageService = storage.storageService
 			switch flow {
 			case .ble:
-				let bleSvc = try await BlePresentationService(parameters: parameters)
+				let bleSvc = try await BlePresentationService(parameters: parameters, transportFactory: bleTransportFactory)
 				return PresentationSession(presentationService: bleSvc, storageManager: storage, storageService: storageService, docIdToPresentInfo: docIdToPresentInfo, documentKeyIndexes: parameters.documentKeyIndexes, userAuthenticationRequired: eudiWalletConfig.userAuthenticationRequired, transactionLogger: mergedTransactionLogger)
 			case .openid4vp(let qrCode):
 				let docTypeDisplayNames: [String: String] = Dictionary(documents.compactMap { doc in

--- a/Sources/EudiWalletKit/EudiWalletKit.docc/GetStarted.md
+++ b/Sources/EudiWalletKit/EudiWalletKit.docc/GetStarted.md
@@ -22,12 +22,12 @@ dependencies: [
 The ``EudiWallet`` class provides a unified API for the two user attestation presentation flows. It is initialized with a document storage manager instance. For SwiftUI apps, the wallet instance can be added as an ``environmentObject`` to be accessible from all views. A KeyChain implementation of document storage is available.
 
 ```swift
-	let certificates = ["pidissuerca02_cz", "pidissuerca02_ee", "pidissuerca02_eu", "pidissuerca02_lu", "pidissuerca02_nl", "pidissuerca02_pt", "pidissuerca02_ut"]
-    wallet = try! EudiWallet(serviceName: "my_wallet_app", trustedReaderCertificates: certificates.map { Data(name: $0, ext: "der")! }, logFileName: "temp.txt")
-    wallet.userAuthenticationRequired = true
-    wallet.openID4VpConfig = OpenId4VpConfiguration(clientIdSchemes: [.x509SanDns, .x509Hash])
-    wallet.transactionLogger = MyFileTransactionLogger(wallet: wallet)
-	wallet.loadAllDocuments()
+let config = EudiWalletConfiguration(serviceName: "my_wallet_app", logFileName: "temp.txt")
+let trustConfig = TrustConfiguration(trustSource: .etsi(.eudiRef), fallbackTrustSource: nil)
+let wallet = try! EudiWallet(eudiWalletConfig: config, trustConfig: trustConfig)
+wallet.openID4VpConfig = OpenId4VpConfiguration(clientIdSchemes: [.x509SanDns, .x509Hash])
+wallet.transactionLogger = MyFileTransactionLogger(wallet: wallet)
+wallet.loadAllDocuments()
 ```
 
 ### BLE Transfer Mode
@@ -42,11 +42,28 @@ You can set it during initialization via ``EudiWalletConfiguration/bleTransferMo
 ```swift
 let config = EudiWalletConfiguration(
     serviceName: "my_wallet_app",
-    trustedReaderCertificates: [Data(name: "eudi_pid_issuer_ut", ext: "der")!],
     bleTransferMode: .server  // default; use .client or .both as needed
 )
-let wallet = try! EudiWallet(eudiWalletConfig: config)
+let trustConfig = TrustConfiguration(trustSource: .etsi(.eudiRef), fallbackTrustSource: nil)
+let wallet = try! EudiWallet(eudiWalletConfig: config, trustConfig: trustConfig)
 wallet.bleTransferMode = .client
+```
+
+### BLE Transport Factory
+
+The ``EudiWallet/bleTransportFactory`` property lets you plug in a custom BLE transport implementation for proximity presentation. This enables alternative BLE communication channels (e.g., L2CAP or a custom BLE client mdoc transport) without modifying the library.
+
+A transport factory conforms to the `BleTransportFactory` protocol and provides `createServer()` and `createClient()` methods that each return an `MdocBleTransport` instance. When `nil` (the default), `DefaultBleTransportFactory` is used, which creates the standard GATT server/central transports.
+
+```swift
+// Provide a custom factory at initialization
+let config = EudiWalletConfiguration(
+    serviceName: "my_wallet_app",
+    bleTransferMode: .server,
+    bleTransportFactory: MyCustomTransportFactory()
+)
+let trustConfig = TrustConfiguration(trustSource: .etsi(.eudiRef), fallbackTrustSource: nil)
+let wallet = try! EudiWallet(eudiWalletConfig: config, trustConfig: trustConfig)
 ```
 
 ### OpenID4VCI Configuration

--- a/Sources/EudiWalletKit/EudiWalletKit.docc/IssueDocuments.md
+++ b/Sources/EudiWalletKit/EudiWalletKit.docc/IssueDocuments.md
@@ -141,8 +141,10 @@ let config = OpenId4VciConfiguration(
   issuerMetadataPolicy: issuerMetadataPolicy
 )
 
+let trustConfig = TrustConfiguration(trustSource: .etsi(.eudiRef), fallbackTrustSource: nil)
 let wallet = try EudiWallet(
-  eudiWalletConfig: EudiWalletConfiguration(trustedReaderCertificates: []),
+  eudiWalletConfig: EudiWalletConfiguration(),
+  trustConfig: trustConfig,
   openID4VciConfigurations: ["trusted_issuer": config]
 )
 

--- a/Sources/EudiWalletKit/EudiWalletKit.docc/PresentationService.md
+++ b/Sources/EudiWalletKit/EudiWalletKit.docc/PresentationService.md
@@ -21,11 +21,48 @@ Set it through ``EudiWalletConfiguration/bleTransferMode`` during initialization
 
 ```swift
 let config = EudiWalletConfiguration(
-    trustedReaderCertificates: [Data(name: "eudi_pid_issuer_ut", ext: "der")!],
     bleTransferMode: .server  // default
 )
-let wallet = try! EudiWallet(eudiWalletConfig: config)
+let trustConfig = TrustConfiguration(trustSource: .etsi(.eudiRef), fallbackTrustSource: nil)
+let wallet = try! EudiWallet(eudiWalletConfig: config, trustConfig: trustConfig)
 wallet.bleTransferMode = .both
+```
+
+## BLE Transport Factory
+
+The ``EudiWallet/bleTransportFactory`` property allows you to inject a custom BLE transport implementation for proximity presentation. This is useful when you need to use alternative BLE communication channels such as L2CAP or a custom BLE client mdoc transport.
+
+The factory conforms to the `BleTransportFactory` protocol, which requires two methods:
+- `createServer()` – returns a transport instance acting as a GATT peripheral (server).
+- `createClient()` – returns a transport instance acting as a GATT central (client).
+
+When no factory is provided (the default), `DefaultBleTransportFactory` is used, which creates standard GATT server and central transports from the `MdocDataTransfer18013` library.
+
+You can set the factory during initialization via ``EudiWalletConfiguration/bleTransportFactory`` or assign it directly on the wallet instance before starting a BLE presentation:
+
+```swift
+// Custom factory example
+struct L2CAPTransportFactory: BleTransportFactory {
+    func createServer() -> any MdocBleTransport {
+        // return your custom L2CAP server transport
+    }
+    func createClient() -> any MdocBleTransport {
+        // return your custom L2CAP client transport
+    }
+}
+
+// Set via configuration
+let config = EudiWalletConfiguration(
+    bleTransferMode: .server,
+    bleTransportFactory: L2CAPTransportFactory()
+)
+let trustConfig = TrustConfiguration(trustSource: .etsi(.eudiRef),fallbackTrustSource: nil)
+let wallet = try! EudiWallet(eudiWalletConfig: config, trustConfig: trustConfig)
+```
+
+```swift
+// Or set directly on the wallet instance
+wallet.bleTransportFactory = L2CAPTransportFactory()
 ```
 
 ```swift

--- a/Sources/EudiWalletKit/EudiWalletKit.docc/SecureAreas.md
+++ b/Sources/EudiWalletKit/EudiWalletKit.docc/SecureAreas.md
@@ -13,9 +13,9 @@ Assuming that the application developer has implemented the SecureArea protocol 
 ```swift
 let keyChainStorage = KeyChainSecureKeyStorage(serviceName: self.serviceName, accessGroup: nil)
 let mySecureArea = MySecureArea(storage: keyChainStorage)
-let wallet = try! EudiWallet(serviceName: "wallet_dev_ui",
-		trustedReaderCertificates: [Data(name: "eudi_pid_issuer_ut", ext: "der")!],
-		secureAreas: [mySecureArea])
+let config = EudiWalletConfiguration(serviceName: "wallet_dev_ui")
+let trustConfig = TrustConfiguration(trustSource: .etsi(.eudiRef), fallbackTrustSource: nil)
+let wallet = try! EudiWallet(eudiWalletConfig: config, trustConfig: trustConfig, secureAreas: [mySecureArea])
 ```
 
 ### Secure key creation on issuing

--- a/Sources/EudiWalletKit/Models/EudiWalletConfiguration.swift
+++ b/Sources/EudiWalletKit/Models/EudiWalletConfiguration.swift
@@ -38,6 +38,9 @@ public struct EudiWalletConfiguration: Sendable {
 	/// - `.client`: The holder device acts as a GATT central (client), scanning and connecting to the reader's peripheral.
 	/// - `.both`: The holder device supports both peripheral server and central client modes simultaneously.
 	public let bleTransferMode: BleTransferMode
+	/// Optional factory for creating custom BLE transport instances (e.g., L2CAP, BLE client mdoc).
+	/// When `nil`, the default GATT server/central transports are used.
+	public let bleTransportFactory: (any BleTransportFactory)?
 	/// Default service name for the keychain, used if no service name is provided in the initializer
 	static let defaultServiceName: String = "eudiw"
 
@@ -48,7 +51,8 @@ public struct EudiWalletConfiguration: Sendable {
 		deviceAuthMethod: DeviceAuthMethod = .deviceSignature,
 		uiCulture: String? = nil,
 		logFileName: String? = nil,
-		bleTransferMode: BleTransferMode = .server
+		bleTransferMode: BleTransferMode = .server,
+		bleTransportFactory: (any BleTransportFactory)? = nil
 	) {
 		self.serviceName = serviceName ?? Self.defaultServiceName
 		self.accessGroup = accessGroup
@@ -57,5 +61,6 @@ public struct EudiWalletConfiguration: Sendable {
 		self.uiCulture = uiCulture
 		self.logFileName = logFileName
 		self.bleTransferMode = bleTransferMode
+		self.bleTransportFactory = bleTransportFactory
 	}
 }

--- a/Sources/EudiWalletKit/Services/BlePresentationService.swift
+++ b/Sources/EudiWalletKit/Services/BlePresentationService.swift
@@ -26,7 +26,7 @@ import struct WalletStorage.Document
 
 public final class BlePresentationService: @unchecked Sendable, PresentationService {
 	var bleTranport: any MdocBleTransport
-	var bleServer: MdocGattServer?
+	var bleServer: (any MdocBleTransport)?
 	let bleTransferMode: BleTransferMode
 	public var status: TransferStatus = .initialized
 	var isPeripheralManagerPoweredOn = false
@@ -56,7 +56,7 @@ public final class BlePresentationService: @unchecked Sendable, PresentationServ
 	public var deviceResponseBytes: Data?
 	public var responseMetadata: [Data?]!
 
-	public init(parameters: InitializeTransferData) async throws {
+	public init(parameters: InitializeTransferData, transportFactory: (any BleTransportFactory)? = nil) async throws {
 		let objs = try await parameters.toInitializeTransferInfo()
 		self.docs = try objs.documentObjects.mapValues { try IssuerSigned(data: $0.bytes) }
 		docMetadata = parameters.docMetadata
@@ -65,8 +65,9 @@ public final class BlePresentationService: @unchecked Sendable, PresentationServ
 		self.dauthMethod = objs.deviceAuthMethod
 		self.zkSystemRepository = objs.zkSystemRepository
 		bleTransferMode = parameters.bleTransferMode
-		bleTranport = bleTransferMode == .server ? MdocGattServer() : MdocGattCentral()
-		if bleTransferMode == .both { bleServer = MdocGattServer() }
+		let factory = transportFactory ?? DefaultBleTransportFactory()
+		bleTranport = bleTransferMode == .server ? factory.createServer() : factory.createClient()
+		if bleTransferMode == .both { bleServer = factory.createServer() }
 		transactionLog = TransactionLogUtils.initializeTransactionLog(type: .presentation, dataFormat: .cbor)
 		bleTranport.delegate = self
 		bleServer?.delegate = self
@@ -273,11 +274,8 @@ public final class BlePresentationService: @unchecked Sendable, PresentationServ
 		await handleSelected?(userAccepted, itemsToSend, deviceNameSpacesToSend)
 		handleSelected = nil
 		// documentIds is populated by userSelected after a successful response build.
-		// docType and displayName are not available on this service; they are populated by the
-		// PresentationSession caller which has access to docIdToPresentInfo.
-let firstDocId = documentIds.first
-let firstDocType = firstDocId.flatMap { docs[$0]?.issuerAuth.mso.docType }
-TransactionLogUtils.setCborTransactionLogResponseInfo(self, documentId: firstDocId, docType: firstDocType, displayName: nil, transactionLog: &transactionLog)
+		// docType and displayName are not available on this service; they are populated by the PresentationSession caller which has access to docIdToPresentInfo.
+		let firstDocId = documentIds.first		let firstDocType = firstDocId.flatMap { docs[$0]?.issuerAuth.mso.docType }		TransactionLogUtils.setCborTransactionLogResponseInfo(self, documentId: firstDocId, docType: firstDocType, displayName: nil, transactionLog: &transactionLog)		
 	}
 	
 	public func waitForDisconnect() async throws {

--- a/Sources/EudiWalletKit/Services/OpenId4VpService.swift
+++ b/Sources/EudiWalletKit/Services/OpenId4VpService.swift
@@ -339,8 +339,7 @@ public final class OpenId4VpService: @unchecked Sendable, PresentationService {
 				}
 			}
 			let responsePayload = VpResponsePayload(verifiable_presentations: vpTokenValues, data_formats: data_formats, transaction_data: transactionData)
-			// Resolve document identity from the first presented document.
-			// docType comes from transferInfo.idsToDocTypes; displayName is not held on this service.
+			// Resolve document identity from the first presented document. docType comes from transferInfo.idsToDocTypes; displayName is not held on this service.
 			let firstDocId = vpTokens.compactMap { $0.1 }.first
 			let firstDocType = firstDocId.flatMap { transferInfo.idsToDocTypes[$0] }
 			TransactionLogUtils.setTransactionLogResponseInfo(deviceResponseBytes: try? JSONEncoder().encode(responsePayload), dataFormat: .json, sessionTranscript: Data(sessionTranscript.taggedEncoded.encode(options: CBOROptions())), responseMetadata: responseMetadata, documentId: firstDocId, docType: firstDocType, displayName: nil, transactionLog: &transactionLog)

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ Trust validation now uses ETSI Trusted Lists via `EtsiTrustManager` instead of m
 - **Issuer certificate validation** during OpenID4VCI issuance uses the configured issuer trust manager (with optional fallback trust source).
 - **Reader/relying-party certificate validation** during OpenID4VP and BLE presentations uses the access trust manager (WRPAC verification context).
 - **Status token signature validation** now verifies the x5c certificate chain against the trust configuration instead of ignoring signatures.
+- **`statusTrustPolicy`** allows controlling trust failure behaviour specifically for status list tokens (`.enforce` or `.warning`). Defaults to `.enforce`.
 - **Signed issuer metadata** is validated against the trust anchors when `requireSignedMetadata` is enabled (default).
 - Per doc-type trust policy overrides are supported via `TrustConfiguration.docTypePolicies`.
 


### PR DESCRIPTION
Enhance EudiWallet with BLE transport factory support and update the eudi-lib-ios-iso18013-data-transfer dependency to version 0.23.3. Additionally, update documentation to reflect these changes.