### PR TITLE
Update clientId handling and enhance transaction logging

### DIFF
--- a/Sources/EudiWalletKit/Models/OpenId4VciConfiguration.swift
+++ b/Sources/EudiWalletKit/Models/OpenId4VciConfiguration.swift
@@ -30,7 +30,7 @@ public struct OpenId4VciConfiguration: Sendable {
 	/// The URL of the credential issuer
 	public let credentialIssuerURL: String?
 	/// The client identifier used for OpenID4VCI flows
-	public let clientId: String
+	public let clientId: String?
 	/// Configuration for key attestation, if supported by the issuer
 	public let keyAttestationsConfig: KeyAttestationConfiguration
 	/// The redirect URI used after authorization flow completion
@@ -74,7 +74,7 @@ public struct OpenId4VciConfiguration: Sendable {
 		trustedIssuerCertificates: [x5chain]? = nil
 	) {
 		self.credentialIssuerURL = credentialIssuerURL
-		self.clientId = clientId ?? "eudiw-abca"
+		self.clientId = clientId
 		self.keyAttestationsConfig = keyAttestationsConfig
 		self.authFlowRedirectionURI = authFlowRedirectionURI ?? URL(string: "eudi-openid4ci://authorize")!
 		self.authorizeIssuanceConfig = authorizeIssuanceConfig
@@ -166,7 +166,7 @@ extension OpenId4VciConfiguration {
 		}
 		return DPoPConstructor(algorithm: jwsAlgorithm, jwk: jwk, privateKey: signingKeyProxy)
 	}
-	
+
 	static let supportedCredentialReusePolicies: SupportedCredentialReusePolicies = .supported([.limitedTime, .onceOnly, .rotatingBatch])
 
 	func toOpenId4VCIConfig(credentialIssuerId: String, clientAttestationPopSigningAlgValuesSupported: [JWSAlgorithm], registrationCertificatePolicy: RegistrationCertificatePolicy? = nil) async throws -> OpenId4VCIConfig {
@@ -192,9 +192,11 @@ extension OpenId4VciConfiguration {
 			throw WalletError(description: "Unsupported DPoP algorithm: \(popConstructor.algorithm.name) for client attestation", code: .unsupportedAlgorithm)
 		}
 		let popJwtSpec = try ClientAttestationPoPJWTSpec(signingAlgorithm: signatureAlgorithm, duration: config.popKeyDuration ?? 300.0, typ: "oauth-client-attestation-pop+jwt")
-		let client: Client = .attested(id: clientId, alg: popConstructor.algorithm, jwk: popConstructor.jwk, popJwtSpec: popJwtSpec, clientAttestationProvider: { _ in
-			let attestation = try await attestationsProvider.getWalletAttestation(signingKey: signingKey)
-			return (try ClientAttestationJWT(jws: JWS(compactSerialization: attestation)), signingKey)
+		let attestation = try await attestationsProvider.getWalletAttestation(signingKey: signingKey)
+		let attestationJWT = try ClientAttestationJWT(jws: JWS(compactSerialization: attestation))
+		let resolvedClientId = try clientId ?? attestationJWT.decodeAsClientAttestationClaims().subject.value
+		let client: Client = .attested(id: resolvedClientId, alg: popConstructor.algorithm, jwk: popConstructor.jwk, popJwtSpec: popJwtSpec, clientAttestationProvider: { _ in
+			return (attestationJWT, signingKey)
 		})
 		return client
 	}

--- a/Sources/EudiWalletKit/Services/BlePresentationService.swift
+++ b/Sources/EudiWalletKit/Services/BlePresentationService.swift
@@ -306,7 +306,7 @@ func handleStatusChange(_ newValue: TransferStatus) async {
 		let userRequestInfo = try await withCheckedThrowingContinuation { c in
 			continuationRequest = c
 		}
-		TransactionLogUtils.setCborTransactionLogRequestInfo(userRequestInfo, transactionLog: &transactionLog)
+		TransactionLogUtils.setCborTransactionLogRequestInfo(userRequestInfo, wrpVpPolicy: wrpVerifierPolicy, transactionLog: &transactionLog)
 		return [userRequestInfo]
 	}
 

--- a/Sources/EudiWalletKit/Services/OpenId4VpService.swift
+++ b/Sources/EudiWalletKit/Services/OpenId4VpService.swift
@@ -191,7 +191,7 @@ public final class OpenId4VpService: @unchecked Sendable, PresentationService {
 				)
 				logger.info("Verifier requested items: \(requestItems.mapValues { $0.mapValues { ar in ar.map(\.elementIdentifier) } })")
 				result.readerAuthResults = ["": rar]
-				TransactionLogUtils.setCborTransactionLogRequestInfo(result, transactionLog: &transactionLog)
+				TransactionLogUtils.setCborTransactionLogRequestInfo(result, wrpVpPolicy: wrpVerifierPolicy, transactionLog: &transactionLog)
 				results.append(result)
 			}
 			return results

--- a/Sources/EudiWalletKit/Services/TransactionLogUtils.swift
+++ b/Sources/EudiWalletKit/Services/TransactionLogUtils.swift
@@ -31,8 +31,8 @@ class TransactionLogUtils {
 		return transactionLog
 	}
 
-	static func setCborTransactionLogRequestInfo(_ requestInfo: UserRequestInfo, transactionLog: inout TransactionLog) {
-		transactionLog = transactionLog.copy(timestamp: getTimestamp(), rawRequest: requestInfo.deviceRequestBytes, relyingParty: TransactionLogUtils.getRelyingParty(requestInfo), dataFormat: .cbor)
+	static func setCborTransactionLogRequestInfo(_ requestInfo: UserRequestInfo, wrpVpPolicy: WrpRegistrationPolicy? = nil, transactionLog: inout TransactionLog) {
+		transactionLog = transactionLog.copy(timestamp: getTimestamp(), rawRequest: requestInfo.deviceRequestBytes, relyingParty: TransactionLogUtils.getRelyingParty(requestInfo, wrpVpPolicy: wrpVpPolicy), dataFormat: .cbor)
 	}
 
 	static func setCborTransactionLogResponseInfo(_ bleService: BlePresentationService, documentId: String?, docType: String?, displayName: String?, transactionLog: inout TransactionLog) {
@@ -50,9 +50,9 @@ class TransactionLogUtils {
 		transactionLog = TransactionLog(timestamp: getTimestamp(), status: .failed, errorMessage: error.localizedDescription, type: type, dataFormat: transactionLog.dataFormat)
 	}
 
-	static func getRelyingParty(_ requestInfo: UserRequestInfo) -> TransactionLog.RelyingParty? {
+	static func getRelyingParty(_ requestInfo: UserRequestInfo, wrpVpPolicy: WrpRegistrationPolicy?) -> TransactionLog.RelyingParty? {
 		let defaultReaderAuthResult = requestInfo.defaultReaderAuthResult
-		guard let name = defaultReaderAuthResult?.legalName ?? defaultReaderAuthResult?.certificateIssuer else { return nil }
+		guard let name = wrpVpPolicy?.name ?? defaultReaderAuthResult?.certificateIssuer else { return nil }
 		let isVerified = defaultReaderAuthResult?.isValidated ?? false
 		let certificateChain = defaultReaderAuthResult?.certificateChain ?? []
 		let readerAuth = defaultReaderAuthResult?.authBytes

--- a/Sources/EudiWalletKit/Services/TransactionLogUtils.swift
+++ b/Sources/EudiWalletKit/Services/TransactionLogUtils.swift
@@ -51,8 +51,8 @@ class TransactionLogUtils {
 	}
 
 	static func getRelyingParty(_ requestInfo: UserRequestInfo) -> TransactionLog.RelyingParty? {
-		guard let name = requestInfo.defaultReaderAuthResult?.certificateIssuer else { return nil }
 		let defaultReaderAuthResult = requestInfo.defaultReaderAuthResult
+		guard let name = defaultReaderAuthResult?.legalName ?? defaultReaderAuthResult?.certificateIssuer else { return nil }
 		let isVerified = defaultReaderAuthResult?.isValidated ?? false
 		let certificateChain = defaultReaderAuthResult?.certificateChain ?? []
 		let readerAuth = defaultReaderAuthResult?.authBytes

--- a/Tests/EudiWalletKitTests/PresentationSessionTests.swift
+++ b/Tests/EudiWalletKitTests/PresentationSessionTests.swift
@@ -169,6 +169,41 @@ struct PresentationSessionTests {
         #expect(party.logoUrl == nil)
     }
 
+    // MARK: - RelyingParty
+
+    @Test("RelyingParty uses WRP registration legal name")
+    func testRelyingPartyUsesLegalName() {
+        var requestInfo = UserRequestInfo(docDataFormats: [:], itemsRequested: [:])
+        requestInfo.readerAuthResults = [
+            "": ReaderAuthenticationResult(
+                isValidated: true,
+                certificateIssuer: "Access Certificate CN",
+                legalName: "WRP Registration Identity"
+            )
+        ]
+
+        let relyingParty = TransactionLogUtils.getRelyingParty(requestInfo)
+
+        #expect(relyingParty?.name == "WRP Registration Identity")
+        #expect(relyingParty?.isVerified == true)
+    }
+
+    @Test("RelyingParty falls back to certificate issuer")
+    func testRelyingPartyFallsBackToCertificateIssuer() {
+        var requestInfo = UserRequestInfo(docDataFormats: [:], itemsRequested: [:])
+        requestInfo.readerAuthResults = [
+            "": ReaderAuthenticationResult(
+                isValidated: false,
+                certificateIssuer: "Access Certificate CN"
+            )
+        ]
+
+        let relyingParty = TransactionLogUtils.getRelyingParty(requestInfo)
+
+        #expect(relyingParty?.name == "Access Certificate CN")
+        #expect(relyingParty?.isVerified == false)
+    }
+
     // MARK: - IssuanceLogData
 
     @Test("IssuanceLogData parses from TransactionLog")

--- a/Tests/EudiWalletKitTests/PresentationSessionTests.swift
+++ b/Tests/EudiWalletKitTests/PresentationSessionTests.swift
@@ -199,11 +199,9 @@ struct PresentationSessionTests {
                 legalName: "Resolved Legal Name"
             )
         ]
-        let wrpVpPolicy = WrpRegistrationPolicy(sub: "registration-sub", credentials: [])
-
+		let wrpVpPolicy = WrpRegistrationPolicy(sub: "sub", credentials: [], name: "registration-name")
         let relyingParty = TransactionLogUtils.getRelyingParty(requestInfo, wrpVpPolicy: wrpVpPolicy)
-
-        #expect(relyingParty?.name == "registration-sub")
+        #expect(relyingParty?.name == "registration-name")
         #expect(relyingParty?.isVerified == true)
     }
 

--- a/Tests/EudiWalletKitTests/PresentationSessionTests.swift
+++ b/Tests/EudiWalletKitTests/PresentationSessionTests.swift
@@ -181,10 +181,29 @@ struct PresentationSessionTests {
                 legalName: "WRP Registration Identity"
             )
         ]
+        let wrpVpPolicy = WrpRegistrationPolicy(sub: "registration-sub", credentials: [], name: "WRP Registration Identity")
 
-        let relyingParty = TransactionLogUtils.getRelyingParty(requestInfo)
+        let relyingParty = TransactionLogUtils.getRelyingParty(requestInfo, wrpVpPolicy: wrpVpPolicy)
 
         #expect(relyingParty?.name == "WRP Registration Identity")
+        #expect(relyingParty?.isVerified == true)
+    }
+
+    @Test("RelyingParty falls back to WRP registration subject")
+    func testRelyingPartyFallsBackToWrpRegistrationSubject() {
+        var requestInfo = UserRequestInfo(docDataFormats: [:], itemsRequested: [:])
+        requestInfo.readerAuthResults = [
+            "": ReaderAuthenticationResult(
+                isValidated: true,
+                certificateIssuer: "Access Certificate CN",
+                legalName: "Resolved Legal Name"
+            )
+        ]
+        let wrpVpPolicy = WrpRegistrationPolicy(sub: "registration-sub", credentials: [])
+
+        let relyingParty = TransactionLogUtils.getRelyingParty(requestInfo, wrpVpPolicy: wrpVpPolicy)
+
+        #expect(relyingParty?.name == "registration-sub")
         #expect(relyingParty?.isVerified == true)
     }
 
@@ -198,7 +217,7 @@ struct PresentationSessionTests {
             )
         ]
 
-        let relyingParty = TransactionLogUtils.getRelyingParty(requestInfo)
+        let relyingParty = TransactionLogUtils.getRelyingParty(requestInfo, wrpVpPolicy: nil)
 
         #expect(relyingParty?.name == "Access Certificate CN")
         #expect(relyingParty?.isVerified == false)


### PR DESCRIPTION
- Adjust the `clientId` property to be optional, allowing for the retrieval of the attested client ID from the wallet attestation. 
- Enhance the `getRelyingParty` method to utilize the w.relying party registration name and include tests for fallback logic. Update transaction log methods to incorporate the `wrpVpPolicy`.

Fixes #455