### PR TITLE
Make file logging resilient to write failures

### DIFF
--- a/Sources/EudiWalletKit/Services/FileLogging.swift
+++ b/Sources/EudiWalletKit/Services/FileLogging.swift
@@ -37,7 +37,7 @@ struct FileHandlerOutputStream: TextOutputStream, Sendable {
 
     mutating func write(_ string: String) {
         if let data = string.data(using: encoding) {
-            fileHandle.write(data)
+            try? fileHandle.write(contentsOf: data)
         }
     }
 }


### PR DESCRIPTION
FileHandle.write(_:) raises an Objective-C exception when a write fails, for example when the filesystem is out of space. Objective-C exceptions can't be caught from Swift, so that surfaces as a crash in the host app.

write(contentsOf:) throws instead, so a failed write drops the log line and the app keeps running.
