### PR TITLE
Expose grant type in OfferedIssuanceModel

### DIFF
--- a/Sources/EudiWalletKit/EudiWalletKit.docc/IssueDocuments.md
+++ b/Sources/EudiWalletKit/EudiWalletKit.docc/IssueDocuments.md
@@ -135,7 +135,7 @@ if let warnings = result.wrpIssuerWarnings, !warnings.isEmpty {
 ### Resolving Credential offer
 
 The library provides the `resolveOfferUrlDocTypes(offerUri:authFlowRedirectionURI:)` method that resolves the credential offer URI.
-The method returns the resolved ``OfferedIssuanceModel`` object that contains the offer's data (offered document types, issuer name and transaction code specification for pre-authorized flow). When registration certificate validation is enabled (``OpenId4VciConfiguration/validateRegistrationCertificate``), the model also includes:
+The method returns the resolved ``OfferedIssuanceModel`` object that contains the offer's data (offered document types, issuer name, grants, and transaction code specification for pre-authorized flow). When registration certificate validation is enabled (``OpenId4VciConfiguration/validateRegistrationCertificate``), the model also includes:
 
 - ``OfferedIssuanceModel/wrpVciRegistrationPolicy`` — the parsed issuer registration policy decoded from the WRPRC.
 - ``OfferedIssuanceModel/wrpVciWarnings`` — validation warnings keyed by credential configuration identifier; the empty key holds request-wide warnings. `nil` when validation is not enabled.
@@ -205,7 +205,7 @@ The user is redirected in an authorization web view to the issuer's authorizatio
 ### Pre-Authorization code flow
 
 When Issuer supports the pre-authorization code flow, the resolved offer will also contain the corresponding
-information. Specifically, the `txCodeSpec` field in the ``OfferedIssuanceModel`` object will contain:
+information. The ``OfferedIssuanceModel/grants`` field exposes whether the offer includes `authorization_code`, `pre-authorized_code`, or both. When a transaction code is required, the `txCodeSpec` field in the ``OfferedIssuanceModel`` object will contain:
 
 - The input mode, whether it is NUMERIC or TEXT
 - The expected length of the input

--- a/Sources/EudiWalletKit/Models/OfferedIssuanceModel.swift
+++ b/Sources/EudiWalletKit/Models/OfferedIssuanceModel.swift
@@ -24,10 +24,11 @@ import Copyable
 /// This information is returned from ``EudiWallet/resolveOfferUrlDocTypes(uriOffer:)``
 public struct OfferedIssuanceModel: Sendable {
 	/// public initializer
-	public init(issuerName: String, issuerLogoUrl: String? = nil, docModels: [OfferedDocModel], txCodeSpec: TxCode? = nil, wrpVciRegistrationPolicy: WrpRegistrationPolicy? = nil, wrpVciWarnings: [String: [RegistrationPolicyViolation]]? = nil) {
+	public init(issuerName: String, issuerLogoUrl: String? = nil, docModels: [OfferedDocModel], grants: Grants? = nil, txCodeSpec: TxCode? = nil, wrpVciRegistrationPolicy: WrpRegistrationPolicy? = nil, wrpVciWarnings: [String: [RegistrationPolicyViolation]]? = nil) {
 		self.issuerName = issuerName
 		self.issuerLogoUrl = issuerLogoUrl
 		self.docModels = docModels
+		self.grants = grants
 		self.txCodeSpec = txCodeSpec
 		self.wrpVciRegistrationPolicy = wrpVciRegistrationPolicy
 		self.wrpVciWarnings = wrpVciWarnings
@@ -38,6 +39,8 @@ public struct OfferedIssuanceModel: Sendable {
 	public let issuerLogoUrl: String?
 	/// Document types included in the offer
 	public let docModels: [OfferedDocModel]
+	/// Grants included in the offer
+	public let grants: Grants?
 	/// Transaction code specification (in case of preauthorized flow)
 	public let txCodeSpec: TxCode?
 	/// Helper var for transaction code requirement

--- a/Sources/EudiWalletKit/Services/OpenId4VciService.swift
+++ b/Sources/EudiWalletKit/Services/OpenId4VciService.swift
@@ -221,7 +221,7 @@ public actor OpenId4VciService {
 			warnings = nil
 			registrationPolicy = nil
 		}
-		return OfferedIssuanceModel(issuerName: issuerName, issuerLogoUrl: issuerLogoUrl, docModels: credentialInfo.map(\.offered), txCodeSpec: code?.txCode, wrpVciRegistrationPolicy: registrationPolicy, wrpVciWarnings: warnings)
+		return OfferedIssuanceModel(issuerName: issuerName, issuerLogoUrl: issuerLogoUrl, docModels: credentialInfo.map(\.offered), grants: offer.grants, txCodeSpec: code?.txCode, wrpVciRegistrationPolicy: registrationPolicy, wrpVciWarnings: warnings)
 	}
 
 	/// Resolve the issuer's WRP registration certificate for a set of credential configuration identifiers
@@ -852,7 +852,7 @@ public actor OpenId4VciService {
 		var encyptionSpec: EncryptionSpec? = nil
 		let isResponseEncryptionSupported = if case .notSupported = await issuer.issuerMetadata.credentialResponseEncryption { false } else { true }
 		if let derKeyData, isResponseEncryptionSupported {
-			encyptionSpec = makeRequestEncryptionSpec(derKeyData: derKeyData, algorithm: JWSAlgorithm.AlgorithmType.ES256) 
+			encyptionSpec = makeRequestEncryptionSpec(derKeyData: derKeyData, algorithm: JWSAlgorithm.AlgorithmType.ES256)
 			deferredResponseEncryptionSpec = await Issuer.createResponseEncryptionSpec(issuer.issuerMetadata.credentialResponseEncryption, privateKeyData: derKeyData)
 			await issuer.setDeferredResponseEncryptionSpec(deferredResponseEncryptionSpec)
 		}
@@ -874,7 +874,7 @@ public actor OpenId4VciService {
 			throw WalletError(description: "\(errorDescription ?? "Something went wrong with your deferred request response")", code: .issuanceRequestFailed)
 		}
 	}
-	
+
 	func makeRequestEncryptionSpec(derKeyData: Data, algorithm: JWSAlgorithm.AlgorithmType?) -> EncryptionSpec? {
 		var additionalParameters: [String: String] = ["use": "sig", "kid": UUID().uuidString]
 		if let algorithm { additionalParameters["alg"] = JWSAlgorithm(algorithm).name }


### PR DESCRIPTION
The OfferedIssuanceModel now includes the grant type, allowing the wallet app to determine whether the offer includes `authorization_code`, `pre-authorized_code`, or both. This enhancement enables the app to present the appropriate UI flow based on the grant type before starting the issuance process.

Fixes #451