### PR TITLE
Fix log entries overwriting each other

### DIFF
--- a/Sources/EudiWalletKit/Services/FileLogging.swift
+++ b/Sources/EudiWalletKit/Services/FileLogging.swift
@@ -27,15 +27,11 @@ struct FileHandlerOutputStream: TextOutputStream, Sendable {
     let encoding: String.Encoding
 
     init(localFile url: URL, encoding: String.Encoding = .utf8) throws {
-        if !FileManager.default.fileExists(atPath: url.path) {
-            guard FileManager.default.createFile(atPath: url.path, contents: nil, attributes: nil) else {
-                throw FileHandlerOutputStream.couldNotCreateFile
-            }
+        let descriptor = open(url.path, O_WRONLY | O_CREAT | O_APPEND, 0o600)
+        guard descriptor >= 0 else {
+            throw FileHandlerOutputStream.couldNotCreateFile
         }
-
-        let fileHandle = try FileHandle(forWritingTo: url)
-        fileHandle.seekToEndOfFile()
-        self.fileHandle = fileHandle
+        self.fileHandle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: true)
         self.encoding = encoding
     }
 


### PR DESCRIPTION
Each logger label opens its own FileHandle to the log file. wallet-kit alone creates several (EudiWalletKit, OpenId4VCI, OpenId4VpService, ...), plus more from its dependencies. Each handle seeks to the end once, then keeps its own position, so they write on top of each other. Lines get cut in half, timestamps jump backwards, and the start of the log disappears as the file grows.

O_APPEND makes every write go to the real end of the file, so the handles can't overwrite each other any more. The file is now created with 0600, since it can hold sensitive data.