### PR TITLE
Add entitlement missing reason to failure enums

### DIFF
--- a/Sources/EudiWalletKit/Models/PresentationPolicyViolation.swift
+++ b/Sources/EudiWalletKit/Models/PresentationPolicyViolation.swift
@@ -51,6 +51,8 @@ public enum PresentationFailureReason: Sendable, Hashable {
 	case wrprcNotRepeated
 	/// Different WRPRC values found across ItemsRequest.requestInfo entries.
 	case wrprcMismatch
+	/// The WRPRC entitlements do not include the expected operation.
+	case entitlementMissing(expected: String)
 	/// An unclassified failure.
 	case other
 

--- a/Sources/EudiWalletKit/Models/RegistrationPolicyViolation.swift
+++ b/Sources/EudiWalletKit/Models/RegistrationPolicyViolation.swift
@@ -46,6 +46,8 @@ public enum RegistrationFailureReason: Sendable, Hashable {
 	case accessCertificateUnavailable
 	/// A credential configuration is not covered by the issuer's `provides_attestations` claim.
 	case credentialNotCovered(credentialId: String)
+	/// The required entitlement is missing from the WRPRC.
+	case entitlementMissing(expected: String)
 	/// An unclassified failure.
 	case other
 }

--- a/Sources/EudiWalletKit/Services/Openid4VpUtils.swift
+++ b/Sources/EudiWalletKit/Services/Openid4VpUtils.swift
@@ -70,7 +70,7 @@ class OpenId4VpUtils {
 		var zkSpecsRequested: [DocType: [ZkSystemSpec]]?
 		for credQuery in dcql.credentials {
 			let formatRequested: DocDataFormat = credQuery.dataFormat
-			guard let docType = credQuery.docType else { continue }
+			guard let docType = credQuery.docTypeOrVct else { continue }
 			if !idsToDocTypes.values.contains(docType) {logger?.warning("Document type \(docType) not in supported document types \(idsToDocTypes.values)")}
 			inputDescriptorMap[docType] = credQuery.id.value; formatsRequested[docType] = formatRequested
 			if let zkSpecs = credQuery.zkSpecs {
@@ -281,7 +281,7 @@ extension ClaimPathElement {
 }
 
 extension CredentialQuery {
-	public var docType: String? {
+	public var docTypeOrVct: String? {
 		let mdocTypeValue = meta.dictionaryObject?["doctype_value"]
 		let vctValues = meta.dictionaryObject?["vct_values"]
 		let metaDocType = mdocTypeValue ?? vctValues ?? meta.dictionaryObject?.first?.value
@@ -367,7 +367,7 @@ extension OpenId4VpUtils {
 		var credentialQueryResults: OrderedDictionary<QueryId, [CredentialSelection]> = [:]
 		// Step 1: Process individual credential queries
 		for credQuery in dcql.credentials {
-			guard let docType = credQuery.docType else { throw WalletError(description: "Credential query \(credQuery.id.value) does not have a doc type", code: .invalidQueryResolution) }
+			guard let docType = credQuery.docTypeOrVct else { throw WalletError(description: "Credential query \(credQuery.id.value) does not have a doc type", code: .invalidQueryResolution) }
 			let format = credQuery.dataFormat
 			let isMultiple = credQuery.multiple == true
 			// Find matching credentials
@@ -493,7 +493,7 @@ extension OpenId4VpUtils {
 		}
 		if resultDict.isEmpty {
 			let notFoundCred = dcql.credentials.first { c in credentialQueryResults[c.id]?.isEmpty != false }
-			if let notFoundCred {logger.warning("No credential found matching docType: \(notFoundCred.docType ?? "") with format: \(notFoundCred.format)")}
+			if let notFoundCred {logger.warning("No credential found matching docType/vct: \(notFoundCred.docTypeOrVct ?? "") with format: \(notFoundCred.format)")}
 			throw lastError ?? WalletError(description: "DCQL query could not be satisfied", code: .dcqlQueryNotSatisfied)
 		}
 		return resultDict

--- a/Sources/EudiWalletKit/Services/WrpVciRegistrationValidator.swift
+++ b/Sources/EudiWalletKit/Services/WrpVciRegistrationValidator.swift
@@ -65,6 +65,7 @@ public actor WrpVciRegistrationValidator {
 			var vciNotCoveredWarnings = [String: [RegistrationPolicyViolation]]()
 			Self.validateOfferedConfigurations(offeredConfigurations, policy: policy, wrpVciWarnings: &vciNotCoveredWarnings)
 			wrpVciWarnings.merge(vciNotCoveredWarnings, uniquingKeysWith: { (_, new) in new })
+			Self.validateEntitlements(offeredConfigurations, policy: policy, wrpVciWarnings: &wrpVciWarnings)
 			let policyViolationWarnings = wrpVciWarnings.mapValues { $0.map { PolicyViolation($0.message) } }
 			// Under .enforce, hard failures block issuance.
 			if trustConfig.wrprcVciTrustPolicy == .enforce {
@@ -98,17 +99,39 @@ public actor WrpVciRegistrationValidator {
 	/// registered to provide (`provides_attestations` claim of the WRPRC).
 	/// Warnings for uncovered configurations are appended to `wrpVciWarnings`, keyed by credential configuration identifier.
 	static func validateOfferedConfigurations(_ offeredConfigurations: [CredentialConfigurationIdentifier: CredentialSupported], policy: WrpRegistrationPolicy, wrpVciWarnings: inout [String: [RegistrationPolicyViolation]]) {
-		guard let providedAttestations = policy.providesAttestations else { return }
+		let providedAttestations = policy.providesAttestations ?? []
 		for (identifier, supported) in offeredConfigurations {
 			let isCovered: Bool = switch supported {
 			case .msoMdoc(let msoMdoc): providedAttestations.contains { $0.meta.doctypeValue == msoMdoc.docType }
 			case .sdJwtVc(let sdJwtVc): providedAttestations.contains { attestation in
 				if let vct = sdJwtVc.vct { attestation.meta.vctValues?.contains(vct) ?? false } else { false } }
-			default: true
+			default: false
 			}
 			if !isCovered {
 				wrpVciWarnings[identifier.value, default: []].append(RegistrationPolicyViolation(reason: .credentialNotCovered(credentialId: identifier.value), message: "Credential configuration \(identifier.value) is not covered by the issuer registration certificate"))
 			}
+		}
+	}
+
+	static let pidEntitlement = "https://uri.etsi.org/19475/Entitlement/PID_Provider"
+	static let pubEaaEntitlement = "https://uri.etsi.org/19475/Entitlement/PUB_EAA_Provider"
+	private static let pidMdocDocType = "eu.europa.ec.eudi.pid.1"
+	private static let pidSdJwtVct = "urn:eudi:pid:1"
+
+	/// Validate that the WRPRC entitlements contain the expected entitlement for the offered configurations.
+	/// PID configurations require `PID_Provider`; other configurations require `PUB_EAA_Provider`.
+	static func validateEntitlements(_ offeredConfigurations: [CredentialConfigurationIdentifier: CredentialSupported], policy: WrpRegistrationPolicy, wrpVciWarnings: inout [String: [RegistrationPolicyViolation]]) {
+		let entitlements = policy.entitlements ?? []
+		let offeredIncludesPID = offeredConfigurations.values.contains { supported in
+			switch supported {
+			case .msoMdoc(let msoMdoc): return msoMdoc.docType == pidMdocDocType
+			case .sdJwtVc(let sdJwtVc): return sdJwtVc.vct == pidSdJwtVct
+			default: return false
+			}
+		}
+		let expectedEntitlement = offeredIncludesPID ? pidEntitlement : pubEaaEntitlement
+		if !entitlements.contains(expectedEntitlement) {
+			wrpVciWarnings["", default: []].append(RegistrationPolicyViolation(reason: .entitlementMissing(expected: expectedEntitlement), message: "WRPRC is missing required entitlement: \(expectedEntitlement)"))
 		}
 	}
 }

--- a/Sources/EudiWalletKit/Services/WrpVpRegistrationValidator.swift
+++ b/Sources/EudiWalletKit/Services/WrpVpRegistrationValidator.swift
@@ -36,6 +36,7 @@ public actor WrpVpRegistrationValidator {
 	static let logger = Logger(label: "WrpRegistrationValidator")
 	/// Label of the `ItemsRequest.requestInfo` member carrying the WRPRC in ISO/IEC 18013-5 requests (ETSI TS 119 472-2)
 	static let REG_CERT_REQUEST_INFO_KEY = "euWrprc"
+	static let serviceProviderEntitlement = "https://uri.etsi.org/19475/Entitlement/Service_Provider"
 	/// The registration policy decoded from the WRPRC by the last `validateCertificate` call, if any.
 	public var wrpVpRegistrationPolicy: WrpRegistrationPolicy?
 	/// Typed violations collected during validation, keyed by credential query identifier; the empty key holds request-wide violations.
@@ -48,8 +49,15 @@ public actor WrpVpRegistrationValidator {
 	}
 	
 	public func set(dcqlQueryable: DefaultDcqlQueryable?) { self.dcqlQueryable = dcqlQueryable }
-	
+
+	/// Resets state from the previous request so it does not leak into the next one.
+	public func resetValidations() {
+		wrpVpRegistrationPolicy = nil
+		wrpVpWarnings = [:]
+	}
+
 	public func validateCertificate(wrpac: Certificate, wrprc: String, dcql: DCQL) async -> Authorization {
+		resetValidations()
 		guard let wrprcData = wrprc.data(using: .ascii) else {
 			wrpVpWarnings["", default: []].append(PresentationPolicyViolation(reason: .invalidCertificate, message: "WRPRC cannot be decoded"))
 			let policyViolationWarnings = wrpVpWarnings.mapValues { $0.map { PolicyViolation($0.message) } }
@@ -71,6 +79,7 @@ public actor WrpVpRegistrationValidator {
 	///   - dcql: A DCQL query equivalent to the requested items, used to validate the request scope against the registration policy
 	/// - Returns: The authorization result, or `nil` when the request carries no registration certificate
 	public func validateDeviceRequestCertificate(wrpac: Certificate?, deviceRequest: DeviceRequest, dcql: DCQL) async -> Authorization? {
+		resetValidations()
 		var wrprcValues = [Data]()
 		for docR in deviceRequest.docRequests {
 			guard let extValue = docR.itemsRequest.requestInfo?.extensions?[Self.REG_CERT_REQUEST_INFO_KEY],
@@ -101,6 +110,7 @@ public actor WrpVpRegistrationValidator {
 			   let enforceable = wrpVpWarnings[""]?.first(where: { enforceableReasons.contains($0.reason) }) {
 				return .notGranted(error: PolicyViolation(enforceable.message))
 			}
+			Self.validateEntitlements(policy: policy, expectedEntitlement: Self.serviceProviderEntitlement, wrpVpWarnings: &wrpVpWarnings)
 			guard let dcqlQueryable else { throw WalletError(description: "DCQL queryable not computed", code: .internalError) }
 			let options = try OpenId4VpUtils.resolveDcql(dcql, queryable: dcqlQueryable)
 			OpenId4VpUtils.validateDcqlPolicy(credentialSetOptions: options, policy: policy, wrpVpWarnings: &wrpVpWarnings)
@@ -113,5 +123,13 @@ public actor WrpVpRegistrationValidator {
 				.notGranted(error: .init(error.localizedDescription)) :
 				.granted(warnings: ["": [.init(error.localizedDescription)]])
 	  }
+	}
+
+	/// Warn when the WRPRC `entitlements` claim is present but does not include the expected operation.
+	static func validateEntitlements(policy: WrpRegistrationPolicy, expectedEntitlement: String, wrpVpWarnings: inout [String: [PresentationPolicyViolation]]) {
+		guard let entitlements = policy.entitlements else { return }
+		if !entitlements.contains(expectedEntitlement) {
+			wrpVpWarnings["", default: []].append(PresentationPolicyViolation(reason: .entitlementMissing(expected: expectedEntitlement), message: "Registration certificate entitlements \(entitlements) do not include '\(expectedEntitlement)'"))
+		}
 	}
 }

--- a/Tests/EudiWalletKitTests/DcqlQueryTests.swift
+++ b/Tests/EudiWalletKitTests/DcqlQueryTests.swift
@@ -1249,8 +1249,9 @@ struct DcqlQueryTests {
 		)
 		var options = CredentialSelectionSetOptions()
 		options["option1"] = [selection]
-		let result = OpenId4VpUtils.validateDcqlPolicy(credentialSetOptions: options, policy: policy)
-		#expect(result.isEmpty, "Should have no violations when all claims are within policy")
+		var warnings = [String: [PresentationPolicyViolation]]()
+		OpenId4VpUtils.validateDcqlPolicy(credentialSetOptions: options, policy: policy, wrpVpWarnings: &warnings)
+		#expect(warnings.isEmpty, "Should have no violations when all claims are within policy")
 	}
 
 	@Test("validateDcqlPolicy - warns on extra claims beyond policy scope")
@@ -1266,11 +1267,12 @@ struct DcqlQueryTests {
 		)
 		var options = CredentialSelectionSetOptions()
 		options["option1"] = [selection]
-		let result = OpenId4VpUtils.validateDcqlPolicy(credentialSetOptions: options, policy: policy)
-		#expect(result.count == 1, "Should have one option key with violations")
-		let violations = result["option1"]
+		var warnings = [String: [PresentationPolicyViolation]]()
+		OpenId4VpUtils.validateDcqlPolicy(credentialSetOptions: options, policy: policy, wrpVpWarnings: &warnings)
+		#expect(warnings.count == 1, "Should have one option key with violations")
+		let violations = warnings["option1"]
 		#expect(violations?.count == 1)
-		#expect(violations?.first?.violation.contains("DCQL_EXTRA_CLAIMS") == true || violations?.first?.violation.contains("portrait") == true)
+		#expect(violations?.first?.message.contains("portrait") == true)
 	}
 
 	@Test("validateDcqlPolicy - warns on credential not declared in policy")
@@ -1286,11 +1288,12 @@ struct DcqlQueryTests {
 		)
 		var options = CredentialSelectionSetOptions()
 		options["option1"] = [selection]
-		let result = OpenId4VpUtils.validateDcqlPolicy(credentialSetOptions: options, policy: policy)
-		#expect(result.count == 1)
-		let violations = result["option1"]
+		var warnings = [String: [PresentationPolicyViolation]]()
+		OpenId4VpUtils.validateDcqlPolicy(credentialSetOptions: options, policy: policy, wrpVpWarnings: &warnings)
+		#expect(warnings.count == 1)
+		let violations = warnings["option1"]
 		#expect(violations?.count == 1)
-		#expect(violations?.first?.violation.contains("DCQL_EXTRA_CREDENTIAL") == true || violations?.first?.violation.contains("not declared") == true)
+		#expect(violations?.first?.message.contains("not declared") == true)
 	}
 
 	@Test("validateDcqlPolicy - no violations when selection has no claim queries")
@@ -1306,8 +1309,9 @@ struct DcqlQueryTests {
 		)
 		var options = CredentialSelectionSetOptions()
 		options["option1"] = [selection]
-		let result = OpenId4VpUtils.validateDcqlPolicy(credentialSetOptions: options, policy: policy)
-		#expect(result.isEmpty, "Should have no violations when no claims are requested")
+		var warnings = [String: [PresentationPolicyViolation]]()
+		OpenId4VpUtils.validateDcqlPolicy(credentialSetOptions: options, policy: policy, wrpVpWarnings: &warnings)
+		#expect(warnings.isEmpty, "Should have no violations when no claims are requested")
 	}
 
 	@Test("validateDcqlPolicy - matches by vct_values for SD-JWT credentials")
@@ -1324,8 +1328,9 @@ struct DcqlQueryTests {
 		)
 		var options = CredentialSelectionSetOptions()
 		options["option1"] = [selection]
-		let result = OpenId4VpUtils.validateDcqlPolicy(credentialSetOptions: options, policy: policy)
-		#expect(result.isEmpty, "Should match by vct_values and find no violations")
+		var warnings = [String: [PresentationPolicyViolation]]()
+		OpenId4VpUtils.validateDcqlPolicy(credentialSetOptions: options, policy: policy, wrpVpWarnings: &warnings)
+		#expect(warnings.isEmpty, "Should match by vct_values and find no violations")
 	}
 
 	@Test("validateDcqlPolicy - multiple selections with mixed violations")
@@ -1345,9 +1350,10 @@ struct DcqlQueryTests {
 		)
 		var options = CredentialSelectionSetOptions()
 		options["option1"] = [validSelection, unknownCredSelection]
-		let result = OpenId4VpUtils.validateDcqlPolicy(credentialSetOptions: options, policy: policy)
-		#expect(result.count == 1)
-		let violations = result["option1"]
+		var warnings = [String: [PresentationPolicyViolation]]()
+		OpenId4VpUtils.validateDcqlPolicy(credentialSetOptions: options, policy: policy, wrpVpWarnings: &warnings)
+		#expect(warnings.count == 1)
+		let violations = warnings["option1"]
 		#expect(violations?.count == 1, "Should have one violation for the unknown credential")
 	}
 
@@ -1355,7 +1361,8 @@ struct DcqlQueryTests {
 	func testValidateDcqlPolicyEmptyOptions() {
 		let policy = makePolicy(credentials: [])
 		let options = CredentialSelectionSetOptions()
-		let result = OpenId4VpUtils.validateDcqlPolicy(credentialSetOptions: options, policy: policy)
-		#expect(result.isEmpty)
+		var warnings = [String: [PresentationPolicyViolation]]()
+		OpenId4VpUtils.validateDcqlPolicy(credentialSetOptions: options, policy: policy, wrpVpWarnings: &warnings)
+		#expect(warnings.isEmpty)
 	}
 }


### PR DESCRIPTION
Introduce new reasons for presentation and registration failures to indicate when expected entitlements are missing. Additionally, implement validation logic to check for these entitlements in the registration process. Fix an issue with handling nil values for `provides_attestations`.