### PR TITLE
Refactor keychain key access and update dependencies

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "51eb9d685cdb5e6a2fd6a448b15ffb40583dd03719b3d48425830a48067990b8",
+  "originHash" : "d10ee5ceeb02fa13937ccd3a078980ccc6a3637905fbc9d7b9f17ab635355f0d",
   "pins" : [
     {
       "identity" : "cryptoswift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
       "state" : {
-        "revision" : "e45a26384239e028ec87fbcc788f513b67e10d8f",
-        "version" : "1.9.0"
+        "revision" : "f2a627b84c1ff96f21ac2fcb623ab36142dd5512",
+        "version" : "1.10.0"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git",
       "state" : {
-        "revision" : "6d3424611604ccb67b993739b42e41e871a5ed80",
-        "version" : "0.24.1"
+        "revision" : "2bc9318fe4b8365ac50a19f4c724b375f21374b6",
+        "version" : "0.25.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git",
       "state" : {
-        "revision" : "e38cd1b4ba88bfb3212deed5b2daf606dbc4e6dd",
-        "version" : "0.24.3"
+        "revision" : "9a593f3c88bee78c8812fac0c4748c3331bc9362",
+        "version" : "0.25.0"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-security",
       "state" : {
-        "revision" : "c2d8ad046fcf7745dbcde98adf22033651bcbc5e",
-        "version" : "0.24.6"
+        "revision" : "72b3b4864665616b9537ae1f2e142e620c3a920d",
+        "version" : "0.25.0"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git",
       "state" : {
-        "revision" : "37c712ee275a3c01ca6423aaeb0a82288f575828",
-        "version" : "0.53.1"
+        "revision" : "c2f29c93ce813eeb225f1dce54aad50ed9b3ddf2",
+        "version" : "0.53.2"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git",
       "state" : {
-        "revision" : "5fc8442563b6502a01e8e30bde7b9700fdbf63c5",
-        "version" : "0.23.2"
+        "revision" : "a6017b0ce984261639564004e486ae7f1663c15d",
+        "version" : "0.25.0"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift.git",
       "state" : {
-        "revision" : "a3c4bd2c52e9f91ac45d720e728fb757c63f39fc",
-        "version" : "0.14.6"
+        "revision" : "0cc38aaab39bc41f61799e03322d0b7fdbb8705d",
+        "version" : "0.14.7"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/beatt83/jose-swift.git",
       "state" : {
-        "revision" : "b7d3ef55660fefd045641293bc95d4cdc07a15d8",
-        "version" : "6.0.4"
+        "revision" : "9b5fde623a083ef86291e9b1a1b8a4fe3084b29f",
+        "version" : "6.0.5"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GigaBitcoin/secp256k1.swift.git",
       "state" : {
-        "revision" : "4c77c7384768acf1093d66ccaacf298d322b10b7",
-        "version" : "0.15.0"
+        "revision" : "e70a10e036a55fffea31568f0af92d69b6d449cd",
+        "version" : "0.23.2"
       }
     },
     {
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
-        "version" : "3.15.1"
+        "revision" : "da9d28d69ebe3894b18376c8f2395c2f37b8448f",
+        "version" : "4.5.2"
       }
     },
     {
@@ -182,15 +182,6 @@
       }
     },
     {
-      "identity" : "swift-zlib",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/beatt83/swift-zlib.git",
-      "state" : {
-        "revision" : "8cf51bfdf81c46702dac496d16397d92ac392532",
-        "version" : "1.0.2"
-      }
-    },
-    {
       "identity" : "swiftcbor",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/niscy-eudiw/SwiftCBOR.git",
@@ -215,6 +206,15 @@
       "state" : {
         "revision" : "af76cf3ef710b6ca5f8c05f3a31307d44a3c5828",
         "version" : "5.0.2"
+      }
+    },
+    {
+      "identity" : "zlib",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/DLTAStudio/zlib.git",
+      "state" : {
+        "revision" : "b68b56c8549c50777663b50a3b076d6589b19c58",
+        "version" : "1.0.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
 	],
 	dependencies: [
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git", exact: "0.25.0"),
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git", exact: "0.23.2"),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git", exact: "0.25.0"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift.git", exact: "0.14.7"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vp-swift.git", exact: "0.41.0"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git", exact: "0.53.2"),

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
 	name: "EudiWalletKit",
-	platforms: [.macOS(.v14), .iOS(.v16), .watchOS(.v10)],
+	platforms: [.macOS(.v14), .iOS(.v17), .watchOS(.v10)],
 	products: [
 		// Products define the executables and libraries a package produces, making them visible to other packages.
 		.library(
@@ -13,11 +13,11 @@ let package = Package(
 			targets: ["EudiWalletKit"])
 	],
 	dependencies: [
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git", exact: "0.24.3"),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git", exact: "0.25.0"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git", exact: "0.23.2"),
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift.git", exact: "0.14.6"),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift.git", exact: "0.14.7"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vp-swift.git", exact: "0.41.0"),
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git", exact: "0.53.1"),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git", exact: "0.53.2"),
 		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-statium-swift.git", exact: "0.5.0"),
     	.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.5.0"),
 	],

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The library provides the following functionality:
         - [x] DCQL
         - [x] Optional partial claim presentation for DCQL requests
 
-The library is written in Swift and is compatible with iOS 16 or higher. It requires Swift 6.2 or later. It is distributed as a Swift package and can be included in any iOS project.
+The library is written in Swift and is compatible with iOS 17 or higher. It requires Swift 6.2 or later. It is distributed as a Swift package and can be included in any iOS project.
 
 It is based on the following specifications:
 - ISO/IEC 18013-5 – Published

--- a/Sources/EudiWalletKit/EudiWallet.swift
+++ b/Sources/EudiWalletKit/EudiWallet.swift
@@ -19,7 +19,7 @@ import MdocDataModel18013
 import MdocSecurity18013
 import MdocDataTransfer18013
 import WalletStorage
-import LocalAuthentication
+@preconcurrency import LocalAuthentication
 import CryptoKit
 import StatiumSwift
 import SwiftCBOR
@@ -63,6 +63,8 @@ public final class EudiWallet: ObservableObject, @unchecked Sendable {
 	public var bleTransportFactory: (any BleTransportFactory)?
 	/// Repository for zk system parameters, used in mdoc presentation when zk proofs are required.
 	public var zkSystemRepository: ZkSystemRepository?
+	/// Local authentication context reused by wallet operations.
+	public var localAuthenticationContext = ThreadSafeAuthContext()
 
 	/// Initialize a wallet instance using a configuration object.
 	/// - Parameters:
@@ -203,13 +205,15 @@ public final class EudiWallet: ObservableObject, @unchecked Sendable {
 		guard let vciService else {
 			throw WalletError(description: "No OpenId4VCI service registered for name \(issuerName)", code: .issuerNotRegistered)
 		}
+		
+		await vciService.setLocalAuthenticationContext(localAuthenticationContext: localAuthenticationContext)
 		return vciService
 	}
 
 	/// Register an OpenId4VCI service with a given name and configuration.
 	@discardableResult func registerOpenId4VciService(name: String, config: OpenId4VciConfiguration) throws -> OpenId4VciService {
 		let uiCulture = eudiWalletConfig.uiCulture
-		let vciService = try OpenId4VciService(uiCulture: uiCulture, config: config, networking: self.networkingVci, storage: storage, storageService: storage.storageService, trustConfig: trustConfig, transactionLogger: transactionLogger)
+		let vciService = try OpenId4VciService(uiCulture: uiCulture, config: config, networking: self.networkingVci, storage: storage, storageService: storage.storageService, trustConfig: trustConfig, transactionLogger: transactionLogger, localAuthenticationContext: localAuthenticationContext)
 		OpenId4VCIServiceRegistry.shared.register(name: name, service: vciService)
 		return vciService
 	}
@@ -234,6 +238,7 @@ public final class EudiWallet: ObservableObject, @unchecked Sendable {
 	/// - Returns: An ``IssuerResponse`` with the issued documents (saved in storage), the decoded issuer registration policy and any WRP registration certificate warnings.
 	@discardableResult public func issueDocuments(issuerName: String, docTypeIdentifiers: [DocTypeIdentifier], credentialOptions: CredentialOptions? = nil, keyOptions: KeyOptions? = nil, promptMessage: String? = nil) async throws -> IssuerResponse {
 		OpenId4VciService.clearIssuerMetadataCache()
+		localAuthenticationContext = ThreadSafeAuthContext()
 		let vciService = try await resolveVCIService(issuerName: issuerName)
 		let documents = try await vciService.issueDocuments(docTypeIdentifiers: docTypeIdentifiers, credentialOptions: credentialOptions, keyOptions: keyOptions, promptMessage: promptMessage)
 		return IssuerResponse(documents: documents, wrpIssuerWarnings: await vciService.wrpIssuerWarnings, wrpIssuerPolicy: await vciService.wrpIssuerPolicy)
@@ -417,6 +422,7 @@ public final class EudiWallet: ObservableObject, @unchecked Sendable {
 	/// - Returns: Offered issue information model
 	public func resolveOfferUrlDocTypes(offerUri: String, authFlowRedirectionURI: URL?) async throws -> OfferedIssuanceModel {
 		OpenId4VciService.clearIssuerMetadataCache()
+		localAuthenticationContext = ThreadSafeAuthContext()
 		let vciServiceFromOfferUri = await resolveVCIServiceFromOfferUri(offerUri)
 		let policy: IssuerMetadataPolicy = if let vciServiceFromOfferUri { await vciServiceFromOfferUri.config.issuerMetadataPolicy } else { trustConfig.issuerMetadataPolicy }
 		let offer = try await resolveCredentialOffer(offerUri: offerUri, policy: policy)
@@ -652,33 +658,34 @@ public final class EudiWallet: ObservableObject, @unchecked Sendable {
 	/// - Returns: A presentation session instance,
 	public func beginPresentation(flow: FlowType, sessionTransactionLogger: (any TransactionLogger)? = nil) async -> PresentationSession {
 		do {
+			localAuthenticationContext = ThreadSafeAuthContext()
 			let (parameters, documents) = try await prepareServiceDataParameters(format: flow == .ble ? .cbor : nil)
 			let docIdToPresentInfo = try await storage.getDocIdsToPresentInfo(documents: documents)
 			let mergedTransactionLogger = sessionTransactionLogger ?? transactionLogger
 			let storageService = storage.storageService
 			switch flow {
 			case .ble:
-				let bleSvc = try await BlePresentationService(parameters: parameters, transportFactory: bleTransportFactory, wrpRegistrationValidator: wrpRegistrationValidator)
-				return PresentationSession(presentationService: bleSvc, storageManager: storage, storageService: storageService, docIdToPresentInfo: docIdToPresentInfo, documentKeyIndexes: parameters.documentKeyIndexes, userAuthenticationRequired: eudiWalletConfig.userAuthenticationRequired, transactionLogger: mergedTransactionLogger)
+				let bleSvc = try await BlePresentationService(parameters: parameters, authenticationContext: localAuthenticationContext, transportFactory: bleTransportFactory, wrpRegistrationValidator: wrpRegistrationValidator)
+				return PresentationSession(presentationService: bleSvc, storageManager: storage, storageService: storageService, docIdToPresentInfo: docIdToPresentInfo, documentKeyIndexes: parameters.documentKeyIndexes, userAuthenticationRequired: eudiWalletConfig.userAuthenticationRequired, localAuthenticationContext: localAuthenticationContext, transactionLogger: mergedTransactionLogger)
 			case .openid4vp(let qrCode):
 				let docTypeDisplayNames: [String: String] = Dictionary(documents.compactMap { doc in
 					guard let displayName = docIdToPresentInfo[doc.id]?.displayName else { return nil }
 					return (doc.docType, displayName)
 				}, uniquingKeysWith: { first, _ in first })
 				let openIdSvc = try await OpenId4VpService(
-					parameters: parameters, qrCode: qrCode,	openID4VpConfig: self.openID4VpConfig, networking: networkingVp,
+					parameters: parameters, qrCode: qrCode, openID4VpConfig: self.openID4VpConfig, networking: networkingVp,
 					trustConfig: trustConfig, wrpRegistrationValidator: wrpRegistrationValidator, docTypeDisplayNames: docTypeDisplayNames
 				)
-				return PresentationSession(presentationService: openIdSvc, storageManager: storage, storageService: storageService, docIdToPresentInfo: docIdToPresentInfo, documentKeyIndexes: parameters.documentKeyIndexes, userAuthenticationRequired: eudiWalletConfig.userAuthenticationRequired, transactionLogger: mergedTransactionLogger)
+				return PresentationSession(presentationService: openIdSvc, storageManager: storage, storageService: storageService, docIdToPresentInfo: docIdToPresentInfo, documentKeyIndexes: parameters.documentKeyIndexes, userAuthenticationRequired: eudiWalletConfig.userAuthenticationRequired, localAuthenticationContext: localAuthenticationContext, transactionLogger: mergedTransactionLogger)
 			default:
 				let fallbackError = WalletError(description: "Use beginPresentation(service:)", code: .internalError)
 				let faultService = FaultPresentationService(error: fallbackError)
-				return PresentationSession(presentationService: faultService, storageManager: storage, storageService: storageService, docIdToPresentInfo: docIdToPresentInfo, documentKeyIndexes: parameters.documentKeyIndexes, userAuthenticationRequired: false, transactionLogger: mergedTransactionLogger)
+				return PresentationSession(presentationService: faultService, storageManager: storage, storageService: storageService, docIdToPresentInfo: docIdToPresentInfo, documentKeyIndexes: parameters.documentKeyIndexes, userAuthenticationRequired: false, localAuthenticationContext: localAuthenticationContext, transactionLogger: mergedTransactionLogger)
 			}
 		} catch {
 			let faultService = FaultPresentationService(error: error)
 			let mergedTransactionLogger = sessionTransactionLogger ?? transactionLogger
-			return PresentationSession(presentationService: faultService, storageManager: storage, storageService: storage.storageService, docIdToPresentInfo: [:], documentKeyIndexes: [:], userAuthenticationRequired: false, transactionLogger: mergedTransactionLogger)
+			return PresentationSession(presentationService: faultService, storageManager: storage, storageService: storage.storageService, docIdToPresentInfo: [:], documentKeyIndexes: [:], userAuthenticationRequired: false, localAuthenticationContext: localAuthenticationContext, transactionLogger: mergedTransactionLogger)
 		}
 	}
 
@@ -693,11 +700,11 @@ public final class EudiWallet: ObservableObject, @unchecked Sendable {
 			let (parameters, documents) = try await prepareServiceDataParameters()
 			let docIdToPresentInfo = try await storage.getDocIdsToPresentInfo(documents: documents)
 			let mergedTransactionLogger = sessionTransactionLogger ?? self.transactionLogger
-			return PresentationSession(presentationService: service, storageManager: storage, storageService: storage.storageService, docIdToPresentInfo: docIdToPresentInfo, documentKeyIndexes: parameters.documentKeyIndexes, userAuthenticationRequired: eudiWalletConfig.userAuthenticationRequired, transactionLogger: mergedTransactionLogger)
+			return PresentationSession(presentationService: service, storageManager: storage, storageService: storage.storageService, docIdToPresentInfo: docIdToPresentInfo, documentKeyIndexes: parameters.documentKeyIndexes, userAuthenticationRequired: eudiWalletConfig.userAuthenticationRequired, localAuthenticationContext: localAuthenticationContext, transactionLogger: mergedTransactionLogger)
 		} catch {
 			let faultService = FaultPresentationService(error: error)
 			let mergedTransactionLogger = sessionTransactionLogger ?? transactionLogger
-			return PresentationSession(presentationService: faultService, storageManager: storage, storageService: storage.storageService, docIdToPresentInfo: [:], documentKeyIndexes: [:], userAuthenticationRequired: false, transactionLogger: mergedTransactionLogger)
+			return PresentationSession(presentationService: faultService, storageManager: storage, storageService: storage.storageService, docIdToPresentInfo: [:], documentKeyIndexes: [:], userAuthenticationRequired: false, localAuthenticationContext: localAuthenticationContext, transactionLogger: mergedTransactionLogger)
 		}
 	}
 
@@ -705,8 +712,8 @@ public final class EudiWallet: ObservableObject, @unchecked Sendable {
 	/// - Parameters:
 	///   - dismiss: Action to perform if the user cancels authorization
 	///   - action: Action to perform after user authorization
-	public nonisolated static func authorizedAction<T: Sendable>(action: sending () async throws -> T, disabled: Bool, dismiss: () -> Void, localizedReason: String) async throws -> T? {
-		return try await authorizedAction(isFallBack: false, action: action, disabled: disabled, dismiss: dismiss, localizedReason: localizedReason)
+	public nonisolated static func authorizedAction<T: Sendable>(action: sending () async throws -> T, disabled: Bool, dismiss: () -> Void, localizedReason: String, authenticationContext: ThreadSafeAuthContext) async throws -> T? {
+		return try await authorizedAction(isFallBack: false, action: action, disabled: disabled, dismiss: dismiss, localizedReason: localizedReason, authenticationContext: authenticationContext)
 	}
 
 	/// Parse transaction log
@@ -740,16 +747,15 @@ public final class EudiWallet: ObservableObject, @unchecked Sendable {
 	/// - Returns: An optional result of type `T` if the action is successful, otherwise `nil`.
 	///
 	/// - Throws: An error if the action fails.
-	static nonisolated func authorizedAction<T: Sendable>(isFallBack: Bool = false, action: sending () async throws -> T, disabled: Bool, dismiss: () -> Void, localizedReason: String) async throws -> T? {
+	static nonisolated func authorizedAction<T: Sendable>(isFallBack: Bool = false, action: sending () async throws -> T, disabled: Bool, dismiss: () -> Void, localizedReason: String, authenticationContext: ThreadSafeAuthContext) async throws -> T? {
 		guard !disabled else {
 			return try await action()
 		}
-		let context = LAContext()
 		var error: NSError?
 		let policy: LAPolicy = .deviceOwnerAuthentication
-		if context.canEvaluatePolicy(policy, error: &error) {
+		if authenticationContext.canEvaluatePolicy(policy, error: &error) {
 			do {
-				let success = try await context.evaluatePolicy(policy, localizedReason: localizedReason)
+				let success = try await authenticationContext.evaluatePolicy(policy, localizedReason: localizedReason)
 				#if os(iOS)
 				if success, let scene = await UIApplication.shared.connectedScenes.first {
 					let activateState = await scene.activationState
@@ -765,7 +771,7 @@ public final class EudiWallet: ObservableObject, @unchecked Sendable {
 				#endif
 			} catch let laError as LAError {
 				if !isFallBack, laError.code == .userFallback {
-					return try await authorizedAction(isFallBack: true, action: action, disabled: disabled, dismiss: dismiss, localizedReason: localizedReason)
+					return try await authorizedAction(isFallBack: true, action: action, disabled: disabled, dismiss: dismiss, localizedReason: localizedReason, authenticationContext: authenticationContext)
 				} else {
 					dismiss()
 					return nil

--- a/Sources/EudiWalletKit/Models/OpenId4VciConfiguration.swift
+++ b/Sources/EudiWalletKit/Models/OpenId4VciConfiguration.swift
@@ -120,13 +120,14 @@ extension OpenId4VciConfiguration {
 			}
 			jwsAlgorithm = jwsAlg
 			let existingKeyInfo: KeyBatchInfo? = try? await secureArea.getKeyBatchInfo(id: privateKeyId)
-			let hasCompatibleExistingKey = existingKeyInfo != nil && keyOptions.secureAreaName == existingKeyInfo?.secureAreaName && keyOptions.curve == ecCurve && existingKeyInfo?.usedCounts.count == 1
-			let existingPublicKey: CoseKey? = if hasCompatibleExistingKey { try? await secureArea.getPublicKey(id: privateKeyId, index: 0, curve: ecCurve) } else { nil }
-			if hasCompatibleExistingKey, existingPublicKey == nil { try await secureArea.deleteKeyInfo(id: privateKeyId) }
-			let publicCoseKey: CoseKey =
-				if let existingPublicKey { existingPublicKey } else {
-					(try await secureArea.createKeyBatch(id: privateKeyId, credentialOptions: CredentialOptions(credentialPolicy: .rotateUse, batchSize: 1), keyOptions: keyOptions)).first!
-				}
+			let hasCompatibleExistingKey = if let existingKeyInfo = existingKeyInfo, keyOptions == existingKeyInfo.keyOptions, keyOptions.curve == ecCurve, existingKeyInfo.usedCounts.count == 1 { true } else { false }
+			if !hasCompatibleExistingKey {
+				logger.info("Creating new key batch for id: \(privateKeyId) with curve: \(ecCurve.SECGName)")
+				try? await secureArea.deleteKeyInfo(id: privateKeyId)
+				try? await secureArea.deleteKeyBatch(id: privateKeyId, startIndex: 0, batchSize: 1)
+				_ = try await secureArea.createKeyBatch(id: privateKeyId, credentialOptions: CredentialOptions(credentialPolicy: .rotateUse, batchSize: 1), keyOptions: keyOptions)
+			}
+			var publicCoseKey = try await secureArea.getPublicKey(id: privateKeyId, index: 0, curve: ecCurve) 
 			let publicKeyJwk = try publicCoseKey.jwk
 			let unlockData = try await secureArea.unlockKey(id: privateKeyId)
 			let signer = try SecureAreaSigner(secureArea: secureArea, id: privateKeyId, index: 0, publicKey: publicKeyJwk.toJoseSwiftJWK(), curve: ecCurve, ecAlgorithm: ecAlgorithm, unlockData: unlockData)

--- a/Sources/EudiWalletKit/Models/OpenId4VciConfiguration.swift
+++ b/Sources/EudiWalletKit/Models/OpenId4VciConfiguration.swift
@@ -18,6 +18,7 @@ limitations under the License.
 import Foundation
 import Copyable
 import CryptoKit
+@preconcurrency import LocalAuthentication
 import JOSESwift
 import MdocDataModel18013
 import MdocSecurity18013
@@ -103,7 +104,7 @@ extension OpenId4VciConfiguration {
 	}
 
 	/// Creates a PoP constructor based on the provided parameters and configuration.
-	func makePoPConstructor(popUsage: PopUsage, privateKeyId: String, algorithms: [JWSAlgorithm]?, keyOptions: KeyOptions?) async throws -> DPoPConstructor? {
+	func makePoPConstructor(popUsage: PopUsage, privateKeyId: String, algorithms: [JWSAlgorithm]?, keyOptions: KeyOptions?, context: ThreadSafeAuthContext) async throws -> DPoPConstructor? {
 		guard let algorithms = algorithms, !algorithms.isEmpty else { return nil }
 		let signingKeyProxy: SigningKeyProxy
 		let publicKey: SecKey
@@ -127,10 +128,10 @@ extension OpenId4VciConfiguration {
 				try? await secureArea.deleteKeyBatch(id: privateKeyId, startIndex: 0, batchSize: 1)
 				_ = try await secureArea.createKeyBatch(id: privateKeyId, credentialOptions: CredentialOptions(credentialPolicy: .rotateUse, batchSize: 1), keyOptions: keyOptions)
 			}
-			var publicCoseKey = try await secureArea.getPublicKey(id: privateKeyId, index: 0, curve: ecCurve) 
+			let publicCoseKey = try await secureArea.getPublicKey(id: privateKeyId, index: 0, curve: ecCurve) 
 			let publicKeyJwk = try publicCoseKey.jwk
 			let unlockData = try await secureArea.unlockKey(id: privateKeyId)
-			let signer = try SecureAreaSigner(secureArea: secureArea, id: privateKeyId, index: 0, publicKey: publicKeyJwk.toJoseSwiftJWK(), curve: ecCurve, ecAlgorithm: ecAlgorithm, unlockData: unlockData)
+			let signer = try SecureAreaSigner(secureArea: secureArea, id: privateKeyId, index: 0, publicKey: publicKeyJwk.toJoseSwiftJWK(), curve: ecCurve, ecAlgorithm: ecAlgorithm, unlockData: unlockData, context: context)
 			signingKeyProxy = .custom(signer)
 			publicKey = try publicCoseKey.toSecKey()
 		} else {
@@ -170,7 +171,7 @@ extension OpenId4VciConfiguration {
 
 	static let supportedCredentialReusePolicies: SupportedCredentialReusePolicies = .supported([.limitedTime, .onceOnly, .rotatingBatch])
 
-	func toOpenId4VCIConfig(credentialIssuerId: String, clientAttestationPopSigningAlgValuesSupported: [JWSAlgorithm]?, registrationCertificatePolicy: RegistrationCertificatePolicy? = nil) async throws -> OpenId4VCIConfig {
+	func toOpenId4VCIConfig(credentialIssuerId: String, clientAttestationPopSigningAlgValuesSupported: [JWSAlgorithm]?, registrationCertificatePolicy: RegistrationCertificatePolicy? = nil, context: ThreadSafeAuthContext) async throws -> OpenId4VCIConfig {
 		if registrationCertificatePolicy != nil {
 			// The OpenID4VCI library fails at OpenId4VCIConfig construction if not required signed
 			guard case .requireSigned = issuerMetadataPolicy else {
@@ -178,7 +179,7 @@ extension OpenId4VciConfiguration {
 			}
 		}
 		let client: Client = if let clientAttestationPopSigningAlgValuesSupported {
-			try await makeAttestationClient(config: keyAttestationsConfig, credentialIssuerId: credentialIssuerId, algorithms: clientAttestationPopSigningAlgValuesSupported)
+			try await makeAttestationClient(config: keyAttestationsConfig, credentialIssuerId: credentialIssuerId, algorithms: clientAttestationPopSigningAlgValuesSupported, context: context)
 		} else {
 			try makePublicClient()
 		}
@@ -193,9 +194,9 @@ extension OpenId4VciConfiguration {
 		return .public(id: clientId)
 	}
 
-	private func makeAttestationClient(config: KeyAttestationConfiguration, credentialIssuerId: String, algorithms: [JWSAlgorithm]?) async throws -> Client {
+	private func makeAttestationClient(config: KeyAttestationConfiguration, credentialIssuerId: String, algorithms: [JWSAlgorithm]?, context: ThreadSafeAuthContext) async throws -> Client {
 		let keyId = Self.generatePopKeyId(popUsage: .clientAttestation, credentialIssuerId: credentialIssuerId)
-		guard let popConstructor = try await makePoPConstructor(popUsage: .clientAttestation, privateKeyId: keyId, algorithms: algorithms, keyOptions: config.popKeyOptions) else {
+		guard let popConstructor = try await makePoPConstructor(popUsage: .clientAttestation, privateKeyId: keyId, algorithms: algorithms, keyOptions: config.popKeyOptions, context: context) else {
 			throw WalletError(description: "Failed to create DPoP constructor for client attestation", code: .internalError)
 		}
 		let signingKey = popConstructor.privateKey

--- a/Sources/EudiWalletKit/Services/BlePresentationService.swift
+++ b/Sources/EudiWalletKit/Services/BlePresentationService.swift
@@ -39,7 +39,6 @@ public final class BlePresentationService: @unchecked Sendable, PresentationServ
 	var continuationDisconnect: CheckedContinuation<Void, Error>?
     /// Continuation for awaiting L2CAP PSM publication
     var psm: UInt16?
-	var handleSelected: ((Bool, RequestItems?, RequestDeviceNameSpaces?) async -> Void)?
 	var request: UserRequestInfo?
 	var readBuffer = Data()
 	public var wrpVerifierPolicy: WrpRegistrationPolicy?
@@ -64,8 +63,10 @@ public final class BlePresentationService: @unchecked Sendable, PresentationServ
 	public var unlockData: [String: Data]!
 	public var deviceResponseBytes: Data?
 	public var responseMetadata: [Data?]!
+	/// Local authentication context reused for the device-key operations of the response
+	var authenticationContext: ThreadSafeAuthContext
 
-	public init(parameters: InitializeTransferData, transportFactory: (any BleTransportFactory)? = nil, wrpRegistrationValidator: WrpVpRegistrationValidator? = nil) async throws {
+	public init(parameters: InitializeTransferData, authenticationContext: ThreadSafeAuthContext, transportFactory: (any BleTransportFactory)? = nil, wrpRegistrationValidator: WrpVpRegistrationValidator? = nil) async throws {
 		let objs = try await parameters.toInitializeTransferInfo()
 		self.docs = try objs.documentObjects.mapValues { try IssuerSigned(data: $0.bytes) }
 		docMetadata = parameters.docMetadata
@@ -75,6 +76,7 @@ public final class BlePresentationService: @unchecked Sendable, PresentationServ
 		self.dauthMethod = objs.deviceAuthMethod
 		self.zkSystemRepository = objs.zkSystemRepository
 		bleTransferMode = parameters.bleTransferMode
+		self.authenticationContext = authenticationContext
 		let factory = transportFactory ?? DefaultBleTransportFactory()
 		bleTranport = bleTransferMode == .server ? factory.createServer() : factory.createClient()
 		if bleTransferMode == .both { bleServer = factory.createServer() }
@@ -82,7 +84,7 @@ public final class BlePresentationService: @unchecked Sendable, PresentationServ
 		bleTranport.delegate = self
 		bleServer?.delegate = self
 	}
-	
+
 	var isInErrorState: Bool { status == .error }
 	// Create a new device engagement object and start the device engagement process.
 	///
@@ -151,7 +153,7 @@ func handleStatusChange(_ newValue: TransferStatus) async {
 			bleTranport.stopBleAdvertising()
 			bleServer?.stopBleAdvertising()
 			let compactDocMetadata = docMetadata.compactMapValues { $0 }
-			let decodedRes = await MdocHelpers.decodeRequestAndInformUser(deviceEngagement: deviceEngagement, docs: docs, docMetadata: compactDocMetadata, trustValidator: trustValidator, requestData: readBuffer, privateKeyObjects: privateKeyObjects, dauthMethod: dauthMethod, unlockData: unlockData, readerKeyRawData: nil, handOver: BleTransferMode.QRHandover)
+			let decodedRes = await MdocHelpers.decodeRequestAndInformUser(deviceEngagement: deviceEngagement, docs: docs, docMetadata: compactDocMetadata, trustValidator: trustValidator, requestData: readBuffer, privateKeyObjects: privateKeyObjects, dauthMethod: dauthMethod, unlockData: unlockData, readerKeyRawData: nil, handOver: BleTransferMode.QRHandover, authenticationContext: authenticationContext)
 			switch decodedRes {
 			case .success(let decoded):
 				deviceRequest = decoded.deviceRequest
@@ -163,7 +165,6 @@ func handleStatusChange(_ newValue: TransferStatus) async {
 						didFinishedWithError(error)
 						return
 					}
-					self.handleSelected = userSelected
 					continuationRequest?.resume(returning: decoded.userRequestInfo)
 					continuationRequest = nil
 				} else {
@@ -187,7 +188,7 @@ func handleStatusChange(_ newValue: TransferStatus) async {
 		default: break
 		}
 	}
-	
+
 	/// Validate the relying party registration certificate (WRPRC) carried in the BLE device request.
 	///
 	/// According to ETSI TS 119 472-2 (clause 5.3.2), the WRPRC is repeated in the `requestInfo` member
@@ -270,7 +271,8 @@ func handleStatusChange(_ newValue: TransferStatus) async {
 					dauthMethod: dauthMethod,
 					unlockData: unlockData,
 					zkSystemRepository: zkSystemRepository,
-					deviceNameSpacesRequested: deviceNameSpaces) else {
+					deviceNameSpacesRequested: deviceNameSpaces,
+					authenticationContext: authenticationContext) else {
 					errorToSend = MdocHelpers.getErrorNoDocuments(docTypeReq)
 					return
 				}
@@ -323,16 +325,16 @@ func handleStatusChange(_ newValue: TransferStatus) async {
 	///   - itemsToSend: The selected items to send organized in document types and namespaces
 	///   - deviceNameSpacesToSend: Optional device-signed namespaces to include in the response
 	///   - onSuccess: Callback invoked on successful response with an optional redirect URL
-	public func sendResponse(userAccepted: Bool, itemsToSend: RequestItems, deviceNameSpacesToSend: RequestDeviceNameSpaces? = nil, onSuccess: (@Sendable (URL?) -> Void)?) async throws  {
-		await handleSelected?(userAccepted, itemsToSend, deviceNameSpacesToSend)
-		handleSelected = nil
+	public func sendResponse(userAccepted: Bool, itemsToSend: RequestItems, deviceNameSpacesToSend: RequestDeviceNameSpaces? = nil, authenticationContext: ThreadSafeAuthContext, onSuccess: (@Sendable (URL?) -> Void)?) async throws  {
+		self.authenticationContext = authenticationContext
+		await userSelected(userAccepted, itemsToSend, deviceNameSpacesToSend)
 		// documentIds is populated by userSelected after a successful response build.
 		// docType and displayName are not available on this service; they are populated by the PresentationSession caller which has access to docIdToPresentInfo.
 		let firstDocId = documentIds.first
 		let firstDocType = firstDocId.flatMap { docs[$0]?.issuerAuth.mso.docType }
 		TransactionLogUtils.setCborTransactionLogResponseInfo(self, documentId: firstDocId, docType: firstDocType, displayName: nil, transactionLog: &transactionLog)
 	}
-	
+
 	public func waitForDisconnect() async throws {
 		if status == .disconnected { return }
 		try await withCheckedThrowingContinuation { c in
@@ -378,7 +380,7 @@ public func didPoweredOn(isPeripheralManager: Bool) {
 	}
 
 	/// BLE device connected
-	/// - Parameters:	
+	/// - Parameters:
 	///  - isPeripheral: True if the device connected is a peripheral
 	/// - deviceName: The name of the connected device if available
 	public func didConnected(isPeripheral: Bool, deviceName: String?) {

--- a/Sources/EudiWalletKit/Services/FaultPresentationService.swift
+++ b/Sources/EudiWalletKit/Services/FaultPresentationService.swift
@@ -49,7 +49,7 @@ public final class FaultPresentationService: @unchecked Sendable, PresentationSe
 		throw error
 	}
 
-	public func sendResponse(userAccepted: Bool, itemsToSend: RequestItems, deviceNameSpacesToSend: RequestDeviceNameSpaces? = nil, onSuccess: ((URL?) -> Void)?) async throws{
+	public func sendResponse(userAccepted: Bool, itemsToSend: RequestItems, deviceNameSpacesToSend: RequestDeviceNameSpaces? = nil, authenticationContext: ThreadSafeAuthContext = ThreadSafeAuthContext(), onSuccess: ((URL?) -> Void)?) async throws{
 		throw error
 	}
 

--- a/Sources/EudiWalletKit/Services/OpenId4VciService.swift
+++ b/Sources/EudiWalletKit/Services/OpenId4VciService.swift
@@ -27,7 +27,7 @@ import WalletStorage
 import SwiftCBOR
 import JOSESwift
 import SwiftyJSON
-import LocalAuthentication
+@preconcurrency import LocalAuthentication
 import X509
 import class eudi_lib_sdjwt_swift.ClaimsVerifier
 import class eudi_lib_sdjwt_swift.CompactParser
@@ -47,6 +47,7 @@ public actor OpenId4VciService {
 	var networking: Networking
 	var authRequested: AuthorizationRequested?
 	var keyBatchSize: Int { issueReq.credentialOptions.batchSize }
+	var localAuthenticationContext: ThreadSafeAuthContext
 	var storage: StorageManager
 	var storageService: any DataStorageService
 	var transactionLogger: (any TransactionLogger)?
@@ -61,11 +62,12 @@ public actor OpenId4VciService {
 	@MainActor var simpleAuthWebContext: SimpleAuthenticationPresentationContext!
 	typealias FuncKeyAttestationJWT = @Sendable (_ nonce: String?) async throws -> KeyAttestationJWT
 
-	init(uiCulture: String?, config: OpenId4VciConfiguration, networking: Networking, storage: StorageManager, storageService: any DataStorageService, trustConfig: TrustConfiguration, transactionLogger: (any TransactionLogger)? = nil) throws {
+	init(uiCulture: String?, config: OpenId4VciConfiguration, networking: Networking, storage: StorageManager, storageService: any DataStorageService, trustConfig: TrustConfiguration, transactionLogger: (any TransactionLogger)? = nil, localAuthenticationContext: ThreadSafeAuthContext) throws {
 		logger = Logger(label: "OpenId4VCI")
 		guard config.credentialIssuerURL != nil else { throw WalletError(description: "credentialIssuerURL must be set in OpenId4VciConfiguration", code: .internalError) }
 		self.uiCulture = uiCulture
 		self.networking = networking
+		self.localAuthenticationContext = localAuthenticationContext
 		self.storage = storage
 		self.storageService = storageService
 		self.config = config
@@ -86,7 +88,7 @@ public actor OpenId4VciService {
 		let localizedReason = promptMessage ?? defaultLocalizedReason.replacingOccurrences(of: "{docType}", with: localizedDocTypeName)
 		issueReq = try await EudiWallet.authorizedAction(action: {
 			return try beginIssueDocument(id: id, credentialOptions: usedCredentialOptions, keyOptions: keyOptions)
-		}, disabled: !config.userAuthenticationRequired || disablePrompt, dismiss: {}, localizedReason: localizedReason)
+		}, disabled: !config.userAuthenticationRequired || disablePrompt, dismiss: {}, localizedReason: localizedReason, authenticationContext: localAuthenticationContext)
 		guard issueReq != nil else {
 			logger.error("User cancelled authentication")
 			throw LAError(.userCancel)
@@ -148,10 +150,14 @@ public actor OpenId4VciService {
 	func setConfiguration(_ config: OpenId4VciConfiguration) {
 		self.config = config
 	}
+	
+	func setLocalAuthenticationContext(localAuthenticationContext: ThreadSafeAuthContext = ThreadSafeAuthContext()) {
+		self.localAuthenticationContext = localAuthenticationContext
+	}
 
 	func createBindingKey(_ publicKeyJWK: ECPublicKey, secureAreaSigningAlg: MdocDataModel18013.SigningAlgorithm, unlockData: Data?, index: Int, funcKeyAttestationJWT: @escaping FuncKeyAttestationJWT, issuer: String) throws -> BindingKey {
 		let algType = Self.mapToJWSAlgorithmType(secureAreaSigningAlg)!
-		let signer = try SecureAreaSigner(secureArea: issueReq.secureArea, id: issueReq.id, index: index, publicKey: publicKeyJWK, curve: publicKeyJWK.crv.coseEcCurve, ecAlgorithm: secureAreaSigningAlg, unlockData: unlockData)
+		let signer = try SecureAreaSigner(secureArea: issueReq.secureArea, id: issueReq.id, index: index, publicKey: publicKeyJWK, curve: publicKeyJWK.crv.coseEcCurve, ecAlgorithm: secureAreaSigningAlg, unlockData: unlockData, context: localAuthenticationContext)
 		let bindingKey: BindingKey
 		bindingKey = try .jwtKeyAttestation(algorithm: JWSAlgorithm(algType), keyAttestationJWT: funcKeyAttestationJWT, keyIndex: UInt(index), privateKey: .custom(signer), issuer: issuer)
 		return bindingKey
@@ -334,10 +340,10 @@ public actor OpenId4VciService {
 		let credentialIssuerId = offer.credentialIssuerIdentifier.url.absoluteString
 		if config.requireDpop {
 			let keyId = OpenId4VciConfiguration.generatePopKeyId(popUsage: .dpop, credentialIssuerId: credentialIssuerId)
-			dpopConstructor = try await config.makePoPConstructor(popUsage: .dpop, privateKeyId: keyId, algorithms: offer.authorizationServerMetadata.dpopSigningAlgValuesSupported, keyOptions: config.dpopKeyOptions)
+			dpopConstructor = try await config.makePoPConstructor(popUsage: .dpop, privateKeyId: keyId, algorithms: offer.authorizationServerMetadata.dpopSigningAlgValuesSupported, keyOptions: config.dpopKeyOptions, context: localAuthenticationContext)
 		}
 		let registrationCertificateEnforcement = makeRegistrationCertificatePolicy()
-		let vciConfig = try await config.toOpenId4VCIConfig(credentialIssuerId: credentialIssuerId, clientAttestationPopSigningAlgValuesSupported: offer.authorizationServerMetadata.clientAttestationPopSigningAlgValuesSupported, registrationCertificatePolicy: registrationCertificateEnforcement?.policy)
+		let vciConfig = try await config.toOpenId4VCIConfig(credentialIssuerId: credentialIssuerId, clientAttestationPopSigningAlgValuesSupported: offer.authorizationServerMetadata.clientAttestationPopSigningAlgValuesSupported, registrationCertificatePolicy: registrationCertificateEnforcement?.policy, context: localAuthenticationContext)
 		if let (_, validator) = registrationCertificateEnforcement {
 			let result = try await Issuer.make(credentialOffer: offer, config: vciConfig, dpopConstructor: dpopConstructor, session: networking)
 			wrpIssuerWarnings = await validator.wrpVciWarnings
@@ -367,12 +373,12 @@ public actor OpenId4VciService {
 	}
 
 	func getIssuerForDeferred(data: DeferredIssuanceModel, configuration: CredentialConfiguration) async throws -> (Issuer,DPoPConstructor?) {
-		let vciConfig = try await config.toOpenId4VCIConfig(credentialIssuerId: configuration.credentialIssuerIdentifier, clientAttestationPopSigningAlgValuesSupported: configuration.clientAttestationPopSigningAlgValuesSupported?.map { JWSAlgorithm(name: $0) })
+		let vciConfig = try await config.toOpenId4VCIConfig(credentialIssuerId: configuration.credentialIssuerIdentifier, clientAttestationPopSigningAlgValuesSupported: configuration.clientAttestationPopSigningAlgValuesSupported?.map { JWSAlgorithm(name: $0) }, context: localAuthenticationContext)
 		var dpopConstructor: DPoPConstructor? = nil
 		let dpopSigningAlgValuesSupported = configuration.dpopSigningAlgValuesSupported?.map { JWSAlgorithm(name: $0) }
 		if config.requireDpop {
 			let keyId = OpenId4VciConfiguration.generatePopKeyId(popUsage: .dpop, credentialIssuerId: configuration.credentialIssuerIdentifier)
-			dpopConstructor = try await config.makePoPConstructor(popUsage: .dpop, privateKeyId: keyId, algorithms: dpopSigningAlgValuesSupported, keyOptions: config.dpopKeyOptions)
+			dpopConstructor = try await config.makePoPConstructor(popUsage: .dpop, privateKeyId: keyId, algorithms: dpopSigningAlgValuesSupported, keyOptions: config.dpopKeyOptions, context: localAuthenticationContext)
 		}
 		let (_, issuerMetadata) = try await resolveIssuerMetadata()
 		guard let authorizationServer = issuerMetadata.authorizationServers?.first else {
@@ -412,7 +418,7 @@ public actor OpenId4VciService {
 			}
 		}
 		if let preAuthorizedCode, let authCode = try? IssuanceAuthorization(preAuthorizationCode: preAuthorizedCode, txCode: txCodeSpec) {
-			let vciConfig = try await config.toOpenId4VCIConfig(credentialIssuerId: offer.credentialIssuerIdentifier.url.absoluteString, clientAttestationPopSigningAlgValuesSupported: offer.authorizationServerMetadata.clientAttestationPopSigningAlgValuesSupported)
+			let vciConfig = try await config.toOpenId4VCIConfig(credentialIssuerId: offer.credentialIssuerIdentifier.url.absoluteString, clientAttestationPopSigningAlgValuesSupported: offer.authorizationServerMetadata.clientAttestationPopSigningAlgValuesSupported, context: localAuthenticationContext)
 			let authorized = try await issuer.authorizeWithPreAuthorizationCode(credentialOffer: offer, authorizationCode: authCode, client: vciConfig.client, transactionCode: txCodeValue)
 			authorizedOutcome = .authorized(authorized)
 		} else if !backgroundOnly {
@@ -534,7 +540,7 @@ public actor OpenId4VciService {
 		var openId4VCIServices = [OpenId4VciService]()
 		for (i, docTypeModel) in docTypes.enumerated() {
 			guard let docTypeIdentifier = docTypeModel.docTypeIdentifier else { continue }
-			let svc = try OpenId4VciService(uiCulture: uiCulture,  config: config, networking: networking, storage: storage, storageService: storageService, trustConfig: trustConfig)
+			let svc = try OpenId4VciService(uiCulture: uiCulture,  config: config, networking: networking, storage: storage, storageService: storageService, trustConfig: trustConfig, localAuthenticationContext: localAuthenticationContext)
 			if let documentId { logger.info("Resolve offer to update document with id \(documentId)") }
 			let id = UUID().uuidString //(i == 0 ? documentId : nil) ?? UUID().uuidString
 			try await svc.prepareIssuing(id: id, docTypeIdentifier: docTypeIdentifier, displayName: i > 0 ? nil : docTypes.map(\.displayName).joined(separator: ", "), credentialOptions: docTypeModel.credentialOptions, keyOptions: docTypeModel.keyOptions, disablePrompt: i > 0, promptMessage: promptMessage, offer: offer)
@@ -772,7 +778,8 @@ public actor OpenId4VciService {
 		}
 		let vciConfig = try await config.toOpenId4VCIConfig(
 			credentialIssuerId: configuration.credentialIssuerIdentifier,
-			clientAttestationPopSigningAlgValuesSupported: configuration.clientAttestationPopSigningAlgValuesSupported?.map { JWSAlgorithm(name: $0) }
+			clientAttestationPopSigningAlgValuesSupported: configuration.clientAttestationPopSigningAlgValuesSupported?.map { JWSAlgorithm(name: $0) },
+			context: localAuthenticationContext
 		)
 		let refreshedAuthorized = try await issuer.refresh(client: vciConfig.client, authorizedRequest: authorized, dPopNonce: nil)
 		logger.info("Refreshed authorized request for issuance")
@@ -1281,7 +1288,8 @@ public final class OpenId4VCIServiceRegistry: @unchecked Sendable {
 	public func get(name: String) -> OpenId4VciService? {
 		lock.lock()
 		defer { lock.unlock() }
-		return services[name]
+		let service = services[name]
+		return service
 	}
 
 	public func getAllNames() -> [String] {

--- a/Sources/EudiWalletKit/Services/OpenId4VpService.swift
+++ b/Sources/EudiWalletKit/Services/OpenId4VpService.swift
@@ -17,6 +17,7 @@ Created on 04/10/2023
 */
 
 import Foundation
+@preconcurrency import LocalAuthentication
 import SwiftCBOR
 import MdocDataModel18013
 import MdocSecurity18013
@@ -202,7 +203,7 @@ public final class OpenId4VpService: @unchecked Sendable, PresentationService {
 		docsCbor = transferInfo.documentObjects.filter { k,v in Self.filterFormat(transferInfo.dataFormats[k]!, fmt: .cbor)} .mapValues { try? IssuerSigned(data: $0.bytes) }.compactMapValues { $0 }
 	}
 
-	func generateCborVpToken(itemsToSend: RequestItems, deviceNameSpacesToSend: RequestDeviceNameSpaces?) async throws -> (VerifiablePresentation, Data, [Data?], [String]) {
+	func generateCborVpToken(itemsToSend: RequestItems, deviceNameSpacesToSend: RequestDeviceNameSpaces?, authenticationContext: ThreadSafeAuthContext) async throws -> (VerifiablePresentation, Data, [Data?], [String]) {
 		let docMetadata = transferInfo.docMetadata
 		let privateKeyObjects = transferInfo.privateKeyObjects
 		let zkSystemRepository = transferInfo.zkSystemRepository
@@ -218,7 +219,8 @@ public final class OpenId4VpService: @unchecked Sendable, PresentationService {
 			unlockData: unlockData,
 			zkSpecsRequested: zkSpecsRequested,
 			zkSystemRepository: zkSystemRepository,
-			deviceNameSpacesRequested: deviceNameSpacesToSend)
+			deviceNameSpacesRequested: deviceNameSpacesToSend,
+			authenticationContext: authenticationContext)
 		guard let resp else { throw WalletError(description: "DOCUMENT_ERROR", code: .internalError) }
 		let vpTokenData = Data(resp.deviceResponse.toCBOR(options: CBOROptions()).encode())
 		let vpTokenStr = vpTokenData.base64URLEncodedString()
@@ -258,7 +260,7 @@ public final class OpenId4VpService: @unchecked Sendable, PresentationService {
 	///   - itemsToSend: The selected items to send organized in document types and namespaces
 	///   - deviceNameSpacesToSend: Optional device-signed namespaces to include in the response
 	///   - onSuccess: Callback invoked on successful response with an optional redirect URL
-	public func sendResponse(userAccepted: Bool, itemsToSend: RequestItems, deviceNameSpacesToSend: RequestDeviceNameSpaces? = nil, onSuccess: ((URL?) -> Void)?) async throws {
+	public func sendResponse(userAccepted: Bool, itemsToSend: RequestItems, deviceNameSpacesToSend: RequestDeviceNameSpaces? = nil, authenticationContext: ThreadSafeAuthContext, onSuccess: ((URL?) -> Void)?) async throws {
 		guard dcql != nil, let resolved = resolvedRequestData else {
 			throw WalletError(description: "Unexpected error", code: .internalError)
 		}
@@ -278,7 +280,7 @@ public final class OpenId4VpService: @unchecked Sendable, PresentationService {
 			if transferInfo.dataFormats[docId] == .cbor {
 				if docsCbor == nil { makeCborDocs() }
 				let itemsToSend1 = Dictionary(uniqueKeysWithValues: [(docId, nsItems)])
-				let vpToken = try await generateCborVpToken(itemsToSend: itemsToSend1, deviceNameSpacesToSend: deviceNameSpacesToSend)
+				let vpToken = try await generateCborVpToken(itemsToSend: itemsToSend1, deviceNameSpacesToSend: deviceNameSpacesToSend, authenticationContext: authenticationContext)
 				zkpDocumentIds!.append(contentsOf: vpToken.3)
 				inputToPresentations.append((inputDescrId, docId, vpToken.0))
 			} else if transferInfo.dataFormats[docId] == .sdjwt {
@@ -290,7 +292,7 @@ public final class OpenId4VpService: @unchecked Sendable, PresentationService {
 				let keyInfo = try await dpk.secureArea.getKeyBatchInfo(id: docId)
 				let keyInfoCrv = keyInfo.keyOptions?.curve ?? .P256
 				let dsa = keyInfoCrv.defaultSigningAlgorithm
-				let signer = try SecureAreaSigner(secureArea: dpk.secureArea, id: docId, index: dpk.index, publicKey: holderPublicJwk, curve: keyInfoCrv, ecAlgorithm: dsa, unlockData: unlockData)
+				let signer = try SecureAreaSigner(secureArea: dpk.secureArea, id: docId, index: dpk.index, publicKey: holderPublicJwk, curve: keyInfoCrv, ecAlgorithm: dsa, unlockData: unlockData, context: authenticationContext)
 				let signAlg = try SecureAreaSigner.getSigningAlgorithm(dsa)
 				let hai = HashingAlgorithmIdentifier(rawValue: transferInfo.hashingAlgs[docId] ?? "") ?? .SHA3256
 				guard let presented = try await OpenId4VpUtils.getSdJwtPresentation(docSigned, hashingAlg: hai.hashingAlgorithm(), signer: signer, signAlg: signAlg, requestItems: items, nonce: vpNonce, aud: vpClientId, transactionData: transactionData) else {

--- a/Sources/EudiWalletKit/Services/OpenId4VpService.swift
+++ b/Sources/EudiWalletKit/Services/OpenId4VpService.swift
@@ -288,8 +288,9 @@ public final class OpenId4VpService: @unchecked Sendable, PresentationService {
 				guard let holderPublicJwk = try SdJwtUtils.parseCnfBindingKeys(fromDocumentData: docData).first else { continue }
 				let unlockData = try await dpk.secureArea.unlockKey(id: docId)
 				let keyInfo = try await dpk.secureArea.getKeyBatchInfo(id: docId)
-				let dsa = keyInfo.crv.defaultSigningAlgorithm
-				let signer = try SecureAreaSigner(secureArea: dpk.secureArea, id: docId, index: dpk.index, publicKey: holderPublicJwk, curve: keyInfo.crv, ecAlgorithm: dsa, unlockData: unlockData)
+				let keyInfoCrv = keyInfo.keyOptions?.curve ?? .P256
+				let dsa = keyInfoCrv.defaultSigningAlgorithm
+				let signer = try SecureAreaSigner(secureArea: dpk.secureArea, id: docId, index: dpk.index, publicKey: holderPublicJwk, curve: keyInfoCrv, ecAlgorithm: dsa, unlockData: unlockData)
 				let signAlg = try SecureAreaSigner.getSigningAlgorithm(dsa)
 				let hai = HashingAlgorithmIdentifier(rawValue: transferInfo.hashingAlgs[docId] ?? "") ?? .SHA3256
 				guard let presented = try await OpenId4VpUtils.getSdJwtPresentation(docSigned, hashingAlg: hai.hashingAlgorithm(), signer: signer, signAlg: signAlg, requestItems: items, nonce: vpNonce, aud: vpClientId, transactionData: transactionData) else {

--- a/Sources/EudiWalletKit/Services/PresentationService.swift
+++ b/Sources/EudiWalletKit/Services/PresentationService.swift
@@ -35,7 +35,7 @@ public protocol PresentationService: Sendable {
 	func receiveRequest() async throws -> [UserRequestInfo]
 
 	var transactionLog: TransactionLog { get }
-	
+
 	var zkpDocumentIds: [Document.ID]? { get }
 	/// The verifier (relying party) registration policy decoded from the WRPRC carried in the request, if any
 	var wrpVerifierPolicy: WrpRegistrationPolicy?  { get }
@@ -46,9 +46,10 @@ public protocol PresentationService: Sendable {
 	///   - userAccepted: True if user accepted to send the response
 	///   - itemsToSend: The selected items to send organized in document types and namespaces (see ``RequestItems``)
 	///   - deviceNameSpacesToSend: Optional device-signed namespaces to include in the response
+	///   - authenticationContext: Local authentication context reused for the device-key operations (signature / key-agreement)
 	///   - onSuccess: Callback invoked on successful response with an optional redirect URL
-	func sendResponse(userAccepted: Bool, itemsToSend: RequestItems, deviceNameSpacesToSend: RequestDeviceNameSpaces?, onSuccess: ( @Sendable (URL?) -> Void)?) async throws
-	
+	func sendResponse(userAccepted: Bool, itemsToSend: RequestItems, deviceNameSpacesToSend: RequestDeviceNameSpaces?, authenticationContext: ThreadSafeAuthContext, onSuccess: ( @Sendable (URL?) -> Void)?) async throws
+
 	/// wait for disconnect
 	func waitForDisconnect() async throws
 }

--- a/Sources/EudiWalletKit/Services/PresentationSession.swift
+++ b/Sources/EudiWalletKit/Services/PresentationSession.swift
@@ -133,7 +133,7 @@ public final class PresentationSession: @unchecked Sendable, ObservableObject {
 		// TODO: localizationKey is kept for backward compatibility — clients can migrate to use `code` instead
 		if docIdToPresentInfo.count == 0 { await setError(Self.notAvailableStr, localizationKey: "request_data_no_document", code: .noDocumentsAvailable); return }
 		do {
-			let data = try await presentationService.startQrEngagement(secureAreaName: nil, keyOptions: KeyOptions(curve: .P256, accessControl: []))
+			let data = try await presentationService.startQrEngagement(secureAreaName: nil, keyOptions: KeyOptions(curve: .P256, accessControl: .empty))
 			await MainActor.run {
 				deviceEngagement = data
 				status = .qrEngagementReady

--- a/Sources/EudiWalletKit/Services/PresentationSession.swift
+++ b/Sources/EudiWalletKit/Services/PresentationSession.swift
@@ -54,7 +54,9 @@ public final class PresentationSession: @unchecked Sendable, ObservableObject {
 	// map of document id to key index to use
 	public var documentKeyIndexes: [Document.ID: Int]
 	/// User authentication required
-	var userAuthenticationRequired: Bool
+	public var userAuthenticationRequired: Bool
+	/// Local authentication context owned by the wallet and reused for every device-key operation.
+	public var localAuthenticationContext: ThreadSafeAuthContext
 	/// transaction logger
 	public var transactionLogger: (any TransactionLogger)?
 
@@ -65,6 +67,7 @@ public final class PresentationSession: @unchecked Sendable, ObservableObject {
 		docIdToPresentInfo: [Document.ID: DocPresentInfo],
 		documentKeyIndexes: [Document.ID: Int],
 		userAuthenticationRequired: Bool,
+		localAuthenticationContext: ThreadSafeAuthContext,
 		transactionLogger: (any TransactionLogger)? = nil
 	) {
 		self.presentationService = presentationService
@@ -73,6 +76,7 @@ public final class PresentationSession: @unchecked Sendable, ObservableObject {
 		self.docIdToPresentInfo = docIdToPresentInfo
 		self.documentKeyIndexes = documentKeyIndexes
 		self.userAuthenticationRequired = userAuthenticationRequired
+		self.localAuthenticationContext = localAuthenticationContext
 		self.transactionLogger = transactionLogger
 	}
 
@@ -209,9 +213,10 @@ public final class PresentationSession: @unchecked Sendable, ObservableObject {
 				userAccepted: userAccepted,
 				itemsToSend: itemsToSend,
 				deviceNameSpacesToSend: deviceNameSpacesToSend,
+				authenticationContext: self?.localAuthenticationContext ?? ThreadSafeAuthContext(),
 				onSuccess: onSuccess)
 			}
-			try await EudiWallet.authorizedAction(action: action, disabled: !userAuthenticationRequired, dismiss: { onCancel?() }, localizedReason: NSLocalizedString("authenticate_to_share_data", comment: "") )
+			try await EudiWallet.authorizedAction(action: action, disabled: !userAuthenticationRequired, dismiss: { onCancel?() }, localizedReason: NSLocalizedString("authenticate_to_share_data", comment: ""), authenticationContext: localAuthenticationContext)
 			try await updateKeyBatchInfoAndDeleteCredentialIfNeeded(presentedIds: Array(itemsToSend.keys), zkpDocumentIds: presentationService.zkpDocumentIds)
 			await MainActor.run { status = .responseSent; storageManager?.objectWillChange.send() }
 			if let transactionLogger { do { try await transactionLogger.log(transaction: presentationService.transactionLog) } catch { logger.error("Failed to log transaction: \(error)") } }

--- a/Sources/EudiWalletKit/Services/SecureAreaSigner.swift
+++ b/Sources/EudiWalletKit/Services/SecureAreaSigner.swift
@@ -15,12 +15,13 @@ limitations under the License.
 */
 
 import Foundation
+@preconcurrency import LocalAuthentication
 import MdocDataModel18013
 @preconcurrency import JOSESwift
 import JSONWebAlgorithms
 import OpenID4VCI
 
-final class SecureAreaSigner: AsyncSignerProtocol {
+final class SecureAreaSigner: AsyncSignerProtocol, @unchecked Sendable {
 	let id: String
 	let index: Int
 	let secureArea: SecureArea
@@ -30,8 +31,9 @@ final class SecureAreaSigner: AsyncSignerProtocol {
 	let algorithm: JOSESwift.SignatureAlgorithm
 	let signature: Data?
 	let unlockData: Data?
+	let context: ThreadSafeAuthContext
 
-	init(secureArea: SecureArea, id: String, index: Int, publicKey: any JOSESwift.JWK, curve: CoseEcCurve, ecAlgorithm: MdocDataModel18013.SigningAlgorithm, unlockData: Data?) throws {
+	init(secureArea: SecureArea, id: String, index: Int, publicKey: any JOSESwift.JWK, curve: CoseEcCurve, ecAlgorithm: MdocDataModel18013.SigningAlgorithm, unlockData: Data?, context: ThreadSafeAuthContext) throws {
 		self.id = id
 		self.index = index
 		self.secureArea = secureArea
@@ -40,6 +42,7 @@ final class SecureAreaSigner: AsyncSignerProtocol {
 		self.algorithm = try Self.getSignatureAlgorithm(ecAlgorithm)
 		signature = nil
 		self.unlockData = unlockData
+		self.context = context
 		self.publicKey = publicKey
 	}
 
@@ -64,7 +67,7 @@ final class SecureAreaSigner: AsyncSignerProtocol {
 	}
 
 	func sign(_ signingInput: Data) async throws -> Data {
-		let ecdsaSignature = try await secureArea.signature(id: id, index: index, algorithm: ecAlgorithm, dataToSign: signingInput, unlockData: unlockData)
+		let ecdsaSignature = try await secureArea.signature(id: id, index: index, algorithm: ecAlgorithm, dataToSign: signingInput, unlockData: unlockData, authenticationContext: context)
 		return ecdsaSignature
 	}
 

--- a/Tests/EudiWalletKitTests/EudiWalletKitTests.swift
+++ b/Tests/EudiWalletKitTests/EudiWalletKitTests.swift
@@ -563,6 +563,10 @@ actor InMemorySecureKeyStorage: SecureKeyStorage {
 		keyDataStorage["\(id)_\(index)"] ?? [:]
 	}
 
+	func readKeyData(id: String, index: Int, authenticationContext: ThreadSafeAuthContext) async throws -> [String : Data] {
+		keyDataStorage["\(id)_\(index)"] ?? [:]
+	}
+
 	func writeKeyInfo(id: String, dict: [String : Data]) async throws {
 		keyInfoStorage[id] = dict
 	}

--- a/Tests/EudiWalletKitTests/EudiWalletKitTests.swift
+++ b/Tests/EudiWalletKitTests/EudiWalletKitTests.swift
@@ -452,7 +452,8 @@ struct EudiWalletKitTests {
 			networking: networking,
 			storage: storage,
 			storageService: storageService,
-			trustConfig: trustConfig
+			trustConfig: trustConfig,
+			localAuthenticationContext: ThreadSafeAuthContext()
 		)
 	}
 

--- a/Tests/EudiWalletKitTests/IssuanceNotificationTests.swift
+++ b/Tests/EudiWalletKitTests/IssuanceNotificationTests.swift
@@ -54,7 +54,8 @@ struct IssuanceNotificationTests {
 			networking: networking,
 			storage: storage,
 			storageService: storageService,
-			trustConfig: trustConfig
+			trustConfig: trustConfig,
+			localAuthenticationContext: ThreadSafeAuthContext()
 		)
 	}
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,7 @@
 ## v0.50.0
-
-- Fix dPoP key handling in authentication flows. Ensures that it uses the provided keyOptions.
-- Reuse a shared local authentication context across wallet issuance and presentation operations.
-- Pass the shared authentication context through OpenID4VCI, OpenID4VP, BLE presentation, VP token generation, and secure-area signing so biometric/device authentication state is preserved consistently across device-key operations.
+This release fixes the multiple authentication prompt issue when EUDI Wallet is accessing the keys that are stored in the secure key storage in order to sign attestations during document issuance or presentation.
+For example, during a single document issuance process user needed to enter the passcode or touch ID 4 times.
+With this release, the wallet now reuses a shared local authentication context, so authentication prompt appears only once.
 
 ### Breaking Changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,47 @@
+## v0.50.0
+
+- Fix dPoP key handling in authentication flows. Ensures that it uses the provided keyOptions.
+- Reuse a shared local authentication context across wallet issuance and presentation operations.
+- Pass the shared authentication context through OpenID4VCI, OpenID4VP, BLE presentation, VP token generation, and secure-area signing so biometric/device authentication state is preserved consistently across device-key operations.
+
+### Breaking Changes
+
+- Due to metadata storage changes, existing documents should be deleted.
+- Minimum version of iOS raised to 17.
+
+## v0.40.9
+
+- Support public OpenID4VCI clients.
+- Cache resolved credential offers.
+
+## v0.40.8
+
+- Include WRP VP policy data in transaction logs.
+- Improve relying-party name resolution and fallback handling.
+- Make the VCI client ID optional for attested client IDs.
+
+## v0.40.7
+
+- Update `eudi-lib-ios-iso18013-data-transfer` to version 0.24.3.
+
+## v0.40.6
+
+- Add OAuth grants to `OfferedIssuanceModel`.
+
+## v0.40.5
+
+- Update `eudi-lib-ios-iso18013-data-transfer` to version 0.24.2.
+
+## v0.40.4
+
+- Revert the WRP registration policy intermediary multi-entry change.
+
+## v0.40.3
+
+- Rename `CredentialQuery.docType` to `docTypeOrVct`.
+- Add the missing entitlement failure reason for presentation and registration.
+- Handle absent `provides_attestations` values.
+
 ## v0.40.2
 
 ### WRP Registration Certificate Improvements


### PR DESCRIPTION
- Fix dPoP key handling in authentication flows. Ensures that it uses the provided keyOptions.
- Reuse a shared local authentication context across wallet issuance and presentation operations.
- Pass the shared authentication context through OpenID4VCI, OpenID4VP, BLE presentation, VP token generation, and secure-area signing so biometric/device authentication state is preserved consistently across device-key operations.

Fixes #461