### PR TITLE
Fix credential usage count logic and update dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e98e30813eab4b911768754de00809f255a10a5c96b53483616a68734b34aca4",
+  "originHash" : "f286734b2589ff566a91fa378a468230f7ad8ce9de31ce1049cf86e63d3b6bb3",
   "pins" : [
     {
       "identity" : "cryptoswift",
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git",
       "state" : {
-        "revision" : "3abd8e54a0576d4114b78672e03c22d3613b5044",
-        "version" : "0.23.1"
+        "revision" : "5fc8442563b6502a01e8e30bde7b9700fdbf63c5",
+        "version" : "0.23.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
 	],
 	dependencies: [
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git", exact: "0.23.5"),
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git", exact: "0.23.1"),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git", exact: "0.23.2"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift.git", exact: "0.14.6"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git", exact: "0.50.0"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vp-swift.git", exact: "0.35.1"),

--- a/Sources/EudiWalletKit/Services/StorageManager.swift
+++ b/Sources/EudiWalletKit/Services/StorageManager.swift
@@ -233,8 +233,8 @@ public final class StorageManager: ObservableObject, @unchecked Sendable {
 
 	public static func getCredentialsUsageCount(id: String, secureAreaName: String?) async throws -> CredentialsUsageCounts? {
 		let kbi = try await SecureAreaRegistry.shared.get(name: secureAreaName).getKeyBatchInfo(id: id)
-		let remaining: Int? = if kbi.credentialPolicy == .rotateUse { nil } else { kbi.usedCounts.count { $0 == 0 } }
-		return remaining.map { try! CredentialsUsageCounts(total: kbi.usedCounts.count, remaining: $0) }
+		let remaining = if kbi.credentialPolicy == .rotateUse { kbi.usedCounts.count } else { kbi.usedCounts.count { $0 == 0 } }
+		return try! CredentialsUsageCounts(total: kbi.usedCounts.count, remaining: remaining)
 	}
 
 	/// Load documents from storage


### PR DESCRIPTION
Correct the logic in `getCredentialsUsageCount` to accurately calculate remaining usage counts. Update the `eudi-lib-ios-wallet-storage` dependency to version 0.23.2.