### PR TITLE
Revert intermediary property change in WrpRegistrationPolicy

### DIFF
--- a/Sources/EudiWalletKit/Models/WrpRegistrationPolicy.swift
+++ b/Sources/EudiWalletKit/Models/WrpRegistrationPolicy.swift
@@ -41,13 +41,13 @@ public struct WrpRegistrationPolicy: Decodable, Sendable {
 	public let status: Status?
 	public let intendedUseID: String?
 	public let providesAttestations: [PolicyCredential]?
-	public let intermediary: [PolicyIntermediary]?
+	public let intermediary: PolicyIntermediary?
 	/// Identifiers of the registered relying party, derived from the `sub` claim.
 	public var identifiers: [RegistrationIdentifier] {
 		[RegistrationIdentifier(value: sub)] 
 	}
 
-	public init(entitlements: [String]? = nil, sub: String, country: String? = nil, policyID: [String]? = nil, credentials: [PolicyCredential], purpose: [PolicyPurpose]? = nil, registryURI: String? = nil, certificatePolicy: String? = nil, srvDescription: [PolicyPurpose]? = nil, supportURI: String? = nil, supervisoryAuthority: SupervisoryAuthority? = nil, privacyPolicy: String? = nil, name: String? = nil, infoURI: String? = nil, subLn: String? = nil, subGn: String? = nil, subFn: String? = nil, iat: Int? = nil, exp: Int? = nil, status: Status? = nil, intendedUseID: String? = nil, providesAttestations: [PolicyCredential]? = nil, intermediary: [PolicyIntermediary]? = nil) {
+	public init(entitlements: [String]? = nil, sub: String, country: String? = nil, policyID: [String]? = nil, credentials: [PolicyCredential], purpose: [PolicyPurpose]? = nil, registryURI: String? = nil, certificatePolicy: String? = nil, srvDescription: [PolicyPurpose]? = nil, supportURI: String? = nil, supervisoryAuthority: SupervisoryAuthority? = nil, privacyPolicy: String? = nil, name: String? = nil, infoURI: String? = nil, subLn: String? = nil, subGn: String? = nil, subFn: String? = nil, iat: Int? = nil, exp: Int? = nil, status: Status? = nil, intendedUseID: String? = nil, providesAttestations: [PolicyCredential]? = nil, intermediary: PolicyIntermediary? = nil) {
 		self.entitlements = entitlements
 		self.sub = sub
 		self.country = country

--- a/Sources/EudiWalletKit/Services/WrpRegistrationBinding.swift
+++ b/Sources/EudiWalletKit/Services/WrpRegistrationBinding.swift
@@ -28,7 +28,7 @@ extension WrpRegistrationPolicy {
             return false
         }
         if let intermediary {
-			return intermediary.compactMap(\.identifier).contains(presenterId)
+            return intermediary.identifier == presenterId
         }
         return identifiers.contains { $0.value == presenterId }
     }


### PR DESCRIPTION
Restore the intermediary property in WrpRegistrationPolicy to support multiple entries, reversing a previous change.