### PR TITLE
Update eudi-lib-ios-iso18013-data-transfer to version 0.23.5

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2afacdab2f53a8e95e0234b9a90994d29e395847cd3b88aa8b2eb23836f175e5",
+  "originHash" : "e98e30813eab4b911768754de00809f255a10a5c96b53483616a68734b34aca4",
   "pins" : [
     {
       "identity" : "cryptoswift",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git",
       "state" : {
-        "revision" : "4d7b7286c504ce949b9cbb5e3b16cec3679c1559",
-        "version" : "0.23.4"
+        "revision" : "f20e82fc0a6522ce2bae4f73abef99c51963a344",
+        "version" : "0.23.5"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-security",
       "state" : {
-        "revision" : "2664f2b13d375d25c5be9f13b89724d45842a4fe",
-        "version" : "0.23.4"
+        "revision" : "a4c3bb177f5a27e77ad6eb48375f91271a952043",
+        "version" : "0.23.5"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
 			targets: ["EudiWalletKit"])
 	],
 	dependencies: [
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git", exact: "0.23.4"),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git", exact: "0.23.5"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git", exact: "0.23.1"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift.git", exact: "0.14.6"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git", exact: "0.50.0"),


### PR DESCRIPTION
Upgrade the eudi-lib-ios-iso18013-data-transfer dependency to version 0.23.5, ensuring compatibility with the latest features and fixes. This change also updates the corresponding security library to the same version.