### PR TITLE
Enhance OfferedIssuanceModel with registration policy and validation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,8 +450,12 @@ let defaultOptions = try await wallet.getDefaultCredentialOptions(
 ### Resolving Credential offer
 
 The library provides the `resolveOfferUrlDocTypes(offerUri:authFlowRedirectionURI:)` method that resolves the credential offer URI.
-The method returns the resolved `OfferedIssuanceModel` object that contains the offer's data (offered document types, issuer name and transaction code specification for pre-authorized flow). The offer's data can be displayed to the
-user.
+The method returns the resolved `OfferedIssuanceModel` object that contains the offer's data (offered document types, issuer name and transaction code specification for pre-authorized flow). When registration certificate validation is enabled (`OpenId4VciConfiguration.validateRegistrationCertificate`), the model also includes:
+
+- `wrpVciRegistrationPolicy: WrpRegistrationPolicy?` — the parsed issuer registration policy decoded from the WRPRC.
+- `wrpVciWarnings: [String: [PolicyViolation]]?` — validation warnings keyed by credential configuration identifier; the empty key holds request-wide warnings. `nil` when validation is not enabled.
+
+The offer's data can be displayed to the user, including issuer registration information and any warnings, before proceeding to issuance.
 
 When a pre-registered issuer can be resolved from `offerUri`, the method uses that issuer's `OpenId4VciConfiguration.issuerMetadataPolicy`.
 

--- a/Sources/EudiWalletKit/EudiWalletKit.docc/IssueDocuments.md
+++ b/Sources/EudiWalletKit/EudiWalletKit.docc/IssueDocuments.md
@@ -116,10 +116,14 @@ The wallet currently supports these issuer reuse policies:
 ### Resolving Credential offer
 
 The library provides the `resolveOfferUrlDocTypes(offerUri:authFlowRedirectionURI:)` method that resolves the credential offer URI.
-The method returns the resolved `OfferedIssuanceModel` object that contains the offer's data (offered document types, issuer name and transaction code specification for pre-authorized flow). The offer's data can be displayed to the
-user.
+The method returns the resolved ``OfferedIssuanceModel`` object that contains the offer's data (offered document types, issuer name and transaction code specification for pre-authorized flow). When registration certificate validation is enabled (``OpenId4VciConfiguration/validateRegistrationCertificate``), the model also includes:
 
-When a pre-registered issuer can be resolved from `offerUri`, the method uses that issuer's `OpenId4VciConfiguration.issuerMetadataPolicy`.
+- ``OfferedIssuanceModel/wrpVciRegistrationPolicy`` — the parsed issuer registration policy decoded from the WRPRC.
+- ``OfferedIssuanceModel/wrpVciWarnings`` — validation warnings keyed by credential configuration identifier; the empty key holds request-wide warnings. `nil` when validation is not enabled.
+
+The offer's data can be displayed to the user, including issuer registration information and any warnings, before proceeding to issuance. See <doc:RegistrationCertificate> for details.
+
+When a pre-registered issuer can be resolved from `offerUri`, the method uses that issuer's ``OpenId4VciConfiguration/issuerMetadataPolicy``.
 
 The following example shows how to resolve a credential offer:
 

--- a/Sources/EudiWalletKit/EudiWalletKit.docc/RegistrationCertificate.md
+++ b/Sources/EudiWalletKit/EudiWalletKit.docc/RegistrationCertificate.md
@@ -146,6 +146,25 @@ A valid certificate can still be over-asking. Check **both** ``PresentationSessi
 - `wrpVerifierPolicy != nil` **and** warnings present → valid but over-asking or has other warnings; warn the user.
 - `wrpVerifierPolicy == nil` → no certificate was present, or validation failed (with `.enforce` policy).
 
+## Reading the outcome — offer resolution
+
+When registration certificate validation is enabled for issuance, the ``OfferedIssuanceModel`` returned by ``EudiWallet/resolveOfferUrlDocTypes(offerUri:authFlowRedirectionURI:)`` includes the issuer's WRPRC outcome:
+
+- ``OfferedIssuanceModel/wrpVciRegistrationPolicy`` — the parsed ``WrpRegistrationPolicy`` of the issuer. `nil` when validation is not enabled or the certificate is absent.
+- ``OfferedIssuanceModel/wrpVciWarnings`` — warnings keyed by credential configuration identifier; the empty key holds request-wide warnings. `nil` when validation is not enabled.
+
+This allows the application to display issuer registration information and warn the user about policy violations **before** proceeding to issuance.
+
+```swift
+let offer = try await wallet.resolveOfferUrlDocTypes(offerUri: offerUri, authFlowRedirectionURI: nil)
+if let issuerRegistration = offer.wrpVciRegistrationPolicy {
+    // Show issuer info: issuerRegistration.name, issuerRegistration.country
+}
+if let warnings = offer.wrpVciWarnings?[""], !warnings.isEmpty {
+    // Warn the user about registration policy violations
+}
+```
+
 ## Reading the outcome — issuance
 
 ``EudiWallet/issueDocuments(issuerName:docTypeIdentifiers:credentialOptions:keyOptions:promptMessage:)`` and ``EudiWallet/issueDocumentsByOfferUrl(offerUri:docTypes:txCodeValue:promptMessage:configuration:)`` return an ``IssuerResponse`` that pairs the issued documents with the WRPRC outcome:

--- a/Sources/EudiWalletKit/Models/OfferedIssuanceModel.swift
+++ b/Sources/EudiWalletKit/Models/OfferedIssuanceModel.swift
@@ -24,11 +24,13 @@ import Copyable
 /// This information is returned from ``EudiWallet/resolveOfferUrlDocTypes(uriOffer:)``
 public struct OfferedIssuanceModel: Sendable {
 	/// public initializer
-	public init(issuerName: String, issuerLogoUrl: String? = nil, docModels: [OfferedDocModel], txCodeSpec: TxCode? = nil) {
+	public init(issuerName: String, issuerLogoUrl: String? = nil, docModels: [OfferedDocModel], txCodeSpec: TxCode? = nil, wrpVciRegistrationPolicy: WrpRegistrationPolicy? = nil, wrpVciWarnings: [String: [PolicyViolation]]? = nil) {
 		self.issuerName = issuerName
 		self.issuerLogoUrl = issuerLogoUrl
 		self.docModels = docModels
 		self.txCodeSpec = txCodeSpec
+		self.wrpVciRegistrationPolicy = wrpVciRegistrationPolicy
+		self.wrpVciWarnings = wrpVciWarnings
 	}
 	/// Issuer name
 	public let issuerName: String
@@ -40,6 +42,10 @@ public struct OfferedIssuanceModel: Sendable {
 	public let txCodeSpec: TxCode?
 	/// Helper var for transaction code requirement
 	public var isTxCodeRequired: Bool { txCodeSpec != nil }
+	/// WRP VCI registration policy (if any) decoded from the WRPRC during validation
+	public let wrpVciRegistrationPolicy: WrpRegistrationPolicy?
+	/// Warnings collected during validation, keyed by credential configuration identifier; the empty key holds request-wide warnings.
+	public let wrpVciWarnings: [String: [PolicyViolation]]?
 }
 
 /// Information about an offered document to issue

--- a/Sources/EudiWalletKit/Services/OpenId4VciService.swift
+++ b/Sources/EudiWalletKit/Services/OpenId4VciService.swift
@@ -209,7 +209,19 @@ public actor OpenId4VciService {
 		let credentialInfo = try getCredentialOfferedModels(credentialsSupported: offer.credentialIssuerMetadata.credentialsSupported.filter { offer.credentialConfigurationIdentifiers.contains($0.key) }, batchCredentialIssuance: offer.credentialIssuerMetadata.batchCredentialIssuance)
 		let issuerName = offer.credentialIssuerMetadata.display.map(\.displayMetadata).getName(uiCulture) ?? offer.credentialIssuerIdentifier.url.host ?? offer.credentialIssuerIdentifier.url.absoluteString
 		let issuerLogoUrl = offer.credentialIssuerMetadata.display.map(\.displayMetadata).getLogo(uiCulture)?.uri?.absoluteString
-		return OfferedIssuanceModel(issuerName: issuerName, issuerLogoUrl: issuerLogoUrl, docModels: credentialInfo.map(\.offered), txCodeSpec:  code?.txCode)
+		// authorize registration certificate policy if enabled in the wallet configuration
+		let warnings: [String: [PolicyViolation]]?
+		let registrationPolicy: WrpRegistrationPolicy?
+		if let enforcement = makeRegistrationCertificatePolicy() {
+			let authorizer = IssuanceAuthorizer(policy: enforcement.policy)
+			_ = try? await authorizer.authorize(credentialOffer: offer)
+			warnings = await enforcement.validator.wrpVciWarnings
+			registrationPolicy = await enforcement.validator.wrpVciRegistrationPolicy
+		} else {
+			warnings = nil
+			registrationPolicy = nil
+		}
+		return OfferedIssuanceModel(issuerName: issuerName, issuerLogoUrl: issuerLogoUrl, docModels: credentialInfo.map(\.offered), txCodeSpec: code?.txCode, wrpVciRegistrationPolicy: registrationPolicy, wrpVciWarnings: warnings)
 	}
 
 	func resolveCredentialOptions(batchCredentialIssuance: BatchCredentialIssuance?, credentialReusePolicy: CredentialReusePolicy? = nil, userCredentialOptions: CredentialOptions? = nil) throws -> CredentialOptions {

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+## v0.37.7
+
+- `OfferedIssuanceModel`: Add `wrpVciRegistrationPolicy: WrpRegistrationPolicy?` and `wrpVciWarnings: [String: [PolicyViolation]]?` properties to surface the issuer's registration certificate policy and validation warnings at offer-resolution time (before issuance).
+
 ## v0.37.6
 
 - Refactor document status handling to use `StatusList` instead of `StatusIdentifier` across services and models.

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,18 @@
-## v0.37.7
+## v0.39.2
 
 - `OfferedIssuanceModel`: Add `wrpVciRegistrationPolicy: WrpRegistrationPolicy?` and `wrpVciWarnings: [String: [PolicyViolation]]?` properties to surface the issuer's registration certificate policy and validation warnings at offer-resolution time (before issuance).
+
+## v0.39.1
+
+- Fix log entries overwriting each other.
+
+## v0.39.0
+
+- Add WRP registration certificate validation for OpenID4VCI.
+
+## v0.38.0
+
+- Implement OpenID4VP wallet relying party registration handling.
 
 ## v0.37.6
 


### PR DESCRIPTION
Include `wrpVciRegistrationPolicy` and `wrpVciWarnings` in `OfferedIssuanceModel` to provide issuer registration information and validation warnings during offer resolution. Update documentation to reflect these enhancements.