### PR TITLE
Update CI workflow and dependencies

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,12 +12,12 @@ on:
 jobs:
   build:
 
-    runs-on: macos-latest
+    runs-on: macos-15
 
     steps:
-      - uses: maxim-lobanov/setup-xcode@v1
+      - uses: maxim-lobanov/setup-xcode@v1.7.0
         with:
-          xcode-version: latest
+          xcode-version: latest-stable
       - uses: actions/checkout@v4
       - name: Run Fastlane tests
         run: fastlane tests

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ DerivedData/
 .swiftpm/configuration/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
+/fastlane/test_output
+fastlane/report.xml
+/xcov_output

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1042b76ad4ceef8b4a8f174b004a1538ccaa84c1dc19fbf5c0d35d281e6d6d44",
+  "originHash" : "51eb9d685cdb5e6a2fd6a448b15ffb40583dd03719b3d48425830a48067990b8",
   "pins" : [
     {
       "identity" : "cryptoswift",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git",
       "state" : {
-        "revision" : "ac8a3c9b8319f8577ec4b481a980505c97b1cc68",
-        "version" : "0.24.2"
+        "revision" : "e38cd1b4ba88bfb3212deed5b2daf606dbc4e6dd",
+        "version" : "0.24.3"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-security",
       "state" : {
-        "revision" : "4bf76a5f2e4763029634124b3e7c4f5334cf7e42",
-        "version" : "0.24.5"
+        "revision" : "c2d8ad046fcf7745dbcde98adf22033651bcbc5e",
+        "version" : "0.24.6"
       }
     },
     {
@@ -71,15 +71,6 @@
       "state" : {
         "revision" : "5fc8442563b6502a01e8e30bde7b9700fdbf63c5",
         "version" : "0.23.2"
-      }
-    },
-    {
-      "identity" : "eudi-lib-kmp-etsi-1196x2",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-kmp-etsi-1196x2.git",
-      "state" : {
-        "revision" : "fe25f428471b88e975b6b07814162a2d14abbfe4",
-        "version" : "0.4.0-alpha.1-SPM"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
 			targets: ["EudiWalletKit"])
 	],
 	dependencies: [
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git", exact: "0.24.2"),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git", exact: "0.24.3"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git", exact: "0.23.2"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift.git", exact: "0.14.6"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vp-swift.git", exact: "0.41.0"),

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -29,8 +29,7 @@ platform :ios do
       devices: ['iPhone Air'],
       output_directory: "xcov_output",
       result_bundle: true,
-      parallel_testing: false,
-      xcodebuild_formatter: "xcbeautify"
+      parallel_testing: false
     }
 
     if ENV['CI']


### PR DESCRIPTION
Update the CI workflow to use the latest action versions and update the .gitignore file. Also, update the `eudi-lib-ios-iso18013-data-transfer` dependency to version 0.24.3.